### PR TITLE
fix: Fix navigation for blocks with multiple statement inputs.

### DIFF
--- a/tests/mocha/cursor_test.js
+++ b/tests/mocha/cursor_test.js
@@ -60,6 +60,33 @@ suite('Cursor', function () {
           'tooltip': '',
           'helpUrl': '',
         },
+        {
+          'type': 'multi_statement_input',
+          'message0': '%1 %2',
+          'args0': [
+            {
+              'type': 'input_statement',
+              'name': 'FIRST',
+            },
+            {
+              'type': 'input_statement',
+              'name': 'SECOND',
+            },
+          ],
+        },
+        {
+          'type': 'simple_statement',
+          'message0': '%1',
+          'args0': [
+            {
+              'type': 'field_input',
+              'name': 'NAME',
+              'text': 'default',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+        },
       ]);
       this.workspace = Blockly.inject('blocklyDiv', {});
       this.cursor = this.workspace.getCursor();
@@ -145,6 +172,112 @@ suite('Cursor', function () {
       assert.equal(curNode, this.blocks.D.nextConnection);
     });
   });
+
+  suite('Multiple statement inputs', function () {
+    setup(function () {
+      sharedTestSetup.call(this);
+      Blockly.defineBlocksWithJsonArray([
+        {
+          'type': 'multi_statement_input',
+          'message0': '%1 %2',
+          'args0': [
+            {
+              'type': 'input_statement',
+              'name': 'FIRST',
+            },
+            {
+              'type': 'input_statement',
+              'name': 'SECOND',
+            },
+          ],
+        },
+        {
+          'type': 'simple_statement',
+          'message0': '%1',
+          'args0': [
+            {
+              'type': 'field_input',
+              'name': 'NAME',
+              'text': 'default',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+        },
+      ]);
+      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.cursor = this.workspace.getCursor();
+
+      this.multiStatement1 = createRenderedBlock(
+        this.workspace,
+        'multi_statement_input',
+      );
+      this.multiStatement2 = createRenderedBlock(
+        this.workspace,
+        'multi_statement_input',
+      );
+      this.firstStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.secondStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.thirdStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.fourthStatement = createRenderedBlock(
+        this.workspace,
+        'simple_statement',
+      );
+      this.multiStatement1
+        .getInput('FIRST')
+        .connection.connect(this.firstStatement.previousConnection);
+      this.firstStatement.nextConnection.connect(
+        this.secondStatement.previousConnection,
+      );
+      this.multiStatement1
+        .getInput('SECOND')
+        .connection.connect(this.thirdStatement.previousConnection);
+      this.multiStatement2
+        .getInput('FIRST')
+        .connection.connect(this.fourthStatement.previousConnection);
+    });
+
+    teardown(function () {
+      sharedTestTeardown.call(this);
+    });
+
+    test('In - from field in nested statement block to next nested statement block', function () {
+      this.cursor.setCurNode(this.secondStatement.getField('NAME'));
+      this.cursor.in();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.thirdStatement);
+    });
+    test('In - from field in nested statement block to next stack', function () {
+      this.cursor.setCurNode(this.thirdStatement.getField('NAME'));
+      this.cursor.in();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.multiStatement2);
+    });
+
+    test('Out - from nested statement block to last field of previous nested statement block', function () {
+      this.cursor.setCurNode(this.thirdStatement);
+      this.cursor.out();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.secondStatement.getField('NAME'));
+    });
+
+    test('Out - from root block to last field of last nested statement block in previous stack', function () {
+      this.cursor.setCurNode(this.multiStatement2);
+      this.cursor.out();
+      const curNode = this.cursor.getCurNode();
+      assert.equal(curNode, this.thirdStatement.getField('NAME'));
+    });
+  });
+
   suite('Searching', function () {
     setup(function () {
       sharedTestSetup.call(this);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9139

### Proposed Changes
This PR updates the block navigation policy to correctly handle navigating blocks with multiple statement inputs, e.g. if-else blocks.