### PR TITLE
fix: Treat the workspace as a sibling of the top level blocks to allow navigating to it

### DIFF
--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -91,12 +91,8 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
       return current.workspace;
     }
 
-    const lastBlock = topBlocks[targetIndex]
-      .getDescendants(true)
-      .reverse()
-      .pop();
-
-    return lastBlock?.nextConnection ?? lastBlock ?? null;
+    const block = topBlocks[targetIndex];
+    return block.lastConnectionInStack(false) ?? block;
   }
 
   /**

--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -60,9 +60,9 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
       // connection, it must be the last block in the stack, so its next sibling
       // is the first block of the next stack on the workspace.
       const topBlocks = current.workspace.getTopBlocks(true);
-      let targetIndex = topBlocks.indexOf(current.getRootBlock()) + 1;
+      const targetIndex = topBlocks.indexOf(current.getRootBlock()) + 1;
       if (targetIndex >= topBlocks.length) {
-        targetIndex = 0;
+        return current.workspace;
       }
       const previousBlock = topBlocks[targetIndex];
       return this.getParentConnection(previousBlock) ?? previousBlock;
@@ -86,9 +86,9 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
     // so its previous sibling is the last connection of the last block of the
     // previous stack on the workspace.
     const topBlocks = current.workspace.getTopBlocks(true);
-    let targetIndex = topBlocks.indexOf(current.getRootBlock()) - 1;
+    const targetIndex = topBlocks.indexOf(current.getRootBlock()) - 1;
     if (targetIndex < 0) {
-      targetIndex = topBlocks.length - 1;
+      return current.workspace;
     }
 
     const lastBlock = topBlocks[targetIndex]

--- a/core/keyboard_nav/connection_navigation_policy.ts
+++ b/core/keyboard_nav/connection_navigation_policy.ts
@@ -81,9 +81,9 @@ export class ConnectionNavigationPolicy
         sourceBlock.getRootBlock().lastConnectionInStack(false) === current
       ) {
         const topBlocks = sourceBlock.workspace.getTopBlocks(true);
-        let targetIndex = topBlocks.indexOf(sourceBlock.getRootBlock()) + 1;
+        const targetIndex = topBlocks.indexOf(sourceBlock.getRootBlock()) + 1;
         if (targetIndex >= topBlocks.length) {
-          targetIndex = 0;
+          return sourceBlock.workspace;
         }
         const nextBlock = topBlocks[targetIndex];
         return this.getParentConnection(nextBlock) ?? nextBlock;
@@ -134,9 +134,9 @@ export class ConnectionNavigationPolicy
         this.getParentConnection(sourceBlock.getRootBlock()) === current
       ) {
         const topBlocks = sourceBlock.workspace.getTopBlocks(true);
-        let targetIndex = topBlocks.indexOf(sourceBlock.getRootBlock()) - 1;
+        const targetIndex = topBlocks.indexOf(sourceBlock.getRootBlock()) - 1;
         if (targetIndex < 0) {
-          targetIndex = topBlocks.length - 1;
+          return sourceBlock.workspace;
         }
         const previousRootBlock = topBlocks[targetIndex];
         return (

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -278,6 +278,8 @@ export class LineCursor extends Marker {
       } else if (node.type === ConnectionType.PREVIOUS_STATEMENT) {
         return this.options.stackConnections && !node.isConnected();
       }
+    } else if (node instanceof WorkspaceSvg) {
+      return true;
     }
 
     return false;

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -618,7 +618,11 @@ export class LineCursor extends Marker {
    * @returns The last navigable node on the workspace, or null.
    */
   getLastNode(): INavigable<any> | null {
-    return this.getPreviousNode(this.workspace, () => true, true);
+    return this.getPreviousNode(
+      this.workspace,
+      this.validNode.bind(this),
+      true,
+    );
   }
 }
 

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -609,7 +609,7 @@ export class LineCursor extends Marker {
    * @returns The first navigable node on the workspace, or null.
    */
   getFirstNode(): INavigable<any> | null {
-    return this.workspace.getNavigator().getFirstChild(this.workspace);
+    return this.workspace.getNavigator().getNextSibling(this.workspace);
   }
 
   /**
@@ -618,8 +618,7 @@ export class LineCursor extends Marker {
    * @returns The last navigable node on the workspace, or null.
    */
   getLastNode(): INavigable<any> | null {
-    const first = this.getFirstNode();
-    return this.getPreviousNode(first, () => true, true);
+    return this.workspace.getNavigator().getPreviousSibling(this.workspace);
   }
 }
 

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -618,7 +618,7 @@ export class LineCursor extends Marker {
    * @returns The last navigable node on the workspace, or null.
    */
   getLastNode(): INavigable<any> | null {
-    return this.workspace.getNavigator().getPreviousSibling(this.workspace);
+    return this.getPreviousNode(this.workspace, () => true, true);
   }
 }
 

--- a/core/keyboard_nav/workspace_navigation_policy.ts
+++ b/core/keyboard_nav/workspace_navigation_policy.ts
@@ -17,10 +17,30 @@ export class WorkspaceNavigationPolicy
   /**
    * Returns the first child of the given workspace.
    *
-   * @param current The workspace to return the first child of.
+   * @param _current The workspace to return the first child of.
    * @returns The top block of the first block stack, if any.
    */
-  getFirstChild(current: WorkspaceSvg): INavigable<unknown> | null {
+  getFirstChild(_current: WorkspaceSvg): INavigable<unknown> | null {
+    return null;
+  }
+
+  /**
+   * Returns the parent of the given workspace.
+   *
+   * @param _current The workspace to return the parent of.
+   * @returns Null.
+   */
+  getParent(_current: WorkspaceSvg): INavigable<unknown> | null {
+    return null;
+  }
+
+  /**
+   * Returns the first navigable child of the given workspace.
+   *
+   * @param current The workspace to return the next sibling of.
+   * @returns Null.
+   */
+  getNextSibling(current: WorkspaceSvg): INavigable<unknown> | null {
     const blocks = current.getTopBlocks(true);
     if (!blocks.length) return null;
     const block = blocks[0];
@@ -35,32 +55,15 @@ export class WorkspaceNavigationPolicy
   }
 
   /**
-   * Returns the parent of the given workspace.
+   * Returns the last block of the given workspace.
    *
-   * @param _current The workspace to return the parent of.
+   * @param current The workspace to return the previous sibling of.
    * @returns Null.
    */
-  getParent(_current: WorkspaceSvg): INavigable<unknown> | null {
-    return null;
-  }
-
-  /**
-   * Returns the next sibling of the given workspace.
-   *
-   * @param _current The workspace to return the next sibling of.
-   * @returns Null.
-   */
-  getNextSibling(_current: WorkspaceSvg): INavigable<unknown> | null {
-    return null;
-  }
-
-  /**
-   * Returns the previous sibling of the given workspace.
-   *
-   * @param _current The workspace to return the previous sibling of.
-   * @returns Null.
-   */
-  getPreviousSibling(_current: WorkspaceSvg): INavigable<unknown> | null {
-    return null;
+  getPreviousSibling(current: WorkspaceSvg): INavigable<unknown> | null {
+    const blocks = current.getTopBlocks(true);
+    if (!blocks.length) return null;
+    const block = blocks[blocks.length - 1];
+    return block;
   }
 }

--- a/core/keyboard_nav/workspace_navigation_policy.ts
+++ b/core/keyboard_nav/workspace_navigation_policy.ts
@@ -64,7 +64,6 @@ export class WorkspaceNavigationPolicy
     const blocks = current.getTopBlocks(true);
     if (!blocks.length) return null;
     const block = blocks[blocks.length - 1];
-    const lastBlock = block.getDescendants(true).pop();
-    return lastBlock?.nextConnection ?? lastBlock ?? null;
+    return block.lastConnectionInStack(false) ?? block;
   }
 }

--- a/core/keyboard_nav/workspace_navigation_policy.ts
+++ b/core/keyboard_nav/workspace_navigation_policy.ts
@@ -64,6 +64,7 @@ export class WorkspaceNavigationPolicy
     const blocks = current.getTopBlocks(true);
     if (!blocks.length) return null;
     const block = blocks[blocks.length - 1];
-    return block;
+    const lastBlock = block.getDescendants(true).pop();
+    return lastBlock?.nextConnection ?? lastBlock ?? null;
   }
 }

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -580,7 +580,7 @@ suite('Cursor', function () {
           this.alwaysValid,
           true,
         );
-        assert.equal(nextNode, this.blockA.previousConnection);
+        assert.equal(nextNode, this.workspace);
       });
 
       test('Valid if connection - start at end - with loopback', function () {
@@ -778,7 +778,7 @@ suite('Cursor', function () {
           this.alwaysValid,
           true,
         );
-        assert.equal(previousNode, this.blockC.nextConnection);
+        assert.equal(previousNode, this.workspace);
       });
       test('Valid if connection - start at top - with loopback', function () {
         const startNode = this.blockA.previousConnection;

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -459,7 +459,7 @@ suite('Navigation', function () {
       });
       test('fromWorkspaceToBlock', function () {
         const inNode = this.navigator.getFirstChild(this.workspace);
-        assert.equal(inNode, this.workspace.getTopBlocks(true)[0]);
+        assert.isNull(inNode);
       });
       test('fromWorkspaceToNull', function () {
         const inNode = this.navigator.getFirstChild(this.emptyWorkspace);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/492

### Proposed Changes

Makes the Workspace a sibling of the top blocks in the context of navigation. This allows the user to navigate to the workspace when cycling through blocks which makes it possible to trigger the workspace menu.

### Reason for Changes

Previously you couldn't navigate to the workspace with the keyboard if there were any blocks on it, which prevented accessing the workspace menu.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
