### PR TITLE
Feature: Add a dropdown options setter

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -415,10 +415,8 @@ export class FieldDropdown extends Field<string> {
     } else {
       this.menuGenerator_ = menuGenerator;
     }
-    /**
-     * The currently selected option. The field is initialized with the
-     * first option selected.
-     */
+    // The currently selected option. The field is initialized with the
+    // first option selected.
     this.selectedOption = this.getOptions(false)[0];
     this.setValue(this.selectedOption[1]);
   }

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -136,26 +136,11 @@ export class FieldDropdown extends Field<string> {
     // If we pass SKIP_SETUP, don't do *anything* with the menu generator.
     if (menuGenerator === Field.SKIP_SETUP) return;
 
-    if (Array.isArray(menuGenerator)) {
-      this.validateOptions(menuGenerator);
-      const trimmed = this.trimOptions(menuGenerator);
-      this.menuGenerator_ = trimmed.options;
-      this.prefixField = trimmed.prefix || null;
-      this.suffixField = trimmed.suffix || null;
-    } else {
-      this.menuGenerator_ = menuGenerator;
-    }
-
-    /**
-     * The currently selected option. The field is initialized with the
-     * first option selected.
-     */
-    this.selectedOption = this.getOptions(false)[0];
+    this.setOptions(menuGenerator);
 
     if (config) {
       this.configure_(config);
     }
-    this.setValue(this.selectedOption[1]);
     if (validator) {
       this.setValidator(validator);
     }
@@ -412,6 +397,30 @@ export class FieldDropdown extends Field<string> {
     this.generatedOptions = this.menuGenerator_();
     this.validateOptions(this.generatedOptions);
     return this.generatedOptions;
+  }
+
+  /**
+   * Update the options on this dropdown. This will reset the selected item to
+   * the first item in the list.
+   *
+   * @param menuGenerator The array of options or a generator function.
+   */
+  setOptions(menuGenerator: MenuGenerator) {
+    if (Array.isArray(menuGenerator)) {
+      this.validateOptions(menuGenerator);
+      const trimmed = this.trimOptions(menuGenerator);
+      this.menuGenerator_ = trimmed.options;
+      this.prefixField = trimmed.prefix || null;
+      this.suffixField = trimmed.suffix || null;
+    } else {
+      this.menuGenerator_ = menuGenerator;
+    }
+    /**
+     * The currently selected option. The field is initialized with the
+     * first option selected.
+     */
+    this.selectedOption = this.getOptions(false)[0];
+    this.setValue(this.selectedOption[1]);
   }
 
   /**

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -194,12 +194,30 @@ suite('Dropdown Fields', function () {
       this.field.setValue('B');
       assertFieldValue(this.field, 'B', 'b');
     });
-    test('After options change', function () {
+  });
+  suite('setOptions', function () {
+    setup(function () {
+      this.field = new Blockly.FieldDropdown([
+        ['a', 'A'],
+        ['b', 'B'],
+        ['c', 'C'],
+      ]);
+    });
+    test('With array updates options', function () {
       this.field.setOptions([
         ['d', 'D'],
         ['e', 'E'],
         ['f', 'F'],
       ]);
+      assertFieldValue(this.field, 'D', 'd');
+    });
+    test('With generator updates options', function () {
+      this.field.setOptions(function () {
+        return [
+        ['d', 'D'],
+        ['e', 'E'],
+        ['f', 'F'],
+      ]});
       assertFieldValue(this.field, 'D', 'd');
     });
   });

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -194,6 +194,14 @@ suite('Dropdown Fields', function () {
       this.field.setValue('B');
       assertFieldValue(this.field, 'B', 'b');
     });
+    test('After options change', function () {
+      this.field.setOptions([
+        ['d', 'D'],
+        ['e', 'E'],
+        ['f', 'F'],
+      ]);
+      assertFieldValue(this.field, 'D', 'd');
+    });
   });
 
   suite('Validators', function () {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -220,6 +220,25 @@ suite('Dropdown Fields', function () {
       ]});
       assertFieldValue(this.field, 'D', 'd');
     });
+    test('With trimmable options gets trimmed', function () {
+      this.field.setOptions([
+        ['a d b', 'D'],
+        ['a e b', 'E'],
+        ['a f b', 'F'],
+      ]);
+      assert.deepEqual(this.field.prefixField, 'a');
+      assert.deepEqual(this.field.suffixField, 'b');
+      assert.deepEqual(this.field.getOptions(), [
+        ['d', 'D'],
+        ['e', 'E'],
+        ['f', 'F'],
+      ]);
+    })
+    test('With an empty array of options throws', function () {
+      assert.throws(function () {
+        this.field.setOptions([]);
+      });
+    });
   });
 
   suite('Validators', function () {

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -214,10 +214,11 @@ suite('Dropdown Fields', function () {
     test('With generator updates options', function () {
       this.field.setOptions(function () {
         return [
-        ['d', 'D'],
-        ['e', 'E'],
-        ['f', 'F'],
-      ]});
+          ['d', 'D'],
+          ['e', 'E'],
+          ['f', 'F'],
+        ];
+      });
       assertFieldValue(this.field, 'D', 'd');
     });
     test('With trimmable options gets trimmed', function () {
@@ -233,7 +234,7 @@ suite('Dropdown Fields', function () {
         ['e', 'E'],
         ['f', 'F'],
       ]);
-    })
+    });
     test('With an empty array of options throws', function () {
       assert.throws(function () {
         this.field.setOptions([]);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #1288 

### Proposed Changes

Adds a setOptions function to field_dropdown to allow changing the set of options or the generator for options after creation. 

### Reason for Changes

This makes it easier to define blocks with dynamic dropdowns in JSON.

### Test Coverage

Added a test to verify the selected option is updated after changing the set of options.

### Documentation

We should consider updating the [dropdown field docs](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/dropdown#dynamic_menu) to include this as a simpler option for the JSON definitions.

### Additional Information

<!-- Anything else we should know? -->
