### PR TITLE
fix: Clear the cursor when deleting the block it's on.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -808,6 +808,16 @@ export class BlockSvg
   override dispose(healStack?: boolean, animate?: boolean) {
     this.disposing = true;
 
+    if (
+      this.workspace
+        .getMarkerManager()
+        .getCursor()
+        ?.getCurNode()
+        ?.getLocation() === this
+    ) {
+      this.workspace.getMarkerManager().getCursor()?.setCurNode(null);
+    }
+
     Tooltip.dispose();
     ContextMenu.hide();
 

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -808,14 +808,8 @@ export class BlockSvg
   override dispose(healStack?: boolean, animate?: boolean) {
     this.disposing = true;
 
-    if (
-      this.workspace
-        .getMarkerManager()
-        .getCursor()
-        ?.getCurNode()
-        ?.getLocation() === this
-    ) {
-      this.workspace.getMarkerManager().getCursor()?.setCurNode(null);
+    if (this.workspace.getCursor()?.getCurNode()?.getLocation() === this) {
+      this.workspace.getCursor()?.setCurNode(null);
     }
 
     Tooltip.dispose();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8793

### Proposed Changes
This PR clears the cursor in BlockSvg.dispose() if the cursor is pointing to the block that is being deleted.