### PR TITLE
fix: When moving to a field, scroll the field's block into view

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -14,6 +14,7 @@
  */
 
 import {BlockSvg} from '../block_svg.js';
+import { Field } from '../field.js';
 import {getFocusManager} from '../focus_manager.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {isFocusableNode} from '../interfaces/i_focusable_node.js';
@@ -405,6 +406,11 @@ export class LineCursor extends Marker {
     if (newNode instanceof BlockSvg) {
       newNode.workspace.scrollBoundsIntoView(
         newNode.getBoundingRectangleWithoutChildren(),
+      );
+    } else if (newNode instanceof Field) {
+      const block = newNode.getSourceBlock() as BlockSvg;
+      block.workspace.scrollBoundsIntoView(
+        block.getBoundingRectangleWithoutChildren(),
       );
     }
   }

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -14,7 +14,7 @@
  */
 
 import {BlockSvg} from '../block_svg.js';
-import { Field } from '../field.js';
+import {Field} from '../field.js';
 import {getFocusManager} from '../focus_manager.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {isFocusableNode} from '../interfaces/i_focusable_node.js';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8944

### Proposed Changes

When navigating to a field scroll its block into view.

### Reason for Changes

Navigating to a field that's out of view would let you navigate where you can't see. This makes fields also get scrolled into bounds.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
