### PR TITLE
Revert "chore: Pin node.js v22 to v22.4.1 in CI"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
         # TODO (#2114): re-enable osx build.
         # os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        # TODO(#8392): unpin v22 once npm issue fixed.
-        node-version: [18.x, 20.x, 22.4.1]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at
         # https://nodejs.org/en/about/releases/
 


### PR DESCRIPTION
Reverts google/blockly#8393

Unpin node since [they fixed it](https://github.com/nodejs/node/issues/53902#issuecomment-2239263377). Once this is merged I'll merge develop into `rc/v12.0.0` again. 