### PR TITLE
refactor: Use arrow functions when calling `Array.prototype.filter`

### DIFF
--- a/core/events/utils.ts
+++ b/core/events/utils.ts
@@ -127,13 +127,8 @@ function fireNow() {
   const queue = filter(FIRE_QUEUE, true);
   FIRE_QUEUE.length = 0;
   for (const event of queue) {
-    if (!event.workspaceId) {
-      continue;
-    }
-    const eventWorkspace = common.getWorkspaceById(event.workspaceId);
-    if (eventWorkspace) {
-      eventWorkspace.fireChangeListener(event);
-    }
+    if (!event.workspaceId) continue;
+    common.getWorkspaceById(event.workspaceId)?.fireChangeListener(event);
   }
 }
 

--- a/core/utils/toolbox.ts
+++ b/core/utils/toolbox.ts
@@ -285,9 +285,9 @@ function hasCategoriesInternal(toolboxJson: ToolboxInfo | null): boolean {
     return toolboxKind === CATEGORY_TOOLBOX_KIND;
   }
 
-  const categories = toolboxJson['contents'].filter(function (item) {
-    return item['kind'].toUpperCase() === 'CATEGORY';
-  });
+  const categories = toolboxJson['contents'].filter(
+    (item) => item['kind'].toUpperCase() === 'CATEGORY',
+  );
   return !!categories.length;
 }
 

--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -255,9 +255,7 @@ export class Workspace implements IASTNodeLocation {
       blocks.sort(this.sortObjects_.bind(this));
     }
 
-    return blocks.filter(function (block: Block) {
-      return !block.isInsertionMarker();
-    });
+    return blocks.filter((block) => !block.isInsertionMarker());
   }
 
   /**
@@ -341,11 +339,7 @@ export class Workspace implements IASTNodeLocation {
 
     // Insertion markers exist on the workspace for rendering reasons, but
     // aren't "real" blocks from a developer perspective.
-    const filtered = blocks.filter(function (block) {
-      return !block.isInsertionMarker();
-    });
-
-    return filtered;
+    return blocks.filter((block) => !block.isInsertionMarker());
   }
 
   /** Dispose of all blocks and comments in workspace. */

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -543,9 +543,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
     // Update all blocks in workspace that have a style name.
     this.updateBlockStyles_(
-      this.getAllBlocks(false).filter(function (block) {
-        return !!block.getStyleName();
-      }),
+      this.getAllBlocks(false).filter((block) => !!block.getStyleName()),
     );
 
     // Update current toolbox selection.

--- a/tests/mocha/event_test.js
+++ b/tests/mocha/event_test.js
@@ -1745,9 +1745,9 @@ suite('Events', function () {
       // Fire all events
       this.clock.runAll();
 
-      const disabledEvents = this.workspace.getUndoStack().filter(function (e) {
-        return e.element === 'disabled';
-      });
+      const disabledEvents = this.workspace
+        .getUndoStack()
+        .filter((e) => e.element === 'disabled');
       assert.isEmpty(
         disabledEvents,
         'Undo stack should not contain any disabled events',


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Use arrow functions when calling `Array.prototype.filter`, and make a few other other related changes.

### Reason for Changes

Conciseness and readability.

### Test Coverage

Passes `npm test`.

### Additional Information

I did not refactor one example in `generators/javascript/math.ts` (and associated test) as we want to maintain ES5.1 compatibility there.

