### PR TITLE
Revert "fix: removed X & Y from toolbox.ts and replaced movBy to moveTo"

### DIFF
--- a/core/flyout_horizontal.ts
+++ b/core/flyout_horizontal.ts
@@ -19,7 +19,7 @@ import type {FlyoutButton} from './flyout_button.js';
 import type {Options} from './options.js';
 import * as registry from './registry.js';
 import {Scrollbar} from './scrollbar.js';
-import {Coordinate} from './utils/coordinate.js';
+import type {Coordinate} from './utils/coordinate.js';
 import {Rect} from './utils/rect.js';
 import * as toolbox from './utils/toolbox.js';
 import * as WidgetDiv from './widgetdiv.js';
@@ -285,8 +285,7 @@ export class HorizontalFlyout extends Flyout {
         } else {
           moveX = cursorX - tab;
         }
-        // No 'reason' provided since events are disabled.
-        block!.moveTo(new Coordinate(moveX, cursorY));
+        block!.moveBy(moveX, cursorY);
 
         const rect = this.createRect_(block!, moveX, cursorY, blockHW, i);
         cursorX += blockHW.width + gaps[i];

--- a/core/flyout_vertical.ts
+++ b/core/flyout_vertical.ts
@@ -19,7 +19,7 @@ import type {FlyoutButton} from './flyout_button.js';
 import type {Options} from './options.js';
 import * as registry from './registry.js';
 import {Scrollbar} from './scrollbar.js';
-import {Coordinate} from './utils/coordinate.js';
+import type {Coordinate} from './utils/coordinate.js';
 import {Rect} from './utils/rect.js';
 import * as toolbox from './utils/toolbox.js';
 import * as WidgetDiv from './widgetdiv.js';
@@ -246,8 +246,7 @@ export class VerticalFlyout extends Flyout {
         const moveX = block!.outputConnection
           ? cursorX - this.tabWidth_
           : cursorX;
-        // No 'reason' provided since events are disabled.
-        block!.moveTo(new Coordinate(moveX, cursorY));
+        block!.moveBy(moveX, cursorY);
 
         const rect = this.createRect_(
           block!,
@@ -358,8 +357,7 @@ export class VerticalFlyout extends Flyout {
           if (!block.outputConnection) {
             newX -= this.tabWidth_;
           }
-          // No 'reason' provided since events are disabled.
-          block.moveTo(new Coordinate(newX - oldX, 0));
+          block.moveBy(newX - oldX, 0);
         }
         if (this.rectMap_.has(block)) {
           this.moveRectToBlock_(this.rectMap_.get(block)!, block);

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -24,6 +24,8 @@ export interface BlockInfo {
   disabled?: string | boolean;
   enabled?: boolean;
   id?: string;
+  x?: number;
+  y?: number;
   collapsed?: boolean;
   inline?: boolean;
   data?: string;


### PR DESCRIPTION
Reverts google/blockly#7333

Caused RTL toolbox flyouts to be rendered incorrectly.