### PR TITLE
feat: Only use FocusManager for LineCursor's state

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -384,7 +384,7 @@ export class LineCursor extends Marker {
       this.setCurNode(focused);
     }
 
-    return super.getCurNode();
+    return focused;
   }
 
   /**
@@ -396,8 +396,6 @@ export class LineCursor extends Marker {
    * @param newNode The new location of the cursor.
    */
   override setCurNode(newNode: IFocusableNode | null) {
-    super.setCurNode(newNode);
-
     if (isFocusableNode(newNode)) {
       getFocusManager().focusNode(newNode);
     }


### PR DESCRIPTION
## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-keyboard-experimentation/issues/584

### Proposed Changes

This updates `LineCursor` to only use `FocusManager` as its basic state for `getCurNode`, essentially ignoring `Marker`'s ability to track state.

### Reason for Changes

https://github.com/google/blockly-keyboard-experimentation/issues/584 had a specific issue where the keyboard navigation plugin was explicitly focusing the workspace _and_ updating the cursor to set the workspace as its current node when using 'W', allowing the context menu to be opened (since that's relying on the current cursor node.

There are other ways to solve this, but the easiest is to simply remove the need for `setCurNode` by entirely relying on `FocusNode` for the cursor's state so that there's never an inconsistency. `FocusManager` was already correctly focusing the workspace upon tabbing, so this ensures the two are always in sync.

### Test Coverage

The original case for https://github.com/google/blockly-keyboard-experimentation/issues/584 was manually tested, along with block movement (since that verifies that `Marker.getSourceBlock()` is working correctly in a polymorphic way for `LineCursor` a la the plugin's `move.ts` logic, specifically `getCurrentBlock()`).

Automated tests still need to be added.

### Documentation

No documentation changes are needed here.

### Additional Information

It would be nice to fully remove the marker and cursor classes (or at least their uses), but that's not the goal of this change.