### PR TITLE
fix: Copy shortcuts before returning them.

### DIFF
--- a/core/shortcut_registry.ts
+++ b/core/shortcut_registry.ts
@@ -278,7 +278,9 @@ export class ShortcutRegistry {
    *     Undefined if no shortcuts exist.
    */
   getShortcutNamesByKeyCode(keyCode: string): string[] | undefined {
-    return this.keyMap.get(keyCode) || [];
+    // Copy the list of shortcuts in case one of them unregisters itself
+    // in its callback.
+    return this.keyMap.get(keyCode)?.slice() || [];
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR copies the list of keyboard shortcut names returned by `getShortcutNamesByKeyCode()`. This works around an issue where, if a keyboard shortcut de-registered itself in its callback, other shortcuts with the same key combo might not be run, because the shortcut registry was iterating this list of shortcut names by reference, and de-registering a shortcut mutates it while it is being iterated by the registry.