### PR TITLE
fix: Visit all nodes in getNextSibling and getPreviousSibling

### DIFF
--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -6,6 +6,13 @@
 
 import {BlockSvg} from '../block_svg.js';
 import type {Field} from '../field.js';
+import {
+  DummyInput,
+  EndRowInput,
+  Input,
+  StatementInput,
+  ValueInput,
+} from '../inputs.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
@@ -70,9 +77,12 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
     let siblings: (BlockSvg | Field)[] = [];
     if (parent instanceof BlockSvg) {
       for (let i = 0, input; (input = parent.inputList[i]); i++) {
-        if (input.connection) {
+        if (
+          i == 0 ||
+          this.isStartOfRow(parent, input, parent.inputList[i - 1])
+        ) {
           siblings.push(...input.fieldRow);
-          const child = input.connection.targetBlock();
+          const child = input.connection?.targetBlock();
           if (child) {
             siblings.push(child as BlockSvg);
           }
@@ -164,5 +174,47 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
    */
   isApplicable(current: any): current is BlockSvg {
     return current instanceof BlockSvg;
+  }
+
+  /**
+   * Checks whether an input is the first input on a row. This code is mostly
+   * identical to RenderInfo.
+   *
+   * @param block The block these inputs are on.
+   * @param currInput The current input.
+   * @param prevInput The previous input.
+   * @returns True if the current input is the start of a row.
+   */
+  protected isStartOfRow(
+    block: BlockSvg,
+    currInput: Input,
+    prevInput?: Input,
+  ): boolean {
+    // First input is always the start of a row
+    if (!prevInput) {
+      return true;
+    }
+    // If the previous input was an end-row input, then any following input
+    // should always be rendered on the next row.
+    if (prevInput instanceof EndRowInput) {
+      return true;
+    }
+    // A statement input or an input following one always gets a new row.
+    if (
+      currInput instanceof StatementInput ||
+      prevInput instanceof StatementInput
+    ) {
+      return true;
+    }
+    // Value inputs, dummy inputs, and any input following an external value
+    // input get a new row if inputs are not inlined.
+    if (
+      currInput instanceof ValueInput ||
+      currInput instanceof DummyInput ||
+      prevInput instanceof ValueInput
+    ) {
+      return !block.getInputsInline();
+    }
+    return false;
   }
 }

--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -77,15 +77,10 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
     let siblings: (BlockSvg | Field)[] = [];
     if (parent instanceof BlockSvg) {
       for (let i = 0, input; (input = parent.inputList[i]); i++) {
-        if (
-          i == 0 ||
-          this.isStartOfRow(parent, input, parent.inputList[i - 1])
-        ) {
-          siblings.push(...input.fieldRow);
-          const child = input.connection?.targetBlock();
-          if (child) {
-            siblings.push(child as BlockSvg);
-          }
+        siblings.push(...input.fieldRow);
+        const child = input.connection?.targetBlock();
+        if (child) {
+          siblings.push(child as BlockSvg);
         }
       }
     } else if (parent instanceof WorkspaceSvg) {
@@ -124,12 +119,10 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
     let siblings: (BlockSvg | Field)[] = [];
     if (parent instanceof BlockSvg) {
       for (let i = 0, input; (input = parent.inputList[i]); i++) {
-        if (input.connection) {
-          siblings.push(...input.fieldRow);
-          const child = input.connection.targetBlock();
-          if (child) {
-            siblings.push(child as BlockSvg);
-          }
+        siblings.push(...input.fieldRow);
+        const child = input.connection?.targetBlock();
+        if (child) {
+          siblings.push(child as BlockSvg);
         }
       }
     } else if (parent instanceof WorkspaceSvg) {
@@ -174,47 +167,5 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
    */
   isApplicable(current: any): current is BlockSvg {
     return current instanceof BlockSvg;
-  }
-
-  /**
-   * Checks whether an input is the first input on a row. This code is mostly
-   * identical to RenderInfo.
-   *
-   * @param block The block these inputs are on.
-   * @param currInput The current input.
-   * @param prevInput The previous input.
-   * @returns True if the current input is the start of a row.
-   */
-  protected isStartOfRow(
-    block: BlockSvg,
-    currInput: Input,
-    prevInput?: Input,
-  ): boolean {
-    // First input is always the start of a row
-    if (!prevInput) {
-      return true;
-    }
-    // If the previous input was an end-row input, then any following input
-    // should always be rendered on the next row.
-    if (prevInput instanceof EndRowInput) {
-      return true;
-    }
-    // A statement input or an input following one always gets a new row.
-    if (
-      currInput instanceof StatementInput ||
-      prevInput instanceof StatementInput
-    ) {
-      return true;
-    }
-    // Value inputs, dummy inputs, and any input following an external value
-    // input get a new row if inputs are not inlined.
-    if (
-      currInput instanceof ValueInput ||
-      currInput instanceof DummyInput ||
-      prevInput instanceof ValueInput
-    ) {
-      return !block.getInputsInline();
-    }
-    return false;
   }
 }

--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -6,13 +6,6 @@
 
 import {BlockSvg} from '../block_svg.js';
 import type {Field} from '../field.js';
-import {
-  DummyInput,
-  EndRowInput,
-  Input,
-  StatementInput,
-  ValueInput,
-} from '../inputs.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
@@ -64,7 +57,7 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
    * Returns the next peer node of the given block.
    *
    * @param current The block to find the following element of.
-   * @returns The first block of the next stack if the given block is a terminal
+   * @returns The first node of the next input/stack if the given block is a terminal
    *     block, or its next connection.
    */
   getNextSibling(current: BlockSvg): IFocusableNode | null {

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -283,6 +283,63 @@ suite('Navigation', function () {
           'tooltip': '',
           'helpUrl': '',
         },
+        {
+          'type': 'buttons',
+          'tooltip': '',
+          'helpUrl': '',
+          'message0': 'If %1 %2 Then %3 %4 more %5 %6 %7',
+          'args0': [
+            {
+              'type': 'field_image',
+              'name': 'BUTTON1',
+              'src': 'https://www.gstatic.com/codesite/ph/images/star_on.gif',
+              'width': 30,
+              'height': 30,
+              'alt': '*',
+            },
+            {
+              'type': 'input_value',
+              'name': 'VALUE1',
+              'check': '',
+            },
+            {
+              'type': 'field_image',
+              'name': 'BUTTON2',
+              'src': 'https://www.gstatic.com/codesite/ph/images/star_on.gif',
+              'width': 30,
+              'height': 30,
+              'alt': '*',
+            },
+            {
+              'type': 'input_dummy',
+              'name': 'DUMMY1',
+              'check': '',
+            },
+            {
+              'type': 'input_value',
+              'name': 'VALUE2',
+              'check': '',
+            },
+            {
+              'type': 'input_statement',
+              'name': 'STATEMENT1',
+              'check': 'Number',
+            },
+            {
+              'type': 'field_image',
+              'name': 'BUTTON3',
+              'src': 'https://www.gstatic.com/codesite/ph/images/star_on.gif',
+              'width': 30,
+              'height': 30,
+              'alt': '*',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+          'colour': 230,
+          'tooltip': '',
+          'helpUrl': '',
+        },
       ]);
       const noNextConnection = this.workspace.newBlock('top_connection');
       const fieldAndInputs = this.workspace.newBlock('fields_and_input');
@@ -313,6 +370,27 @@ suite('Navigation', function () {
       const outputNextBlock = this.workspace.newBlock('output_next');
       this.blocks.secondBlock = secondBlock;
       this.blocks.outputNextBlock = outputNextBlock;
+
+      const buttonBlock = this.workspace.newBlock('buttons');
+      const buttonInput1 = this.workspace.newBlock('field_input');
+      const buttonInput2 = this.workspace.newBlock('field_input');
+      buttonBlock.inputList[0].connection.connect(
+        buttonInput1.outputConnection,
+      );
+      buttonBlock.inputList[2].connection.connect(
+        buttonInput2.outputConnection,
+      );
+      // Make buttons by adding a click handler
+      const clickHandler = function () {
+        return;
+      };
+      buttonBlock.getField('BUTTON1').setOnClickHandler(clickHandler);
+      buttonBlock.getField('BUTTON2').setOnClickHandler(clickHandler);
+      buttonBlock.getField('BUTTON3').setOnClickHandler(clickHandler);
+      this.blocks.buttonBlock = buttonBlock;
+      this.blocks.buttonInput1 = buttonInput1;
+      this.blocks.buttonInput2 = buttonInput2;
+
       this.workspace.cleanUp();
     });
     suite('Next', function () {
@@ -427,6 +505,20 @@ suite('Navigation', function () {
         const nextNode = this.navigator.getNextSibling(icons[0]);
         assert.isNull(nextNode);
       });
+      test('fromBlockToFieldInNextInput', function () {
+        const field = this.blocks.buttonBlock.getField('BUTTON2');
+        const prevNode = this.navigator.getNextSibling(
+          this.blocks.buttonInput1,
+        );
+        assert.equal(prevNode, field);
+      });
+      test('fromBlockToFieldSkippingInput', function () {
+        const field = this.blocks.buttonBlock.getField('BUTTON3');
+        const prevNode = this.navigator.getNextSibling(
+          this.blocks.buttonInput2,
+        );
+        assert.equal(prevNode, field);
+      });
     });
 
     suite('Previous', function () {
@@ -540,6 +632,20 @@ suite('Navigation', function () {
         const icons = this.blocks.dummyInput.getIcons();
         const prevNode = this.navigator.getPreviousSibling(icons[0]);
         assert.isNull(prevNode);
+      });
+      test('fromBlockToFieldInSameInput', function () {
+        const field = this.blocks.buttonBlock.getField('BUTTON1');
+        const prevNode = this.navigator.getPreviousSibling(
+          this.blocks.buttonInput1,
+        );
+        assert.equal(prevNode, field);
+      });
+      test('fromBlockToFieldInPrevInput', function () {
+        const field = this.blocks.buttonBlock.getField('BUTTON2');
+        const prevNode = this.navigator.getPreviousSibling(
+          this.blocks.buttonInput2,
+        );
+        assert.equal(prevNode, field);
       });
     });
 

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -285,8 +285,6 @@ suite('Navigation', function () {
         },
         {
           'type': 'buttons',
-          'tooltip': '',
-          'helpUrl': '',
           'message0': 'If %1 %2 Then %3 %4 more %5 %6 %7',
           'args0': [
             {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Previously you couldn't go from a block connected to a value input to a field on another input. Now you can:
[Screen recording 2025-05-21 3.05.51 PM.webm](https://github.com/user-attachments/assets/e5f2ef09-3cc0-4049-ae43-8a5863c85aad)

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
