### PR TITLE
refactor: Make the cursor use the focus manager for tracking the current node.

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -17,7 +17,6 @@ import {BlockSvg} from '../block_svg.js';
 import {Field} from '../field.js';
 import {getFocusManager} from '../focus_manager.js';
 import type {IFocusableNode} from '../interfaces/i_focusable_node.js';
-import {isFocusableNode} from '../interfaces/i_focusable_node.js';
 import * as registry from '../registry.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
 import {Marker} from './marker.js';
@@ -374,17 +373,8 @@ export class LineCursor extends Marker {
    *
    * @returns The current field, connection, or block the cursor is on.
    */
-  override getCurNode(): IFocusableNode | null {
-    // Ensure the current node matches what's currently focused.
-    const focused = getFocusManager().getFocusedNode();
-    const block = this.getSourceBlockFromNode(focused);
-    if (block && block.workspace === this.workspace) {
-      // If the current focused node corresponds to a block then ensure that it
-      // belongs to the correct workspace for this cursor.
-      this.setCurNode(focused);
-    }
-
-    return super.getCurNode();
+  getCurNode(): IFocusableNode | null {
+    return getFocusManager().getFocusedNode();
   }
 
   /**
@@ -395,12 +385,8 @@ export class LineCursor extends Marker {
    *
    * @param newNode The new location of the cursor.
    */
-  override setCurNode(newNode: IFocusableNode | null) {
-    super.setCurNode(newNode);
-
-    if (isFocusableNode(newNode)) {
-      getFocusManager().focusNode(newNode);
-    }
+  setCurNode(newNode: IFocusableNode) {
+    getFocusManager().focusNode(newNode);
 
     // Try to scroll cursor into view.
     if (newNode instanceof BlockSvg) {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes https://github.com/google/blockly-keyboard-experimentation/issues/584, but more generally updates the cursor to no longer track its own state wrt the actively focused element, but instead defer to the `FocusManager`. This also allows Marker and MarkerManager to be trivially deleted, but I'm leaving them for now to avoid breaking changes.