### PR TITLE
feat: Run keyboard plugin tests in CI

### DIFF
--- a/.github/workflows/keyboard_plugin_test.yml
+++ b/.github/workflows/keyboard_plugin_test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly-keyboard-experimentation'
-          ref: 'develop'
+          ref: 'main'
           path: blockly-keyboard-experimentation
 
       - name: Use Node.js 20.x

--- a/.github/workflows/keyboard_plugin_test.yml
+++ b/.github/workflows/keyboard_plugin_test.yml
@@ -1,0 +1,66 @@
+# Workflow for running the keyboard navigation plugin's automated tests.
+
+name: Keyboard Navigation Automated Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  webdriverio_tests:
+    name: WebdriverIO tests
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout core Blockly
+        uses: actions/checkout@v4
+        with:
+          path: core-blockly
+
+      - name: Checkout keyboard navigation plugin
+        uses: actions/checkout@v4
+        with:
+          repository: 'google/blockly-keyboard-experimentation'
+          ref: 'develop'
+          path: blockly-keyboard-experimentation
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: NPM install
+        run: |
+          cd core-blockly
+          npm install
+          cd ..
+          cd blockly-keyboard-experimentation
+          npm install
+          cd ..
+
+      - name: Link latest core develop with plugin
+        run: |
+          cd core-blockly
+          npm run package
+          cd dist
+          npm link
+          cd ../../blockly-keyboard-experimentation
+          npm link blockly
+          cd ..
+
+      - name: Run keyboard navigation plugin tests
+        run: |
+          cd blockly-keyboard-experimentation
+          npm run test


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

N/A (no tracking issue)

### Proposed Changes

Introduces a GitHub actions CI workflow to run the webdriver IO tests from https://github.com/google/blockly-keyboard-experimentation as part of core Blockly's CI.

### Reason for Changes

Since development on the plugin is going to continue for many months yet, this ensures that behavioral changes in core Blockly don't inadvertently break the plugin.

Note that this shouldn't be made a blocking workflow since there may be cases where it's necessary to break the plugin before a change to the plugin itself can be introduced to then fix it (as this has happened many times in the past). However, the CI check is forced signal to both author and reviewer as to whether their change affects the plugin without having to manually check the test suite.

### Test Coverage

N/A -- Verifying that the CI workflow runs is sufficient.

### Documentation

No documentation changes are needed here.

### Additional Information

Nothing.