### PR TITLE
feat: Allow for HTML elements in dropdown field menus.

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -336,9 +336,9 @@ export class FieldDropdown extends Field<string> {
       const content = (() => {
         if (isImageProperties(label)) {
           // Convert ImageProperties to an HTMLImageElement.
-          const image = new Image(label['width'], label['height']);
-          image.src = label['src'];
-          image.alt = label['alt'] || '';
+          const image = new Image(label.width, label.height);
+          image.src = label.src;
+          image.alt = label.alt;
           return image;
         }
         return label;

--- a/tests/mocha/field_dropdown_test.js
+++ b/tests/mocha/field_dropdown_test.js
@@ -92,9 +92,9 @@ suite('Dropdown Fields', function () {
       expectedText: 'a',
       args: [
         [
-          [{src: 'scrA', alt: 'a'}, 'A'],
-          [{src: 'scrB', alt: 'b'}, 'B'],
-          [{src: 'scrC', alt: 'c'}, 'C'],
+          [{src: 'scrA', alt: 'a', width: 10, height: 10}, 'A'],
+          [{src: 'scrB', alt: 'b', width: 10, height: 10}, 'B'],
+          [{src: 'scrC', alt: 'c', width: 10, height: 10}, 'C'],
         ],
       ],
     },
@@ -121,9 +121,9 @@ suite('Dropdown Fields', function () {
       args: [
         () => {
           return [
-            [{src: 'scrA', alt: 'a'}, 'A'],
-            [{src: 'scrB', alt: 'b'}, 'B'],
-            [{src: 'scrC', alt: 'c'}, 'C'],
+            [{src: 'scrA', alt: 'a', width: 10, height: 10}, 'A'],
+            [{src: 'scrB', alt: 'b', width: 10, height: 10}, 'B'],
+            [{src: 'scrC', alt: 'c', width: 10, height: 10}, 'C'],
           ];
         },
       ],

--- a/tests/mocha/json_test.js
+++ b/tests/mocha/json_test.js
@@ -256,12 +256,6 @@ suite('JSON Block Definitions', function () {
         'alt': '%{BKY_ALT_TEXT}',
       };
       const VALUE1 = 'VALUE1';
-      const IMAGE2 = {
-        'width': 90,
-        'height': 123,
-        'src': 'http://image2.src',
-      };
-      const VALUE2 = 'VALUE2';
 
       Blockly.defineBlocksWithJsonArray([
         {
@@ -274,7 +268,6 @@ suite('JSON Block Definitions', function () {
               'options': [
                 [IMAGE0, VALUE0],
                 [IMAGE1, VALUE1],
-                [IMAGE2, VALUE2],
               ],
             },
           ],
@@ -305,11 +298,6 @@ suite('JSON Block Definitions', function () {
       assertImageEquals(IMAGE1, image1);
       assert.equal(image1.alt, IMAGE1_ALT_TEXT); // Via Msg reference
       assert.equal(VALUE1, options[1][1]);
-
-      const image2 = options[2][0];
-      assertImageEquals(IMAGE1, image1);
-      assert.notExists(image2.alt); // No alt specified.
-      assert.equal(VALUE2, options[2][1]);
     });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of https://github.com/google/blockly-samples/issues/2482

### Proposed Changes
This PR adds support for arbitrary HTML elements in the menu of a `FieldDropdown`. This is mostly to allow them in `FieldGrid`, which is a `FieldDropdown` subclass, but also gives developers greater flexibility. This PR does not attempt to ensure reasonable bounds or interaction behavior for HTML elements in menus; provided elements should not be unreasonably large or expect to handle mouse/keyboard interaction, but this is the responsibility of developers to ensure.

When an HTML-element-based menu item is selected, a text representation of the element will be displayed in the field. In order of preference, the text is derived from (1) the `title` attribute of the element, (2) the `aria-label` attribute of the element, and (3) the `innerText` of the element.

This PR also updates several tests that omitted various fields from the `ImageProperties` interface; the interface and [documentation](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/dropdown#image_dropdowns) state that all 4 properties are required, but the implementation was a bit loose on that.