### PR TITLE
refactor(shortcuts): Factor copy-eligibility out of cut/copy `preconditionFn`

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -112,6 +112,12 @@ let copyCoords: Coordinate | null = null;
  * - Additionally, both .isMovable() and .isDeletable() must return
  *   true (i.e., can currently be moved and deleted).
  *
+ * TODO(#9098): Revise these criteria.  The latter criteria prevents
+ * shadow blocks from being copied; additionally, there are likely to
+ * be other circumstances were it is desirable to allow movable /
+ * copyable copies of a currently-unmovable / -copyable block to be
+ * made.
+ *
  * @param focused The focused object.
  */
 function isCopyable(

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -10,8 +10,8 @@ import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
 import * as eventUtils from './events/utils.js';
 import {Gesture} from './gesture.js';
-import {ICopyData, isCopyable} from './interfaces/i_copyable.js';
-import {isDeletable} from './interfaces/i_deletable.js';
+import {ICopyData, isCopyable as isICopyable} from './interfaces/i_copyable.js';
+import {isDeletable as isIDeletable} from './interfaces/i_deletable.js';
 import {isDraggable} from './interfaces/i_draggable.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import {Coordinate} from './utils/coordinate.js';
@@ -61,7 +61,7 @@ export function registerDelete() {
       return (
         !workspace.isReadOnly() &&
         focused != null &&
-        isDeletable(focused) &&
+        isIDeletable(focused) &&
         focused.isDeletable() &&
         !Gesture.inProgress()
       );
@@ -75,7 +75,7 @@ export function registerDelete() {
       const focused = scope.focusedNode;
       if (focused instanceof BlockSvg) {
         focused.checkAndDelete();
-      } else if (isDeletable(focused) && focused.isDeletable()) {
+      } else if (isIDeletable(focused) && focused.isDeletable()) {
         eventUtils.setGroup(true);
         focused.dispose();
         eventUtils.setGroup(false);
@@ -114,7 +114,7 @@ export function registerCopy() {
         focused.isDeletable() &&
         isDraggable(focused) &&
         focused.isMovable() &&
-        isCopyable(focused)
+        isICopyable(focused)
       );
     },
     callback(workspace, e, shortcut, scope) {
@@ -123,7 +123,7 @@ export function registerCopy() {
       e.preventDefault();
       workspace.hideChaff();
       const focused = scope.focusedNode;
-      if (!focused || !isCopyable(focused)) return false;
+      if (!focused || !isICopyable(focused)) return false;
       copyData = focused.toCopyData();
       copyWorkspace =
         focused.workspace instanceof WorkspaceSvg
@@ -162,7 +162,7 @@ export function registerCut() {
         focused.isDeletable() &&
         isDraggable(focused) &&
         focused.isMovable() &&
-        isCopyable(focused) &&
+        isICopyable(focused) &&
         !focused.workspace.isFlyout
       );
     },
@@ -176,9 +176,9 @@ export function registerCut() {
         focused.checkAndDelete();
         return true;
       } else if (
-        isDeletable(focused) &&
+        isIDeletable(focused) &&
         focused.isDeletable() &&
-        isCopyable(focused)
+        isICopyable(focused)
       ) {
         copyData = focused.toCopyData();
         copyWorkspace = workspace;


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

* Factor out copy elegibility criteria from cut and copy shortcut `preconditionFn`s into new `isCopyable` function.
* Rename imports of `isCopyable` and `isDeletable` type predicates to `isICopyable` and `isIDeletable`.

### Reason for Changes

I had made these changes locally while working on #9084, and although we do not intend fix that bug in core in the immediate future I think these small refactors are worth keeping:

* Readability: by making it clearer which functions are type predicates it is easier to understand the logic of the preconditions.
* Consistency: by factoring copy elegibility testing into a shared function the cut and copy preconditions should be less likely to get out of sync.
* Future flexiblity: `isCopyable` becomes the locus for future changes to copy elegibility.

### Test Coverage

Passes `npm test`.

