### PR TITLE
fix: Tweak outline CSS for Safari/Firefox

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -505,6 +505,6 @@ input[type=number] {
   .blocklyIconGroup,
   .blocklyTextarea
 ) {
-  outline-width: 0px;
+  outline: none;
 }
 `;


### PR DESCRIPTION
Without this Safari (desktop) gets an outline still which tears as you drag.

In the keyboard nav demo an outline was visible before this change in both Firefox and Safari.

Fixes #9099

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9099 

### Proposed Changes

Tweak CSS to version that works cross browser.

### Reason for Changes

See issue for screenshots showing unwanted outlines. They're gone with the change.

### Test Coverage

CSS-only change.

### Documentation

CSS-only change.

### Additional Information

