### PR TITLE
Fix: Add padding to the bounds before deciding if it should scroll

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2581,23 +2581,23 @@ export class WorkspaceSvg
       rawViewport.left + rawViewport.width,
     );
 
-    if (
-      bounds.left >= viewport.left &&
-      bounds.top >= viewport.top &&
-      bounds.right <= viewport.right &&
-      bounds.bottom <= viewport.bottom
-    ) {
-      // Do nothing if the block is fully inside the viewport.
-      return;
-    }
-
-    // Add some padding to the bounds so the element is scrolled comfortably
+    // Add the padding to the bounds so the element is scrolled comfortably
     // into view.
     bounds = bounds.clone();
     bounds.top -= padding;
     bounds.bottom += padding;
     bounds.left -= padding;
     bounds.right += padding;
+
+    if (
+      bounds.left >= viewport.left &&
+      bounds.top >= viewport.top &&
+      bounds.right <= viewport.right &&
+      bounds.bottom <= viewport.bottom
+    ) {
+      // Do nothing if the block with padding is fully inside the viewport.
+      return;
+    }
 
     let deltaX = 0;
     let deltaY = 0;


### PR DESCRIPTION
This makes it easier to scroll something into view with context by including the padding before checking if it should be scrolled into view.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes an issue uncovered in https://github.com/google/blockly-keyboard-experimentation/pull/451

### Proposed Changes

Add the padding to the bounds before checking if it's within the viewport.

### Reason for Changes

During a keyboard drag this method may be called more once. When that happens only the first call with default padding is executed.  During a constrained drag we'd like to increase the padding to give more context about the new location, so we should check with the padding to make sure later calls that try to move it further in bounds are respected.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
