### PR TITLE
test: Disable failing tests

### DIFF
--- a/tests/mocha/workspace_svg_test.js
+++ b/tests/mocha/workspace_svg_test.js
@@ -502,7 +502,8 @@ suite('WorkspaceSvg', function () {
       );
     });
 
-    test('two blocks first at (10, 15) second at (0, 0) do not switch places', function () {
+    // TODO(#8676): Reenable once test passes reliably.
+    test.skip('two blocks first at (10, 15) second at (0, 0) do not switch places', function () {
       const blockJson1 = {
         'type': 'math_number',
         'id': 'block1',
@@ -538,7 +539,8 @@ suite('WorkspaceSvg', function () {
       );
     });
 
-    test('two overlapping blocks are moved to origin and below', function () {
+    // TODO(#8676): Reenable once test passes reliably.
+    test.skip('two overlapping blocks are moved to origin and below', function () {
       const blockJson1 = {
         'type': 'math_number',
         'id': 'block1',
@@ -618,7 +620,8 @@ suite('WorkspaceSvg', function () {
       );
     });
 
-    test('two overlapping blocks are moved to origin and below including children', function () {
+    // TODO(#8676): Reenable once test passes reliably.
+    test.skip('two overlapping blocks are moved to origin and below including children', function () {
       const blockJson1 = {
         'type': 'logic_negate',
         'id': 'block1',
@@ -682,7 +685,8 @@ suite('WorkspaceSvg', function () {
       );
     });
 
-    test('two large overlapping blocks are moved to origin and below', function () {
+    // TODO(#8676): Reenable once test passes reliably.
+    test.skip('two large overlapping blocks are moved to origin and below', function () {
       const blockJson1 = {
         'type': 'controls_repeat_ext',
         'id': 'block1',


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This is a temporary workaround for #8676.

### Proposed Changes

Disable four tests added in #8550 that fail reliably enough to prevent PRs from being merged.

### Reason for Changes

I'd like to be able to merge other PRs.

### Test Coverage

Slightly reduced.

### Additional Information

It is unclear to me how we have succeeded in merging so many PRs since #8550 was merged.  It seems that these tests do no _always_ fail in CI (e.g., one recent test run I had them succeed when run on node v18 and v20, but fail on v22, even though the node version should be irrelevant for Mocha tests beyond whether webdriver is able to successfully run the suite as a whole), but they do seem to always fail for me locally.  Perhaps people have just been re-starting failed test jobs until all three build/test jobs succeed simultaneously?

