### PR TITLE
fix: Fix bug that caused the focus manager to attempt to focus unfocusable elements.

### DIFF
--- a/core/layer_manager.ts
+++ b/core/layer_manager.ts
@@ -104,9 +104,11 @@ export class LayerManager {
   moveToDragLayer(elem: IRenderedElement & IFocusableNode) {
     this.dragLayer?.appendChild(elem.getSvgRoot());
 
-    // Since moving the element to the drag layer will cause it to lose focus,
-    // ensure it regains focus (to ensure proper highlights & sent events).
-    getFocusManager().focusNode(elem);
+    if (elem.canBeFocused()) {
+      // Since moving the element to the drag layer will cause it to lose focus,
+      // ensure it regains focus (to ensure proper highlights & sent events).
+      getFocusManager().focusNode(elem);
+    }
   }
 
   /**
@@ -117,9 +119,11 @@ export class LayerManager {
   moveOffDragLayer(elem: IRenderedElement & IFocusableNode, layerNum: number) {
     this.append(elem, layerNum);
 
-    // Since moving the element off the drag layer will cause it to lose focus,
-    // ensure it regains focus (to ensure proper highlights & sent events).
-    getFocusManager().focusNode(elem);
+    if (elem.canBeFocused()) {
+      // Since moving the element off the drag layer will cause it to lose focus,
+      // ensure it regains focus (to ensure proper highlights & sent events).
+      getFocusManager().focusNode(elem);
+    }
   }
 
   /**


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/554

### Proposed Changes
This PR updates the layer manager to check if elements are focusable before focusing them after adding/removing them from the drag layer. This resolves logspam.