### PR TITLE
Change XML attribute for procedure from varId to var-id

### DIFF
--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -131,7 +131,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       var parameter = document.createElement('arg');
       var argModel = this.argumentVarModels_[i];
       parameter.setAttribute('name', argModel.name);
-      parameter.setAttribute('var-id', argModel.getId());
+      parameter.setAttribute('varid', argModel.getId());
       if (opt_paramIds && this.paramIds_) {
         parameter.setAttribute('paramId', this.paramIds_[i]);
       }
@@ -155,7 +155,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         var varName = childNode.getAttribute('name');
-        var varId = childNode.getAttribute('var-id') || childNode.getAttribute('varId');
+        var varId = childNode.getAttribute('varid') || childNode.getAttribute('varId');
         this.arguments_.push(varName);
         var variable = Blockly.Variables.getOrCreateVariablePackage(
             this.workspace, varId, varName, '');

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -131,7 +131,6 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       var parameter = document.createElement('arg');
       var argModel = this.argumentVarModels_[i];
       parameter.setAttribute('name', argModel.name);
-      parameter.setAttribute('varId', argModel.getId());
       parameter.setAttribute('var-id', argModel.getId());
       if (opt_paramIds && this.paramIds_) {
         parameter.setAttribute('paramId', this.paramIds_[i]);

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -132,6 +132,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
       var argModel = this.argumentVarModels_[i];
       parameter.setAttribute('name', argModel.name);
       parameter.setAttribute('varId', argModel.getId());
+      parameter.setAttribute('var-id', argModel.getId());
       if (opt_paramIds && this.paramIds_) {
         parameter.setAttribute('paramId', this.paramIds_[i]);
       }
@@ -155,7 +156,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         var varName = childNode.getAttribute('name');
-        var varId = childNode.getAttribute('varId');
+        var varId = childNode.getAttribute('varId') || childNode.getAttribute('var-id');
         this.arguments_.push(varName);
         var variable = Blockly.Variables.getOrCreateVariablePackage(
             this.workspace, varId, varName, '');

--- a/blocks/procedures.js
+++ b/blocks/procedures.js
@@ -156,7 +156,7 @@ Blockly.Blocks['procedures_defnoreturn'] = {
     for (var i = 0, childNode; childNode = xmlElement.childNodes[i]; i++) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         var varName = childNode.getAttribute('name');
-        var varId = childNode.getAttribute('varId') || childNode.getAttribute('var-id');
+        var varId = childNode.getAttribute('var-id') || childNode.getAttribute('varId');
         this.arguments_.push(varName);
         var variable = Blockly.Variables.getOrCreateVariablePackage(
             this.workspace, varId, varName, '');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I branched from develop
- [x] My pull request is against develop
- [x] My code follows the [style guide](https://developers.google.com/blockly/guides/modify/web/style-guide)

## The details
### Resolves
When function blocks are exported as XML the attribute set for 'varId' in argument variables mutation list are exported as 'varid' with small 'i'. So when the block is loaded back as XML while parsing 'varId' is parsed as null, because getAttribute is case sensitive when parsed as XML.

For example:
Consider an XML exported from blockly where 'varId' is exported as 'varid' and imported with the inbuilt function where 'varid' is parsed as 'varId' which results in null.

`new DOMParser().parseFromString('<xml xmlns="http://www.w3.org/1999/xhtml"><a **varid**="seek"></a></xml>', "text/xml").getElementsByTagName('a')[0].getAttribute('**varId**')`

The above code results `null`

while changing it to 
`new DOMParser().parseFromString('<xml xmlns="http://www.w3.org/1999/xhtml"><a **varid**="seek"></a></xml>', "text/xml").getElementsByTagName('a')[0].getAttribute('**varid**')`

The above code results `seek`

Note: getAttribute is not case sensitive when parsed as HTML, but they are when parsed as XML.

Since it is unable to parse the 'varId' properly while loading when function block is imported separately they create a new variable. This new variable ID will be conflicted with variable ID which is present in the function block XML which causes the error.

`Uncaught (in promise) Error: Variable "x" is already in use and its id is "csN.asr2XahzV(d?*EYW" which conflicts with the passed in id, "=JE@nKuHj|$U]7@|b|+A".`

For the XML:
```
<xml xmlns="http://www.w3.org/1999/xhtml" collection="true">
  <block type="procedures_defnoreturn" id="~WI0tzsDy,J#ssf,3LfS">
    <mutation>
      <arg name="x" varid="=JE@nKuHj|$U]7@|b|+A"></arg>
    </mutation>
    <field name="NAME">sample</field>
    <comment pinned="false" h="80" w="160">Describe this function...</comment>
    <statement name="STACK">
      <block type="variables_set" id="^*]l5G!HH89h3aOvM,0U">
        <field name="VAR" id="=JE@nKuHj|$U]7@|b|+A" variabletype="">x</field>
        <value name="VALUE">
          <block type="variables_get" id="Zt272XF.p%@,?m_|2Rw9">
            <field name="VAR" id="=JE@nKuHj|$U]7@|b|+A" variabletype="">x</field>
          </block>
        </value>
      </block>
    </statement>
  </block>
</xml>
```

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please show how you have added tests to cover your changes,
  -        or tell us how you tested it. For each systems you tested,
  -        uncomment the systems in the list below.
  -->

Tested on:
<!-- * Desktop Chrome -->
<!-- * Desktop Firefox -->
<!-- * Desktop Safari -->
<!-- * Desktop Opera -->
<!-- * Windows Internet Explorer 10 -->
<!-- * Windows Internet Explorer 11 -->
<!-- * Windows Edge -->

<!--
* Smartphone/Tablet/Chromebook (please complete the following information):
  * Device: [e.g. iPhone6]
  * OS: [e.g. iOS8.1]
  * Browser [e.g. stock browser, safari]
  * Version [e.g. 22]
-->

### Additional Information

<!-- Anything else we should know? -->
