### PR TITLE
fix: Ensure `FieldImage` is clickable when appropriate

### DIFF
--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -213,6 +213,17 @@ export class FieldImage extends Field<string> {
   }
 
   /**
+   * Check whether this field should be clickable.
+   *
+   * @returns Whether this field is clickable.
+   */
+  isClickable(): boolean {
+    // Images are only clickable if they have a click handler and fulfill the
+    // contract to be clickable: enabled and attached to an editable block.
+    return super.isClickable() && !!this.clickHandler;
+  }
+
+  /**
    * If field click is called, and click handler defined,
    * call the handler.
    */

--- a/tests/mocha/field_image_test.js
+++ b/tests/mocha/field_image_test.js
@@ -20,6 +20,7 @@ import {
 suite('Image Fields', function () {
   setup(function () {
     sharedTestSetup.call(this);
+    this.workspace = Blockly.inject('blocklyDiv');
   });
   teardown(function () {
     sharedTestTeardown.call(this);
@@ -235,6 +236,115 @@ suite('Image Fields', function () {
           flipRtl: true,
         });
         assert.isTrue(field.getFlipRtl());
+      });
+    });
+    suite('isClickable', function () {
+      setup(function () {
+        this.onClick = function () {
+          console.log('on click');
+        };
+        this.setUpBlockWithFieldImages = function () {
+          const blockJson = {
+            'type': 'text',
+            'id': 'block_id',
+            'x': 0,
+            'y': 0,
+            'fields': {
+              'TEXT': '',
+            },
+          };
+          Blockly.serialization.blocks.append(blockJson, this.workspace);
+          return this.workspace.getBlockById('block_id');
+        };
+        this.extractFieldImage = function (block) {
+          const fields = Array.from(block.getFields());
+          // Sanity check (as a precondition).
+          assert.strictEqual(fields.length, 3);
+          const imageField = fields[0];
+          // Sanity check (as a precondition).
+          assert.isTrue(imageField instanceof Blockly.FieldImage);
+          return imageField;
+        };
+      });
+
+      test('Unattached field without click handler returns false', function () {
+        const field = new Blockly.FieldImage('src', 10, 10, null);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('Unattached field with click handler returns false', function () {
+        const field = new Blockly.FieldImage('src', 10, 10, this.onClick);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('For attached but disabled field without click handler returns false', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+        field.setEnabled(false);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('For attached but disabled field with click handler returns false', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+        field.setEnabled(false);
+        field.setOnClickHandler(this.onClick);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('For attached, enabled, but not editable field without click handler returns false', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+        block.setEditable(false);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('For attached, enabled, but not editable field with click handler returns false', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+        block.setEditable(false);
+        field.setOnClickHandler(this.onClick);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('For attached, enabled, editable field without click handler returns false', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
+      });
+      test('For attached, enabled, editable field with click handler returns true', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+        field.setOnClickHandler(this.onClick);
+
+        const isClickable = field.isClickable();
+
+        assert.isTrue(isClickable);
+      });
+      test('For attached, enabled, editable field with removed click handler returns false', function () {
+        const block = this.setUpBlockWithFieldImages();
+        const field = this.extractFieldImage(block);
+        field.setOnClickHandler(this.onClick);
+        field.setOnClickHandler(null);
+
+        const isClickable = field.isClickable();
+
+        assert.isFalse(isClickable);
       });
     });
   });


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes part of https://github.com/google/blockly-keyboard-experimentation/issues/525

### Proposed Changes

This introduces an `isClickable` override for `FieldImage` that only allows images to be clickable when they have a click handler.

### Reason for Changes

Without this change it's possible to navigate to non-clickable images (like the quotes in certain text blocks) since #9054. This is both a confusing experience and causing a test failure in the keyboard navigation plugin: https://github.com/google/blockly-keyboard-experimentation/pull/527#issuecomment-2885234898.

### Test Coverage

New tests have been added for `FieldImage.isClickable()` and have been specifically verified such that that the following new tests correctly fail without the fix in place:
- `For attached, enabled, editable field without click handler returns false`
- `For attached, enabled, editable field with removed click handler returns false`

The first one perfectly covers the case that caused the regression, so these tests should help ensure the regression doesn't occur again.

Additionally, the tests in https://github.com/google/blockly-keyboard-experimentation/pull/527 have been verified against this PR via linking and verified to pass.

I've manually tested the scenarios involving quotes (since that was the direct failure case) in the keyboard navigation plugin test environment and placed some similar blocks in core Blockly's simple playground (while checking console logs) to verify nothing obvious is broken.

### Documentation

No new documentation changes should be needed.

### Additional Information

This is a fix suggested over chat by @gonfunko when helping to investigate why the new test was found failing. Note that this failure is a discrepancy between beta.7 and the full 12.0.0 release.