### PR TITLE
Revert "fix: message loading from script tags"

### DIFF
--- a/scripts/gulpfiles/package_tasks.js
+++ b/scripts/gulpfiles/package_tasks.js
@@ -321,6 +321,8 @@ function packageLocales() {
   // Remove references to goog.provide and goog.require.
   return gulp.src(`${BUILD_DIR}/msg/js/*.js`)
       .pipe(gulp.replace(/goog\.[^\n]+/g, ''))
+      .pipe(gulp.insert.prepend(`
+      var Blockly = {};Blockly.Msg={};`))
       .pipe(packageUMD('Blockly.Msg', [{
           name: 'Blockly',
           amd: '../core',


### PR DESCRIPTION
Reverts google/blockly#6060 as per https://github.com/google/blockly/pull/6060#issuecomment-1112505377