### PR TITLE
fix: Support RTL in WorkspaceSvg.scrollIntoBounds

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2604,7 +2604,10 @@ export class WorkspaceSvg
 
     if (bounds.left < viewport.left) {
       deltaX = this.RTL
-        ? Math.min(viewport.left - bounds.left, viewport.right - bounds.right)
+        ? Math.min(
+            viewport.left - bounds.left,
+            viewport.right - bounds.right, // Don't move the right side out of view
+          )
         : viewport.left - bounds.left;
     } else if (bounds.right > viewport.right) {
       deltaX = this.RTL

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2603,15 +2603,25 @@ export class WorkspaceSvg
     let deltaY = 0;
 
     if (bounds.left < viewport.left) {
-      deltaX = viewport.left - bounds.left;
+      deltaX = this.RTL
+        ? Math.min(viewport.left - bounds.left, viewport.right - bounds.right)
+        : viewport.left - bounds.left;
     } else if (bounds.right > viewport.right) {
-      deltaX = viewport.right - bounds.right;
+      deltaX = this.RTL
+        ? viewport.right - bounds.right
+        : Math.max(
+            viewport.right - bounds.right,
+            viewport.left - bounds.left, // Don't move the left side out of view
+          );
     }
 
     if (bounds.top < viewport.top) {
       deltaY = viewport.top - bounds.top;
     } else if (bounds.bottom > viewport.bottom) {
-      deltaY = viewport.bottom - bounds.bottom;
+      deltaY = Math.max(
+        viewport.bottom - bounds.bottom,
+        viewport.top - bounds.top, // Don't move the top out of view
+      );
     }
 
     deltaX *= scale;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8935 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Add checks for RTL and update the bounds to keep the right or the left in the viewport depending on whether we're in RTL or LTR.

### Reason for Changes

Previously, blocks that were too long to fit in the viewport would jump around or always prefer the left side be kept in bounds regardless of RTL.

With the changes, RTL is now handled correctly:
[Screen recording 2025-04-28 2.57.15 PM.webm](https://github.com/user-attachments/assets/85965530-8f1c-436e-b67a-86e1531c9a32)
[Screen recording 2025-04-28 2.56.08 PM.webm](https://github.com/user-attachments/assets/fd2c592c-f3b3-45de-a361-fd78c08ca0b9)


### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
