### PR TITLE
fix!: Remove alt+key commands

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -101,9 +101,6 @@ export function registerCopy() {
   const ctrlC = ShortcutRegistry.registry.createSerializedKey(KeyCodes.C, [
     KeyCodes.CTRL,
   ]);
-  const altC = ShortcutRegistry.registry.createSerializedKey(KeyCodes.C, [
-    KeyCodes.ALT,
-  ]);
   const metaC = ShortcutRegistry.registry.createSerializedKey(KeyCodes.C, [
     KeyCodes.META,
   ]);
@@ -140,7 +137,7 @@ export function registerCopy() {
         : null;
       return !!copyData;
     },
-    keyCodes: [ctrlC, altC, metaC],
+    keyCodes: [ctrlC, metaC],
   };
   ShortcutRegistry.registry.register(copyShortcut);
 }
@@ -151,9 +148,6 @@ export function registerCopy() {
 export function registerCut() {
   const ctrlX = ShortcutRegistry.registry.createSerializedKey(KeyCodes.X, [
     KeyCodes.CTRL,
-  ]);
-  const altX = ShortcutRegistry.registry.createSerializedKey(KeyCodes.X, [
-    KeyCodes.ALT,
   ]);
   const metaX = ShortcutRegistry.registry.createSerializedKey(KeyCodes.X, [
     KeyCodes.META,
@@ -198,7 +192,7 @@ export function registerCut() {
       }
       return false;
     },
-    keyCodes: [ctrlX, altX, metaX],
+    keyCodes: [ctrlX, metaX],
   };
 
   ShortcutRegistry.registry.register(cutShortcut);
@@ -210,9 +204,6 @@ export function registerCut() {
 export function registerPaste() {
   const ctrlV = ShortcutRegistry.registry.createSerializedKey(KeyCodes.V, [
     KeyCodes.CTRL,
-  ]);
-  const altV = ShortcutRegistry.registry.createSerializedKey(KeyCodes.V, [
-    KeyCodes.ALT,
   ]);
   const metaV = ShortcutRegistry.registry.createSerializedKey(KeyCodes.V, [
     KeyCodes.META,
@@ -246,7 +237,7 @@ export function registerPaste() {
       const centerCoords = new Coordinate(left + width / 2, top + height / 2);
       return !!clipboard.paste(copyData, copyWorkspace, centerCoords);
     },
-    keyCodes: [ctrlV, altV, metaV],
+    keyCodes: [ctrlV, metaV],
   };
 
   ShortcutRegistry.registry.register(pasteShortcut);
@@ -258,9 +249,6 @@ export function registerPaste() {
 export function registerUndo() {
   const ctrlZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
     KeyCodes.CTRL,
-  ]);
-  const altZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
-    KeyCodes.ALT,
   ]);
   const metaZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
     KeyCodes.META,
@@ -278,7 +266,7 @@ export function registerUndo() {
       e.preventDefault();
       return true;
     },
-    keyCodes: [ctrlZ, altZ, metaZ],
+    keyCodes: [ctrlZ, metaZ],
   };
   ShortcutRegistry.registry.register(undoShortcut);
 }
@@ -291,10 +279,6 @@ export function registerRedo() {
   const ctrlShiftZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
     KeyCodes.SHIFT,
     KeyCodes.CTRL,
-  ]);
-  const altShiftZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
-    KeyCodes.SHIFT,
-    KeyCodes.ALT,
   ]);
   const metaShiftZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
     KeyCodes.SHIFT,
@@ -317,7 +301,7 @@ export function registerRedo() {
       e.preventDefault();
       return true;
     },
-    keyCodes: [ctrlShiftZ, altShiftZ, metaShiftZ, ctrlY],
+    keyCodes: [ctrlShiftZ, metaShiftZ, ctrlY],
   };
   ShortcutRegistry.registry.register(redoShortcut);
 }

--- a/tests/mocha/keydown_test.js
+++ b/tests/mocha/keydown_test.js
@@ -131,12 +131,6 @@ suite('Key Down', function () {
           Blockly.utils.KeyCodes.META,
         ]),
       ],
-      [
-        'Alt C',
-        createKeyDownEvent(Blockly.utils.KeyCodes.C, [
-          Blockly.utils.KeyCodes.ALT,
-        ]),
-      ],
     ];
     // Copy a block.
     suite('Simple', function () {
@@ -222,12 +216,6 @@ suite('Key Down', function () {
           Blockly.utils.KeyCodes.META,
         ]),
       ],
-      [
-        'Alt Z',
-        createKeyDownEvent(Blockly.utils.KeyCodes.Z, [
-          Blockly.utils.KeyCodes.ALT,
-        ]),
-      ],
     ];
     // Undo.
     suite('Simple', function () {
@@ -285,13 +273,6 @@ suite('Key Down', function () {
         'Meta Shift Z',
         createKeyDownEvent(Blockly.utils.KeyCodes.Z, [
           Blockly.utils.KeyCodes.META,
-          Blockly.utils.KeyCodes.SHIFT,
-        ]),
-      ],
-      [
-        'Alt Shift Z',
-        createKeyDownEvent(Blockly.utils.KeyCodes.Z, [
-          Blockly.utils.KeyCodes.ALT,
           Blockly.utils.KeyCodes.SHIFT,
         ]),
       ],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/258

### Proposed Changes

Remove the alt+key code version of commands

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Using alt is non-standard and may conflict with window commands, so we're removing it.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Removed the tests that expect alt to work.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
