### PR TITLE
fix: Add isCopyable to the ICopyable interface and use it

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -791,6 +791,7 @@ export class Block {
   isDeletable(): boolean {
     return (
       this.deletable &&
+      !this.isInFlyout &&
       !this.shadow &&
       !this.isDeadOrDying() &&
       !this.workspace.isReadOnly()
@@ -824,6 +825,7 @@ export class Block {
   isMovable(): boolean {
     return (
       this.movable &&
+      !this.isInFlyout &&
       !this.shadow &&
       !this.isDeadOrDying() &&
       !this.workspace.isReadOnly()

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1726,11 +1726,6 @@ export class BlockSvg
     return this.isOwnDeletable() && this.isOwnMovable();
   }
 
-  /** Returns whether this block is cuttable or not. */
-  isCuttable(): boolean {
-    return this.isDeletable() && this.isMovable();
-  }
-
   /** Returns whether this block is movable or not. */
   override isMovable(): boolean {
     return this.dragStrategy.isMovable();

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1721,6 +1721,16 @@ export class BlockSvg
     this.dragStrategy = dragStrategy;
   }
 
+  /** Returns whether this block is copyable or not. */
+  isCopyable(): boolean {
+    return this.isOwnDeletable() && this.isOwnMovable();
+  }
+
+  /** Returns whether this block is cuttable or not. */
+  isCuttable(): boolean {
+    return this.isDeletable() && this.isMovable();
+  }
+
   /** Returns whether this block is movable or not. */
   override isMovable(): boolean {
     return this.dragStrategy.isMovable();

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -249,11 +249,6 @@ export class RenderedWorkspaceComment
     return this.isOwnMovable() && this.isOwnDeletable();
   }
 
-  /** Returns whether this comment is cuttable or not */
-  isCuttable(): boolean {
-    return this.isMovable() && this.isDeletable();
-  }
-
   /** Returns whether this comment is movable or not. */
   isMovable(): boolean {
     return this.dragStrategy.isMovable();

--- a/core/comments/rendered_workspace_comment.ts
+++ b/core/comments/rendered_workspace_comment.ts
@@ -244,6 +244,16 @@ export class RenderedWorkspaceComment
     }
   }
 
+  /** Returns whether this comment is copyable or not */
+  isCopyable(): boolean {
+    return this.isOwnMovable() && this.isOwnDeletable();
+  }
+
+  /** Returns whether this comment is cuttable or not */
+  isCuttable(): boolean {
+    return this.isMovable() && this.isDeletable();
+  }
+
   /** Returns whether this comment is movable or not. */
   isMovable(): boolean {
     return this.dragStrategy.isMovable();

--- a/core/comments/workspace_comment.ts
+++ b/core/comments/workspace_comment.ts
@@ -165,7 +165,11 @@ export class WorkspaceComment {
    * workspace is read-only.
    */
   isMovable() {
-    return this.isOwnMovable() && !this.workspace.isReadOnly();
+    return (
+      this.isOwnMovable() &&
+      !this.workspace.isReadOnly() &&
+      !this.workspace.isFlyout
+    );
   }
 
   /**
@@ -189,7 +193,8 @@ export class WorkspaceComment {
     return (
       this.isOwnDeletable() &&
       !this.isDeadOrDying() &&
-      !this.workspace.isReadOnly()
+      !this.workspace.isReadOnly() &&
+      !this.workspace.isFlyout
     );
   }
 

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -22,13 +22,6 @@ export interface ICopyable<T extends ICopyData> extends ISelectable {
    * @returns True if it can currently be copied.
    */
   isCopyable?(): boolean;
-
-  /**
-   * Whether this instance is currently cuttable.
-   *
-   * @returns True if it can currently be cut.
-   */
-  isCuttable?(): boolean;
 }
 
 export namespace ICopyable {

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -17,7 +17,8 @@ export interface ICopyable<T extends ICopyData> extends ISelectable {
   toCopyData(): T | null;
 
   /**
-   * Whether this instance is currently copyable.
+   * Whether this instance is currently copyable. The standard implementation
+   * is to return true if isOwnDeletable and isOwnMovable return true.
    *
    * @returns True if it can currently be copied.
    */

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -15,6 +15,20 @@ export interface ICopyable<T extends ICopyData> extends ISelectable {
    * @returns Copy metadata.
    */
   toCopyData(): T | null;
+
+  /**
+   * Whether this instance is currently copyable.
+   *
+   * @returns True if it can currently be copied.
+   */
+  isCopyable?(): boolean;
+
+  /**
+   * Whether this instance is currently cuttable.
+   *
+   * @returns True if it can currently be cut.
+   */
+  isCuttable?(): boolean;
 }
 
 export namespace ICopyable {
@@ -25,7 +39,7 @@ export namespace ICopyable {
 
 export type ICopyData = ICopyable.ICopyData;
 
-/** @returns true if the given object is copyable. */
+/** @returns true if the given object is an ICopyable. */
 export function isCopyable(obj: any): obj is ICopyable<ICopyData> {
   return obj.toCopyData !== undefined;
 }

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -125,19 +125,13 @@ function isCopyable(focused: IFocusableNode): boolean {
 /**
  * Determine if a focusable node can be cut.
  *
- * This will use the isCuttable method if the node implements it, otherwise
- * it will fall back to checking if the node can be moved and deleted in its
- * current workspace.
+ * This will check if the node can be both copied and deleted in its current
+ * workspace.
  *
  * @param focused The focused object.
  */
 function isCuttable(focused: IFocusableNode): boolean {
-  if (!isICopyable(focused) || !isIDeletable(focused) || !isDraggable(focused))
-    return false;
-  if (focused.isCuttable !== undefined) {
-    return focused.isCuttable();
-  }
-  return focused.isMovable() && focused.isDeletable();
+  return isCopyable(focused) && isIDeletable(focused) && focused.isDeletable();
 }
 
 /**

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -8,20 +8,13 @@
 
 import {BlockSvg} from './block_svg.js';
 import * as clipboard from './clipboard.js';
-import { RenderedWorkspaceComment } from './comments.js';
+import {RenderedWorkspaceComment} from './comments.js';
 import * as eventUtils from './events/utils.js';
 import {getFocusManager} from './focus_manager.js';
 import {Gesture} from './gesture.js';
-import {
-  ICopyable,
-  ICopyData,
-  isCopyable as isICopyable,
-} from './interfaces/i_copyable.js';
-import {
-  IDeletable,
-  isDeletable as isIDeletable,
-} from './interfaces/i_deletable.js';
-import {IDraggable, isDraggable} from './interfaces/i_draggable.js';
+import {ICopyData, isCopyable as isICopyable} from './interfaces/i_copyable.js';
+import {isDeletable as isIDeletable} from './interfaces/i_deletable.js';
+import {isDraggable} from './interfaces/i_draggable.js';
 import {IFocusableNode} from './interfaces/i_focusable_node.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import {Coordinate} from './utils/coordinate.js';
@@ -182,17 +175,27 @@ export function registerCopy() {
       e.preventDefault();
 
       const focused = scope.focusedNode;
-      if (!focused || !isCopyable(focused)) return false;
-      let targetWorkspace: WorkspaceSvg | null =
-        focused.workspace instanceof WorkspaceSvg
-          ? focused.workspace
+      if (!focused || !isICopyable(focused) || !isCopyable(focused))
+        return false;
+      let targetWorkspace: WorkspaceSvg | null;
+      let hideChaff = false;
+      if (focused instanceof BlockSvg) {
+        hideChaff = !focused.workspace.isFlyout;
+        targetWorkspace =
+          focused.workspace instanceof WorkspaceSvg
+            ? focused.workspace
+            : workspace;
+        targetWorkspace = targetWorkspace.isFlyout
+          ? targetWorkspace.targetWorkspace
+          : targetWorkspace;
+      } else {
+        targetWorkspace = workspace.isFlyout
+          ? workspace.targetWorkspace
           : workspace;
-      targetWorkspace = targetWorkspace.isFlyout
-        ? targetWorkspace.targetWorkspace
-        : targetWorkspace;
+      }
       if (!targetWorkspace) return false;
 
-      if (!focused.workspace.isFlyout) {
+      if (hideChaff) {
         targetWorkspace.hideChaff();
       }
       copyData = focused.toCopyData();

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -175,7 +175,7 @@ export function registerCopy() {
         : workspace;
       if (!targetWorkspace) return false;
 
-      if (focused.workspace.isFlyout) {
+      if (!focused.workspace.isFlyout) {
         targetWorkspace.hideChaff();
       }
       copyData = focused.toCopyData();

--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -108,7 +108,7 @@ let copyCoords: Coordinate | null = null;
 function isCopyable(focused: IFocusableNode): boolean {
   if (!isICopyable(focused) || !isIDeletable(focused) || !isDraggable(focused))
     return false;
-  if (focused.isCopyable !== undefined) {
+  if (focused.isCopyable) {
     return focused.isCopyable();
   } else if (
     focused instanceof BlockSvg ||

--- a/tests/mocha/shortcut_items_test.js
+++ b/tests/mocha/shortcut_items_test.js
@@ -48,6 +48,16 @@ suite('Keyboard Shortcut Items', function () {
   }
 
   /**
+   * Creates a workspace comment and set it as the focused node.
+   * @param {Blockly.Workspace} workspace The workspace to create a new comment on.
+   */
+  function setSelectedComment(workspace) {
+    const comment = workspace.newComment();
+    sinon.stub(Blockly.getFocusManager(), 'getFocusedNode').returns(comment);
+    return comment;
+  }
+
+  /**
    * Creates a test for not running keyDown events when the workspace is in read only mode.
    * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
    * @param {string=} opt_name An optional name for the test case.
@@ -241,6 +251,22 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.notCalled(this.copySpy);
       sinon.assert.notCalled(this.hideChaffSpy);
     });
+    // Copy a comment.
+    test('Workspace comment', function () {
+      testCases.forEach(function (testCase) {
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
+        test(testCaseName, function () {
+          Blockly.getFocusManager().getFocusedNode.restore();
+          this.comment = setSelectedComment(this.workspace);
+          this.copySpy = sinon.spy(this.comment, 'toCopyData');
+
+          this.injectionDiv.dispatchEvent(keyEvent);
+          sinon.assert.calledOnce(this.copySpy);
+          sinon.assert.calledOnce(this.hideChaffSpy);
+        });
+      });
+    });
   });
 
   suite('Cut', function () {
@@ -352,6 +378,24 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.notCalled(this.copySpy);
       sinon.assert.notCalled(this.disposeSpy);
       sinon.assert.notCalled(this.hideChaffSpy);
+    });
+
+    // Cut a comment.
+    suite('Workspace comment', function () {
+      testCases.forEach(function (testCase) {
+        const testCaseName = testCase[0];
+        const keyEvent = testCase[1];
+        test(testCaseName, function () {
+          Blockly.getFocusManager().getFocusedNode.restore();
+          this.comment = setSelectedComment(this.workspace);
+          this.copySpy = sinon.spy(this.comment, 'toCopyData');
+          this.disposeSpy = sinon.spy(this.comment, 'dispose');
+
+          this.injectionDiv.dispatchEvent(keyEvent);
+          sinon.assert.calledOnce(this.copySpy);
+          sinon.assert.calledOnce(this.disposeSpy);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9129 

### Proposed Changes

Adds an isCopyable method to the ICopyable interface and cleans up the cut/copy shortcut logic.
- Allows copying any block or ws comment that is internally movable (isOwnMovable) and deletable (isOwnDeletable).
- Allows cutting any block or ws comment that is copyable and deletable on the current workspace (isDeletable).
- Makes paste act on the workspace that was passed into the callback instead of the one set during cut/copy.
- Adds tests for cutting and for ws comments.

### Reason for Changes

The logic for cut/copy/paste was out of date with several assumptions about where actions could take place. A first pass on updating the logic had broken copying/cutting ws comments. This fixes the direct problem and does further cleanup and testing of the cut/copy/paste behavior.

### Test Coverage

Added new tests for cutting and for ws comments.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
