### PR TITLE
revert: "chore: remove unused import"

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -157,6 +157,7 @@ import {Trashcan} from './trashcan.js';
 import * as utils from './utils.js';
 import * as colour from './utils/colour.js';
 import * as deprecation from './utils/deprecation.js';
+import * as svgMath from './utils/svg_math.js';
 import * as toolbox from './utils/toolbox.js';
 import {VariableMap} from './variable_map.js';
 import {VariableModel} from './variable_model.js';


### PR DESCRIPTION
Reverts google/blockly#6494

I accidentally made this against master instead of develop :( sorry