### PR TITLE
fix: Don't fire events for changes to potential variables

### DIFF
--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -868,7 +868,7 @@ export class Workspace {
    */
   createPotentialVariableMap() {
     const VariableMap = this.getVariableMapClass();
-    this.potentialVariableMap = new VariableMap(this);
+    this.potentialVariableMap = new VariableMap(this, true);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9018 

### Proposed Changes

Adds a param to variable_map to declare it as a potential map and doesn't fire events if it's a potential map.

### Reason for Changes

The potential map firing delete events was causing the toolbox to refresh which deleted potential variables. This repeated indefinitely while the toolbox was open to a category with a variable.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
