### PR TITLE
fix: Dispatch keyboard events with the workspace they occurred on.

### DIFF
--- a/core/common.ts
+++ b/core/common.ts
@@ -320,6 +320,8 @@ export function defineBlocks(blocks: {[key: string]: BlockDefinition}) {
  * @param e Key down event.
  */
 export function globalShortcutHandler(e: KeyboardEvent) {
+  // This would ideally just be a `focusedTree instanceof WorkspaceSvg`, but
+  // importing `WorkspaceSvg` (as opposed to just its type) causes cycles.
   let workspace: WorkspaceSvg = getMainWorkspace() as WorkspaceSvg;
   const focusedTree = getFocusManager().getFocusedTree();
   for (const ws of getAllWorkspaces()) {

--- a/core/common.ts
+++ b/core/common.ts
@@ -320,21 +320,26 @@ export function defineBlocks(blocks: {[key: string]: BlockDefinition}) {
  * @param e Key down event.
  */
 export function globalShortcutHandler(e: KeyboardEvent) {
-  const mainWorkspace = getMainWorkspace() as WorkspaceSvg;
-  if (!mainWorkspace) {
-    return;
+  let workspace: WorkspaceSvg = getMainWorkspace() as WorkspaceSvg;
+  const focusedTree = getFocusManager().getFocusedTree();
+  for (const ws of getAllWorkspaces()) {
+    if (focusedTree === (ws as WorkspaceSvg)) {
+      workspace = ws as WorkspaceSvg;
+      break;
+    }
   }
 
   if (
     browserEvents.isTargetInput(e) ||
-    (mainWorkspace.rendered && !mainWorkspace.isVisible())
+    !workspace ||
+    (workspace.rendered && !workspace.isFlyout && !workspace.isVisible())
   ) {
     // When focused on an HTML text input widget, don't trap any keys.
     // Ignore keypresses on rendered workspaces that have been explicitly
     // hidden.
     return;
   }
-  ShortcutRegistry.registry.onKeyDown(mainWorkspace, e);
+  ShortcutRegistry.registry.onKeyDown(workspace, e);
 }
 
 export const TEST_ONLY = {defineBlocksWithJsonArrayInternal};


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR dispatches keyboard shortcut events with a reference to the workspace they actually occurred on. Previously, the main workspace was always used. This unblocks functionality in the keyboard navigation experiment, and is broadly more correct. I verified that the built-in shortcuts (cut/copy/paste, delete, escape, undo, redo) work in the main workspace, mutators and flyouts with this change.