### PR TITLE
feat: add extension point for overriding Grid functionality

### DIFF
--- a/core/blockly.ts
+++ b/core/blockly.ts
@@ -103,7 +103,7 @@ import {FlyoutMetricsManager} from './flyout_metrics_manager.js';
 import {VerticalFlyout} from './flyout_vertical.js';
 import {CodeGenerator} from './generator.js';
 import {Gesture} from './gesture.js';
-import {Grid} from './grid.js';
+import {Grid, GridProvider} from './grid.js';
 import * as icons from './icons.js';
 import {inject} from './inject.js';
 import * as inputs from './inputs.js';
@@ -132,6 +132,7 @@ import {
 } from './interfaces/i_draggable.js';
 import {IDragger} from './interfaces/i_dragger.js';
 import {IFlyout} from './interfaces/i_flyout.js';
+import {IGrid, IGridProvider} from './interfaces/i_grid.js';
 import {IHasBubble, hasBubble} from './interfaces/i_has_bubble.js';
 import {IIcon, isIcon} from './interfaces/i_icon.js';
 import {IKeyboardAccessible} from './interfaces/i_keyboard_accessible.js';
@@ -508,6 +509,7 @@ export {
   CodeGenerator as Generator,
   Gesture,
   Grid,
+  GridProvider,
   HorizontalFlyout,
   IASTNodeLocation,
   IASTNodeLocationSvg,
@@ -529,6 +531,8 @@ export {
   IDraggable,
   IDragger,
   IFlyout,
+  IGrid,
+  IGridProvider,
   IHasBubble,
   IIcon,
   IKeyboardAccessible,

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -12,7 +12,6 @@ import * as bumpObjects from './bump_objects.js';
 import * as common from './common.js';
 import * as Css from './css.js';
 import * as dropDownDiv from './dropdowndiv.js';
-import {Grid} from './grid.js';
 import {Msg} from './msg.js';
 import {Options} from './options.js';
 import {ScrollbarPair} from './scrollbar_pair.js';
@@ -141,7 +140,12 @@ function createDom(container: Element, options: Options): SVGElement {
   // https://neil.fraser.name/news/2015/11/01/
   const rnd = String(Math.random()).substring(2);
 
-  options.gridPattern = Grid.createDom(rnd, options.gridOptions, defs);
+  options.gridPattern = options.gridProvider.createDom(
+    rnd,
+    options.gridOptions,
+    defs,
+  );
+
   return svg;
 }
 

--- a/core/interfaces/i_grid.ts
+++ b/core/interfaces/i_grid.ts
@@ -1,0 +1,116 @@
+import {BlocklyOptions} from '../blockly_options.js';
+import {GridOptions} from '../options.js';
+import {Coordinate} from '../utils';
+import type {IRegistrable} from './i_registrable.js';
+
+export interface IGrid {
+  /**
+   * Sets the spacing between the centers of the grid lines.
+   *
+   * This does not trigger snapping to the newly spaced grid. If you want to
+   * snap blocks to the grid programmatically that needs to be triggered
+   * on individual top-level blocks. The next time a block is dragged and
+   * dropped it will snap to the grid if snapping to the grid is enabled.
+   */
+  setSpacing(spacing: number): void;
+
+  /**
+   * Get the spacing of the grid points (in px).
+   *
+   * @returns The spacing of the grid points.
+   */
+  getSpacing(): number;
+
+  /** Sets the length of the grid lines. */
+  setLength(length: number): void;
+
+  /** Get the length of the grid lines (in px). */
+  getLength(): number;
+
+  /**
+   * Sets whether blocks should snap to the grid or not.
+   *
+   * Setting this to true does not trigger snapping. If you want to snap blocks
+   * to the grid programmatically that needs to be triggered on individual
+   * top-level blocks. The next time a block is dragged and dropped it will
+   * snap to the grid.
+   */
+  setSnapToGrid(snap: boolean): void;
+
+  /**
+   * Whether blocks should snap to the grid.
+   *
+   * @returns True if blocks should snap, false otherwise.
+   */
+  shouldSnap(): boolean;
+
+  /**
+   * Get the ID of the pattern element, which should be randomized to avoid
+   * conflicts with other Blockly instances on the page.
+   *
+   * @returns The pattern ID.
+   * @internal
+   */
+  getPatternId(): string;
+
+  /**
+   * Update the grid with a new scale.
+   *
+   * @param scale The new workspace scale.
+   * @internal
+   */
+  update(scale: number): void;
+
+  /**
+   * Move the grid to a new x and y position, and make sure that change is
+   * visible.
+   *
+   * @param x The new x position of the grid (in px).
+   * @param y The new y position of the grid (in px).
+   * @internal
+   */
+  moveTo(x: number, y: number): void;
+
+  /**
+   * Given a coordinate, return the nearest coordinate aligned to the grid.
+   *
+   * @param xy A workspace coordinate.
+   * @returns Workspace coordinate of nearest grid point.
+   *   If there's no change, return the same coordinate object.
+   */
+  alignXY(xy: Coordinate): Coordinate;
+}
+
+export interface IGridProvider extends IRegistrable {
+  /**
+   * Create the DOM for the grid described by options.
+   *
+   * @param rnd A random ID to append to the pattern's ID.
+   * @param gridOptions The object containing grid configuration.
+   * @param defs The root SVG element for this workspace's defs.
+   * @returns The SVG element for the grid pattern.
+   */
+  createDom(
+    rnd: string,
+    gridOptions: GridOptions,
+    defs: SVGElement,
+  ): SVGElement;
+
+  /**
+   * Parse the user-specified grid options, using reasonable defaults where
+   * behaviour is unspecified. See grid documentation:
+   *   https://developers.google.com/blockly/guides/configure/web/grid
+   *
+   * @param options Dictionary of options.
+   * @returns Normalized grid options.
+   */
+  parseGridOptions(options: BlocklyOptions): GridOptions;
+
+  /**
+   * @param pattern The grid's SVG pattern, created during injection.
+   * @param options A dictionary of normalized options for the grid.
+   *     See grid documentation:
+   *     https://developers.google.com/blockly/guides/configure/web/grid
+   */
+  createGrid(pattern: SVGElement, options: GridOptions): IGrid;
+}

--- a/core/options.ts
+++ b/core/options.ts
@@ -12,6 +12,7 @@
 // Former goog.module ID: Blockly.Options
 
 import type {BlocklyOptions} from './blockly_options.js';
+import {IGridProvider} from './interfaces/i_grid.js';
 import * as registry from './registry.js';
 import {Theme} from './theme.js';
 import {Classic} from './theme/classic.js';
@@ -59,6 +60,8 @@ export class Options {
   gridPattern: SVGElement | null = null;
   parentWorkspace: WorkspaceSvg | null;
   plugins: {[key: string]: (new (...p1: any[]) => any) | string};
+
+  gridProvider: IGridProvider;
 
   /**
    * If set, sets the translation of the workspace to match the scrollbars.
@@ -175,7 +178,6 @@ export class Options {
     this.hasCss = hasCss;
     this.horizontalLayout = horizontalLayout;
     this.languageTree = toolboxJsonDef;
-    this.gridOptions = Options.parseGridOptions(options);
     this.zoomOptions = Options.parseZoomOptions(options);
     this.toolboxPosition = toolboxPosition;
     this.theme = Options.parseThemeOptions(options);
@@ -191,6 +193,16 @@ export class Options {
 
     /** Map of plugin type to name of registered plugin or plugin class. */
     this.plugins = plugins;
+
+    // This should be safe to call since this.plugins has been set
+    const GridProvider = registry.getClassFromOptions(
+      registry.Type.GRID_PROVIDER,
+      this,
+      true,
+    );
+
+    this.gridProvider = new GridProvider!();
+    this.gridOptions = this.gridProvider.parseGridOptions(options);
   }
 
   /**
@@ -299,25 +311,6 @@ export class Options {
       zoomOptions.pinch = !!zoom['pinch'];
     }
     return zoomOptions;
-  }
-
-  /**
-   * Parse the user-specified grid options, using reasonable defaults where
-   * behaviour is unspecified. See grid documentation:
-   *   https://developers.google.com/blockly/guides/configure/web/grid
-   *
-   * @param options Dictionary of options.
-   * @returns Normalized grid options.
-   */
-  private static parseGridOptions(options: BlocklyOptions): GridOptions {
-    const grid = options['grid'] || {};
-    const gridOptions = {} as GridOptions;
-    gridOptions.spacing = Number(grid['spacing']) || 0;
-    gridOptions.colour = grid['colour'] || '#888';
-    gridOptions.length =
-      grid['length'] === undefined ? 1 : Number(grid['length']);
-    gridOptions.snap = gridOptions.spacing > 0 && !!grid['snap'];
-    return gridOptions;
   }
 
   /**

--- a/core/registry.ts
+++ b/core/registry.ts
@@ -14,6 +14,7 @@ import type {IConnectionPreviewer} from './interfaces/i_connection_previewer.js'
 import type {ICopyData, ICopyable} from './interfaces/i_copyable.js';
 import type {IDragger} from './interfaces/i_dragger.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
+import {IGridProvider} from './interfaces/i_grid.js';
 import type {IIcon} from './interfaces/i_icon.js';
 import type {IMetricsManager} from './interfaces/i_metrics_manager.js';
 import type {IPaster} from './interfaces/i_paster.js';
@@ -100,6 +101,8 @@ export class Type<_T> {
    * BlockDraggeers, which is why the name is inaccurate.
    */
   static BLOCK_DRAGGER = new Type<IDragger>('blockDragger');
+
+  static GRID_PROVIDER = new Type<IGridProvider>('gridProvider');
 
   /** @internal */
   static SERIALIZER = new Type<ISerializer>('serializer');

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -37,11 +37,11 @@ import {EventType} from './events/type.js';
 import * as eventUtils from './events/utils.js';
 import type {FlyoutButton} from './flyout_button.js';
 import {Gesture} from './gesture.js';
-import {Grid} from './grid.js';
 import type {IASTNodeLocationSvg} from './interfaces/i_ast_node_location_svg.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {IDragTarget} from './interfaces/i_drag_target.js';
 import type {IFlyout} from './interfaces/i_flyout.js';
+import {IGrid} from './interfaces/i_grid.js';
 import type {IMetricsManager} from './interfaces/i_metrics_manager.js';
 import type {IToolbox} from './interfaces/i_toolbox.js';
 import type {Cursor} from './keyboard_nav/cursor.js';
@@ -275,7 +275,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    */
   private readonly highlightedBlocks: BlockSvg[] = [];
   private audioManager: WorkspaceAudio;
-  private grid: Grid | null;
+  private grid: IGrid | null;
   private markerManager: MarkerManager;
 
   /**
@@ -355,7 +355,10 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
 
     /** This workspace's grid object or null. */
     this.grid = this.options.gridPattern
-      ? new Grid(this.options.gridPattern, options.gridOptions)
+      ? options.gridProvider.createGrid(
+          this.options.gridPattern,
+          options.gridOptions,
+        )
       : null;
 
     /** Manager in charge of markers and cursors. */
@@ -2376,7 +2379,7 @@ export class WorkspaceSvg extends Workspace implements IASTNodeLocationSvg {
    *
    * @returns The grid object for this workspace.
    */
-  getGrid(): Grid | null {
+  getGrid(): IGrid | null {
     return this.grid;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly/issues/8614

### Proposed Changes

Refactors the Grid class so that it can be overridden by a plugin. The static methods for [parsing grid options](https://github.com/google/blockly/blob/develop/core/options.ts#L312) and [creating the SVG pattern element](https://github.com/google/blockly/blob/3e4665e5b824041867b79f0cf8b657c5e6c32236/core/grid.ts#L216) have also been moved onto a new GridProvider class which can be passed in as a plugin in the BlocklyOptions object. The implementations of these functions are unchanged; they just got moved around.

Originally, I just wanted these to be static methods on the IGrid interface, but the typings for the registry's `getClass` functions don't really allow for static properties and I didn't want to tear all that up in this PR.

I would love some feedback on the typing of GridOptions here. My example use case for this is the [MakeCode Minecraft editor](https://minecraft.makecode.com/#editor) which overrides the grid with a background image that scrolls with the workspace. A plugin that provided that functionality would likely need to extend the GridOptions type with extra fields like the URL of the image, width/height, opacity, etc. However, the `grid` property of the BlocklyOptions object passed to inject is pretty strongly typed; the only way around it right now is to do a lot of casting to `any`.

### Reason for Changes

See the linked issue for reasoning!

### Test Coverage

Tested manually in the playground and by creating a test plugin locally. Happy to add unit tests, but I didn't see any for other extension points at a click glance.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I can also add a plugin to blockly-samples that utilizes this change should this PR be approved.
