### PR TITLE
feat: Allow visiting empty input connections.

### DIFF
--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -5,6 +5,7 @@
  */
 
 import {BlockSvg} from '../block_svg.js';
+import {ConnectionType} from '../connection_type.js';
 import type {Field} from '../field.js';
 import type {Icon} from '../icons/icon.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';

--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -108,7 +108,7 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
 /**
  * Returns a list of the navigable children of the given block.
  *
- * @param The block to retrieve the navigable children of.
+ * @param block The block to retrieve the navigable children of.
  * @returns A list of navigable/focusable children of the given block.
  */
 function getBlockNavigationCandidates(block: BlockSvg): IFocusableNode[] {

--- a/core/keyboard_nav/block_navigation_policy.ts
+++ b/core/keyboard_nav/block_navigation_policy.ts
@@ -5,7 +5,6 @@
  */
 
 import {BlockSvg} from '../block_svg.js';
-import {ConnectionType} from '../connection_type.js';
 import type {Field} from '../field.js';
 import type {Icon} from '../icons/icon.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
@@ -105,6 +104,12 @@ export class BlockNavigationPolicy implements INavigationPolicy<BlockSvg> {
   }
 }
 
+/**
+ * Returns a list of the navigable children of the given block.
+ *
+ * @param The block to retrieve the navigable children of.
+ * @returns A list of navigable/focusable children of the given block.
+ */
 function getBlockNavigationCandidates(block: BlockSvg): IFocusableNode[] {
   const candidates: IFocusableNode[] = block.getIcons();
 
@@ -121,6 +126,17 @@ function getBlockNavigationCandidates(block: BlockSvg): IFocusableNode[] {
   return candidates;
 }
 
+/**
+ * Returns the next/previous stack relative to the given block's stack.
+ *
+ * @param current The block whose stack will be navigated relative to.
+ * @param delta The difference in index to navigate; positive values navigate
+ *     to the nth next stack, while negative values navigate to the nth previous
+ *     stack.
+ * @returns The first block in the stack offset by `delta` relative to the
+ *     current block's stack, or the last block in the stack offset by `delta`
+ *     relative to the current block's stack when navigating backwards.
+ */
 export function navigateStacks(current: BlockSvg, delta: number) {
   const stacks = current.workspace.getTopBlocks(true);
   const currentIndex = stacks.indexOf(current.getRootBlock());
@@ -143,6 +159,14 @@ export function navigateStacks(current: BlockSvg, delta: number) {
   return result;
 }
 
+/**
+ * Returns the next navigable item relative to the provided block child.
+ *
+ * @param current The navigable block child item to navigate relative to.
+ * @param delta The difference in index to navigate; positive values navigate
+ *     forward by n, while negative values navigate backwards by n.
+ * @returns The navigable block child offset by `delta` relative to `current`.
+ */
 export function navigateBlock(
   current: Icon | Field | RenderedConnection | BlockSvg,
   delta: number,

--- a/core/keyboard_nav/field_navigation_policy.ts
+++ b/core/keyboard_nav/field_navigation_policy.ts
@@ -8,6 +8,7 @@ import type {BlockSvg} from '../block_svg.js';
 import {Field} from '../field.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
+import {navigateBlock} from './block_navigation_policy.js';
 
 /**
  * Set of rules controlling keyboard navigation from a field.
@@ -40,24 +41,7 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
    * @returns The next field or input in the given field's block.
    */
   getNextSibling(current: Field<any>): IFocusableNode | null {
-    const input = current.getParentInput();
-    const block = current.getSourceBlock();
-    if (!block) return null;
-
-    const curIdx = block.inputList.indexOf(input);
-    let fieldIdx = input.fieldRow.indexOf(current) + 1;
-    for (let i = curIdx; i < block.inputList.length; i++) {
-      const newInput = block.inputList[i];
-      if (newInput.isVisible()) {
-        const fieldRow = newInput.fieldRow;
-        if (fieldIdx < fieldRow.length) return fieldRow[fieldIdx];
-        if (newInput.connection?.targetBlock()) {
-          return newInput.connection.targetBlock() as BlockSvg;
-        }
-      }
-      fieldIdx = 0;
-    }
-    return null;
+    return navigateBlock(current, 1);
   }
 
   /**
@@ -67,29 +51,7 @@ export class FieldNavigationPolicy implements INavigationPolicy<Field<any>> {
    * @returns The preceding field or input in the given field's block.
    */
   getPreviousSibling(current: Field<any>): IFocusableNode | null {
-    const parentInput = current.getParentInput();
-    const block = current.getSourceBlock();
-    if (!block) return null;
-
-    const curIdx = block.inputList.indexOf(parentInput);
-    let fieldIdx = parentInput.fieldRow.indexOf(current) - 1;
-    for (let i = curIdx; i >= 0; i--) {
-      const input = block.inputList[i];
-      if (input.isVisible()) {
-        if (input.connection?.targetBlock() && input !== parentInput) {
-          return input.connection.targetBlock() as BlockSvg;
-        }
-        const fieldRow = input.fieldRow;
-        if (fieldIdx > -1) return fieldRow[fieldIdx];
-      }
-      // Reset the fieldIdx to the length of the field row of the previous
-      // input.
-      if (i - 1 >= 0) {
-        fieldIdx = block.inputList[i - 1].fieldRow.length - 1;
-      }
-    }
-
-    return block.getIcons().pop() ?? null;
+    return navigateBlock(current, -1);
   }
 
   /**

--- a/core/keyboard_nav/icon_navigation_policy.ts
+++ b/core/keyboard_nav/icon_navigation_policy.ts
@@ -8,6 +8,7 @@ import {BlockSvg} from '../block_svg.js';
 import {Icon} from '../icons/icon.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import type {INavigationPolicy} from '../interfaces/i_navigation_policy.js';
+import {navigateBlock} from './block_navigation_policy.js';
 
 /**
  * Set of rules controlling keyboard navigation from an icon.
@@ -40,21 +41,7 @@ export class IconNavigationPolicy implements INavigationPolicy<Icon> {
    * @returns The next icon, field or input following this icon, if any.
    */
   getNextSibling(current: Icon): IFocusableNode | null {
-    const block = current.getSourceBlock() as BlockSvg;
-    const icons = block.getIcons();
-    const currentIndex = icons.indexOf(current);
-    if (currentIndex >= 0 && currentIndex + 1 < icons.length) {
-      return icons[currentIndex + 1];
-    }
-
-    for (const input of block.inputList) {
-      if (input.fieldRow.length) return input.fieldRow[0];
-
-      if (input.connection?.targetBlock())
-        return input.connection.targetBlock() as BlockSvg;
-    }
-
-    return null;
+    return navigateBlock(current, 1);
   }
 
   /**
@@ -64,14 +51,7 @@ export class IconNavigationPolicy implements INavigationPolicy<Icon> {
    * @returns The icon's previous icon, if any.
    */
   getPreviousSibling(current: Icon): IFocusableNode | null {
-    const block = current.getSourceBlock() as BlockSvg;
-    const icons = block.getIcons();
-    const currentIndex = icons.indexOf(current);
-    if (currentIndex >= 1) {
-      return icons[currentIndex - 1];
-    }
-
-    return null;
+    return navigateBlock(current, -1);
   }
 
   /**

--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -246,7 +246,7 @@ suite('Cursor', function () {
       });
       test('getLastNode', function () {
         const node = this.cursor.getLastNode();
-        assert.equal(node, this.blockA);
+        assert.equal(node, this.blockA.inputList[0].connection);
       });
     });
     suite('one c-hat block', function () {
@@ -340,7 +340,7 @@ suite('Cursor', function () {
       test('getLastNode', function () {
         const node = this.cursor.getLastNode();
         const blockB = this.workspace.getBlockById('B');
-        assert.equal(node, blockB);
+        assert.equal(node, blockB.inputList[0].connection);
       });
     });
 

--- a/tests/mocha/navigation_test.js
+++ b/tests/mocha/navigation_test.js
@@ -834,10 +834,10 @@ suite('Navigation', function () {
         const outNode = this.navigator.getParent(next);
         assert.equal(outNode, this.blocks.secondBlock);
       });
-      // /**
-      //  * This is where there is a block with both an output connection and a
-      //  * next connection attached to an input.
-      //  */
+      /**
+       * This is where there is a block with both an output connection and a
+       * next connection attached to an input.
+       */
       test('fromNextToBlock_OutputAndPreviousConnection', function () {
         const next = this.blocks.outputNextBlock.nextConnection;
         const outNode = this.navigator.getParent(next);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9075

### Proposed Changes
This PR updates the navigation policies to visit empty input/value connections when using keyboard navigation.