### PR TITLE
fix: Fix bug that prevented using keyboard shortcuts when the DropDownDiv is open.

### DIFF
--- a/core/common.ts
+++ b/core/common.ts
@@ -319,8 +319,6 @@ export function defineBlocks(blocks: {[key: string]: BlockDefinition}) {
  * @internal
  * @param e Key down event.
  */
-// TODO (https://github.com/google/blockly/issues/1998) handle cases where there
-// are multiple workspaces and non-main workspaces are able to accept input.
 export function globalShortcutHandler(e: KeyboardEvent) {
   const mainWorkspace = getMainWorkspace() as WorkspaceSvg;
   if (!mainWorkspace) {

--- a/core/dropdowndiv.ts
+++ b/core/dropdowndiv.ts
@@ -13,6 +13,7 @@
 // Former goog.module ID: Blockly.dropDownDiv
 
 import type {BlockSvg} from './block_svg.js';
+import * as browserEvents from './browser_events.js';
 import * as common from './common.js';
 import type {Field} from './field.js';
 import {ReturnEphemeralFocus, getFocusManager} from './focus_manager.js';
@@ -86,6 +87,9 @@ let positionToField: boolean | null = null;
 /** Callback to FocusManager to return ephemeral focus when the div closes. */
 let returnEphemeralFocus: ReturnEphemeralFocus | null = null;
 
+/** Identifier for shortcut keydown listener used to unbind it. */
+let keydownListener: browserEvents.Data | null = null;
+
 /**
  * Dropdown bounds info object used to encapsulate sizing information about a
  * bounding element (bounding box and width/height).
@@ -129,6 +133,13 @@ export function createDom() {
   content.className = 'blocklyDropDownContent';
   div.appendChild(content);
 
+  keydownListener = browserEvents.conditionalBind(
+    content,
+    'keydown',
+    null,
+    common.globalShortcutHandler,
+  );
+
   arrow = document.createElement('div');
   arrow.className = 'blocklyDropDownArrow';
   div.appendChild(arrow);
@@ -167,6 +178,10 @@ export function getContentDiv(): HTMLDivElement {
 
 /** Clear the content of the drop-down. */
 export function clearContent() {
+  if (keydownListener) {
+    browserEvents.unbind(keydownListener);
+    keydownListener = null;
+  }
   div.remove();
   createDom();
 }

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -15,7 +15,6 @@ import * as dropDownDiv from './dropdowndiv.js';
 import {Grid} from './grid.js';
 import {Options} from './options.js';
 import {ScrollbarPair} from './scrollbar_pair.js';
-import {ShortcutRegistry} from './shortcut_registry.js';
 import * as Tooltip from './tooltip.js';
 import * as Touch from './touch.js';
 import * as dom from './utils/dom.js';
@@ -72,17 +71,12 @@ export function inject(
     common.setMainWorkspace(workspace);
   });
 
-  browserEvents.conditionalBind(subContainer, 'keydown', null, onKeyDown);
   browserEvents.conditionalBind(
-    dropDownDiv.getContentDiv(),
+    subContainer,
     'keydown',
     null,
-    onKeyDown,
+    common.globalShortcutHandler,
   );
-  const widgetContainer = WidgetDiv.getDiv();
-  if (widgetContainer) {
-    browserEvents.conditionalBind(widgetContainer, 'keydown', null, onKeyDown);
-  }
 
   return workspace;
 }
@@ -290,32 +284,6 @@ function init(mainWorkspace: WorkspaceSvg) {
   if (options.hasSounds) {
     loadSounds(options.pathToMedia, mainWorkspace);
   }
-}
-
-/**
- * Handle a key-down on SVG drawing surface. Does nothing if the main workspace
- * is not visible.
- *
- * @param e Key down event.
- */
-// TODO (https://github.com/google/blockly/issues/1998) handle cases where there
-// are multiple workspaces and non-main workspaces are able to accept input.
-function onKeyDown(e: KeyboardEvent) {
-  const mainWorkspace = common.getMainWorkspace() as WorkspaceSvg;
-  if (!mainWorkspace) {
-    return;
-  }
-
-  if (
-    browserEvents.isTargetInput(e) ||
-    (mainWorkspace.rendered && !mainWorkspace.isVisible())
-  ) {
-    // When focused on an HTML text input widget, don't trap any keys.
-    // Ignore keypresses on rendered workspaces that have been explicitly
-    // hidden.
-    return;
-  }
-  ShortcutRegistry.registry.onKeyDown(mainWorkspace, e);
 }
 
 /**

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -67,13 +67,13 @@ export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
 export function createDom() {
   const container = common.getParentContainer() || document.body;
 
-  if (document.querySelector('.' + containerClassName)) {
-    containerDiv = document.querySelector('.' + containerClassName);
+  const existingContainer = document.querySelector('div.' + containerClassName);
+  if (existingContainer) {
+    containerDiv = existingContainer as HTMLDivElement;
   } else {
     containerDiv = document.createElement('div');
     containerDiv.className = containerClassName;
   }
-  if (!containerDiv) return;
 
   browserEvents.conditionalBind(
     containerDiv,

--- a/core/widgetdiv.ts
+++ b/core/widgetdiv.ts
@@ -6,6 +6,7 @@
 
 // Former goog.module ID: Blockly.WidgetDiv
 
+import * as browserEvents from './browser_events.js';
 import * as common from './common.js';
 import {Field} from './field.js';
 import {ReturnEphemeralFocus, getFocusManager} from './focus_manager.js';
@@ -69,11 +70,19 @@ export function createDom() {
   if (document.querySelector('.' + containerClassName)) {
     containerDiv = document.querySelector('.' + containerClassName);
   } else {
-    containerDiv = document.createElement('div') as HTMLDivElement;
+    containerDiv = document.createElement('div');
     containerDiv.className = containerClassName;
   }
+  if (!containerDiv) return;
 
-  container.appendChild(containerDiv!);
+  browserEvents.conditionalBind(
+    containerDiv,
+    'keydown',
+    null,
+    common.globalShortcutHandler,
+  );
+
+  container.appendChild(containerDiv);
 }
 
 /**

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -170,7 +170,7 @@ suite('DropDownDiv', function () {
       assert.isTrue(hidden);
     });
   });
-  
+
   suite('show()', function () {
     test('without bounds set throws error', function () {
       const block = this.setUpBlockWithField();

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -138,7 +138,6 @@ suite('DropDownDiv', function () {
 
   suite('Keyboard Shortcuts', function () {
     setup(function () {
-      sharedTestSetup.call(this);
       this.boundsStub = sinon
         .stub(Blockly.DropDownDiv.TEST_ONLY, 'getBoundsInfo')
         .returns({
@@ -152,7 +151,6 @@ suite('DropDownDiv', function () {
       this.workspace = Blockly.inject('blocklyDiv', {});
     });
     teardown(function () {
-      sharedTestTeardown.call(this);
       this.boundsStub.restore();
     });
     test('Escape dismisses DropDownDiv', function () {

--- a/tests/mocha/dropdowndiv_test.js
+++ b/tests/mocha/dropdowndiv_test.js
@@ -113,4 +113,39 @@ suite('DropDownDiv', function () {
       assert.isNotOk(metrics.arrowAtTop);
     });
   });
+
+  suite('Keyboard Shortcuts', function () {
+    setup(function () {
+      sharedTestSetup.call(this);
+      this.boundsStub = sinon
+        .stub(Blockly.DropDownDiv.TEST_ONLY, 'getBoundsInfo')
+        .returns({
+          left: 0,
+          right: 100,
+          top: 0,
+          bottom: 100,
+          width: 100,
+          height: 100,
+        });
+      this.workspace = Blockly.inject('blocklyDiv', {});
+    });
+    teardown(function () {
+      sharedTestTeardown.call(this);
+      this.boundsStub.restore();
+    });
+    test('Escape dismisses DropDownDiv', function () {
+      let hidden = false;
+      Blockly.DropDownDiv.show(this, false, 0, 0, 0, 0, false, () => {
+        hidden = true;
+      });
+      assert.isFalse(hidden);
+      Blockly.DropDownDiv.getContentDiv().dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          keyCode: 27, // example values.
+        }),
+      );
+      assert.isTrue(hidden);
+    });
+  });
 });

--- a/tests/mocha/widget_div_test.js
+++ b/tests/mocha/widget_div_test.js
@@ -13,6 +13,7 @@ import {
 suite('WidgetDiv', function () {
   setup(function () {
     sharedTestSetup.call(this);
+    this.workspace = Blockly.inject('blocklyDiv', {});
   });
   teardown(function () {
     sharedTestTeardown.call(this);
@@ -267,6 +268,28 @@ suite('WidgetDiv', function () {
           this.widgetSize.height,
         );
       });
+    });
+  });
+  suite('Keyboard Shortcuts', function () {
+    test('Escape dismisses WidgetDiv', function () {
+      let hidden = false;
+      Blockly.WidgetDiv.show(
+        this,
+        false,
+        () => {
+          hidden = true;
+        },
+        this.workspace,
+        false,
+      );
+      assert.isFalse(hidden);
+      Blockly.WidgetDiv.getDiv().dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          keyCode: 27, // example values.
+        }),
+      );
+      assert.isTrue(hidden);
     });
   });
 });


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/522

### Proposed Changes
This PR moves the attachment of the global keyboard shortcut handler to the `DropDownDiv` and `WidgetDiv` into those respective modules, rather than adding the listener in `inject()`. This reduces spooky action at a distance, and fixes a bug caused by a change to the `DropDownDiv` to make it recreate its div between showings in order to guarantee that its state is fully reset. Because the key handler was attached elsewhere, this being unsafe wasn't noticed. Now, the listener is added every time the div is created, and the logic to attach it has been moved into the relevant modules themselves to hopefully avoid being overlooked in a similar manner in the future.