### PR TITLE
refactor(interfaces): Make type predicates more robust

### DIFF
--- a/core/interfaces/i_autohideable.ts
+++ b/core/interfaces/i_autohideable.ts
@@ -23,5 +23,5 @@ export interface IAutoHideable extends IComponent {
 
 /** Returns true if the given object is autohideable. */
 export function isAutoHideable(obj: any): obj is IAutoHideable {
-  return typeof obj.autoHide === 'function';
+  return obj && typeof obj.autoHide === 'function';
 }

--- a/core/interfaces/i_autohideable.ts
+++ b/core/interfaces/i_autohideable.ts
@@ -23,5 +23,5 @@ export interface IAutoHideable extends IComponent {
 
 /** Returns true if the given object is autohideable. */
 export function isAutoHideable(obj: any): obj is IAutoHideable {
-  return obj.autoHide !== undefined;
+  return typeof obj.autoHide === 'function';
 }

--- a/core/interfaces/i_comment_icon.ts
+++ b/core/interfaces/i_comment_icon.ts
@@ -31,17 +31,17 @@ export interface ICommentIcon extends IIcon, IHasBubble, ISerializable {
 }
 
 /** Checks whether the given object is an ICommentIcon. */
-export function isCommentIcon(obj: object): obj is ICommentIcon {
+export function isCommentIcon(obj: any): obj is ICommentIcon {
   return (
     isIcon(obj) &&
     hasBubble(obj) &&
     isSerializable(obj) &&
-    (obj as any)['setText'] !== undefined &&
-    (obj as any)['getText'] !== undefined &&
-    (obj as any)['setBubbleSize'] !== undefined &&
-    (obj as any)['getBubbleSize'] !== undefined &&
-    (obj as any)['setBubbleLocation'] !== undefined &&
-    (obj as any)['getBubbleLocation'] !== undefined &&
+    typeof (obj as any).setText === 'function' &&
+    typeof (obj as any).getText === 'function' &&
+    typeof (obj as any).setBubbleSize === 'function' &&
+    typeof (obj as any).getBubbleSize === 'function' &&
+    typeof (obj as any).setBubbleLocation === 'function' &&
+    typeof (obj as any).getBubbleLocation === 'function' &&
     obj.getType() === IconType.COMMENT
   );
 }

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -35,5 +35,5 @@ export type ICopyData = ICopyable.ICopyData;
 
 /** @returns true if the given object is an ICopyable. */
 export function isCopyable(obj: any): obj is ICopyable<ICopyData> {
-  return typeof obj.toCopyData === 'function';
+  return obj && typeof obj.toCopyData === 'function';
 }

--- a/core/interfaces/i_copyable.ts
+++ b/core/interfaces/i_copyable.ts
@@ -35,5 +35,5 @@ export type ICopyData = ICopyable.ICopyData;
 
 /** @returns true if the given object is an ICopyable. */
 export function isCopyable(obj: any): obj is ICopyable<ICopyData> {
-  return obj.toCopyData !== undefined;
+  return typeof obj.toCopyData === 'function';
 }

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -27,6 +27,7 @@ export interface IDeletable {
 /** Returns whether the given object is an IDeletable. */
 export function isDeletable(obj: any): obj is IDeletable {
   return (
+    obj &&
     typeof obj.isDeletable === 'function' &&
     typeof obj.dispose === 'function' &&
     typeof obj.setDeleteStyle === 'function'

--- a/core/interfaces/i_deletable.ts
+++ b/core/interfaces/i_deletable.ts
@@ -27,8 +27,8 @@ export interface IDeletable {
 /** Returns whether the given object is an IDeletable. */
 export function isDeletable(obj: any): obj is IDeletable {
   return (
-    obj['isDeletable'] !== undefined &&
-    obj['dispose'] !== undefined &&
-    obj['setDeleteStyle'] !== undefined
+    typeof obj.isDeletable === 'function' &&
+    typeof obj.dispose === 'function' &&
+    typeof obj.setDeleteStyle === 'function'
   );
 }

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -62,6 +62,7 @@ export interface IDragStrategy {
 /** Returns whether the given object is an IDraggable or not. */
 export function isDraggable(obj: any): obj is IDraggable {
   return (
+    obj &&
     typeof obj.getRelativeToSurfaceXY === 'function' &&
     typeof obj.isMovable === 'function' &&
     typeof obj.startDrag === 'function' &&

--- a/core/interfaces/i_draggable.ts
+++ b/core/interfaces/i_draggable.ts
@@ -62,11 +62,11 @@ export interface IDragStrategy {
 /** Returns whether the given object is an IDraggable or not. */
 export function isDraggable(obj: any): obj is IDraggable {
   return (
-    obj.getRelativeToSurfaceXY !== undefined &&
-    obj.isMovable !== undefined &&
-    obj.startDrag !== undefined &&
-    obj.drag !== undefined &&
-    obj.endDrag !== undefined &&
-    obj.revertDrag !== undefined
+    typeof obj.getRelativeToSurfaceXY === 'function' &&
+    typeof obj.isMovable === 'function' &&
+    typeof obj.startDrag === 'function' &&
+    typeof obj.drag === 'function' &&
+    typeof obj.endDrag === 'function' &&
+    typeof obj.revertDrag === 'function'
   );
 }

--- a/core/interfaces/i_focusable_node.ts
+++ b/core/interfaces/i_focusable_node.ts
@@ -102,7 +102,7 @@ export interface IFocusableNode {
  * Determines whether the provided object fulfills the contract of
  * IFocusableNode.
  *
- * @param object The object to test.
+ * @param obj The object to test.
  * @returns Whether the provided object can be used as an IFocusableNode.
  */
 export function isFocusableNode(obj: any): obj is IFocusableNode {

--- a/core/interfaces/i_focusable_node.ts
+++ b/core/interfaces/i_focusable_node.ts
@@ -105,13 +105,13 @@ export interface IFocusableNode {
  * @param object The object to test.
  * @returns Whether the provided object can be used as an IFocusableNode.
  */
-export function isFocusableNode(object: any | null): object is IFocusableNode {
+export function isFocusableNode(obj: any): obj is IFocusableNode {
   return (
-    object &&
-    'getFocusableElement' in object &&
-    'getFocusableTree' in object &&
-    'onNodeFocus' in object &&
-    'onNodeBlur' in object &&
-    'canBeFocused' in object
+    obj &&
+    typeof obj.getFocusableElement === 'function' &&
+    typeof obj.getFocusableTree === 'function' &&
+    typeof obj.onNodeFocus === 'function' &&
+    typeof obj.onNodeBlur === 'function' &&
+    typeof obj.canBeFocused === 'function'
   );
 }

--- a/core/interfaces/i_focusable_tree.ts
+++ b/core/interfaces/i_focusable_tree.ts
@@ -128,7 +128,7 @@ export interface IFocusableTree {
  * Determines whether the provided object fulfills the contract of
  * IFocusableTree.
  *
- * @param object The object to test.
+ * @param obj The object to test.
  * @returns Whether the provided object can be used as an IFocusableTree.
  */
 export function isFocusableTree(obj: any): obj is IFocusableTree {

--- a/core/interfaces/i_focusable_tree.ts
+++ b/core/interfaces/i_focusable_tree.ts
@@ -131,14 +131,14 @@ export interface IFocusableTree {
  * @param object The object to test.
  * @returns Whether the provided object can be used as an IFocusableTree.
  */
-export function isFocusableTree(object: any | null): object is IFocusableTree {
+export function isFocusableTree(obj: any): obj is IFocusableTree {
   return (
-    object &&
-    'getRootFocusableNode' in object &&
-    'getRestoredFocusableNode' in object &&
-    'getNestedTrees' in object &&
-    'lookUpFocusableNode' in object &&
-    'onTreeFocus' in object &&
-    'onTreeBlur' in object
+    obj &&
+    typeof obj.getRootFocusableNode === 'function' &&
+    typeof obj.getRestoredFocusableNode === 'function' &&
+    typeof obj.getNestedTrees === 'function' &&
+    typeof obj.lookUpFocusableNode === 'function' &&
+    typeof obj.onTreeFocus === 'function' &&
+    typeof obj.onTreeBlur === 'function'
   );
 }

--- a/core/interfaces/i_has_bubble.ts
+++ b/core/interfaces/i_has_bubble.ts
@@ -30,6 +30,7 @@ export interface IHasBubble {
 /** Type guard that checks whether the given object is a IHasBubble. */
 export function hasBubble(obj: any): obj is IHasBubble {
   return (
-    obj.bubbleIsVisible !== undefined && obj.setBubbleVisible !== undefined
+    typeof obj.bubbleIsVisible === 'function' &&
+    typeof obj.setBubbleVisible === 'function'
   );
 }

--- a/core/interfaces/i_has_bubble.ts
+++ b/core/interfaces/i_has_bubble.ts
@@ -31,6 +31,7 @@ export interface IHasBubble {
 export function hasBubble(obj: any): obj is IHasBubble {
   return (
     typeof obj.bubbleIsVisible === 'function' &&
-    typeof obj.setBubbleVisible === 'function'
+    typeof obj.setBubbleVisible === 'function' &&
+    typeof obj.getBubble === 'function'
   );
 }

--- a/core/interfaces/i_icon.ts
+++ b/core/interfaces/i_icon.ts
@@ -98,19 +98,19 @@ export interface IIcon extends IFocusableNode {
 /** Type guard that checks whether the given object is an IIcon. */
 export function isIcon(obj: any): obj is IIcon {
   return (
-    obj.getType !== undefined &&
-    obj.initView !== undefined &&
-    obj.dispose !== undefined &&
-    obj.getWeight !== undefined &&
-    obj.getSize !== undefined &&
-    obj.applyColour !== undefined &&
-    obj.hideForInsertionMarker !== undefined &&
-    obj.updateEditable !== undefined &&
-    obj.updateCollapsed !== undefined &&
-    obj.isShownWhenCollapsed !== undefined &&
-    obj.setOffsetInBlock !== undefined &&
-    obj.onLocationChange !== undefined &&
-    obj.onClick !== undefined &&
+    typeof obj.getType === 'function' &&
+    typeof obj.initView === 'function' &&
+    typeof obj.dispose === 'function' &&
+    typeof obj.getWeight === 'function' &&
+    typeof obj.getSize === 'function' &&
+    typeof obj.applyColour === 'function' &&
+    typeof obj.hideForInsertionMarker === 'function' &&
+    typeof obj.updateEditable === 'function' &&
+    typeof obj.updateCollapsed === 'function' &&
+    typeof obj.isShownWhenCollapsed === 'function' &&
+    typeof obj.setOffsetInBlock === 'function' &&
+    typeof obj.onLocationChange === 'function' &&
+    typeof obj.onClick === 'function' &&
     isFocusableNode(obj)
   );
 }

--- a/core/interfaces/i_icon.ts
+++ b/core/interfaces/i_icon.ts
@@ -98,19 +98,19 @@ export interface IIcon extends IFocusableNode {
 /** Type guard that checks whether the given object is an IIcon. */
 export function isIcon(obj: any): obj is IIcon {
   return (
-    typeof obj.getType === 'function' &&
-    typeof obj.initView === 'function' &&
-    typeof obj.dispose === 'function' &&
-    typeof obj.getWeight === 'function' &&
-    typeof obj.getSize === 'function' &&
-    typeof obj.applyColour === 'function' &&
-    typeof obj.hideForInsertionMarker === 'function' &&
-    typeof obj.updateEditable === 'function' &&
-    typeof obj.updateCollapsed === 'function' &&
-    typeof obj.isShownWhenCollapsed === 'function' &&
-    typeof obj.setOffsetInBlock === 'function' &&
-    typeof obj.onLocationChange === 'function' &&
-    typeof obj.onClick === 'function' &&
-    isFocusableNode(obj)
+    isFocusableNode(obj) &&
+    typeof (obj as IIcon).getType === 'function' &&
+    typeof (obj as IIcon).initView === 'function' &&
+    typeof (obj as IIcon).dispose === 'function' &&
+    typeof (obj as IIcon).getWeight === 'function' &&
+    typeof (obj as IIcon).getSize === 'function' &&
+    typeof (obj as IIcon).applyColour === 'function' &&
+    typeof (obj as IIcon).hideForInsertionMarker === 'function' &&
+    typeof (obj as IIcon).updateEditable === 'function' &&
+    typeof (obj as IIcon).updateCollapsed === 'function' &&
+    typeof (obj as IIcon).isShownWhenCollapsed === 'function' &&
+    typeof (obj as IIcon).setOffsetInBlock === 'function' &&
+    typeof (obj as IIcon).onLocationChange === 'function' &&
+    typeof (obj as IIcon).onClick === 'function'
   );
 }

--- a/core/interfaces/i_legacy_procedure_blocks.ts
+++ b/core/interfaces/i_legacy_procedure_blocks.ts
@@ -28,9 +28,9 @@ export interface LegacyProcedureDefBlock {
 
 /** @internal */
 export function isLegacyProcedureDefBlock(
-  block: object,
-): block is LegacyProcedureDefBlock {
-  return (block as any).getProcedureDef !== undefined;
+  obj: any,
+): obj is LegacyProcedureDefBlock {
+  return obj && typeof obj.getProcedureDef === 'function';
 }
 
 /** @internal */
@@ -41,10 +41,11 @@ export interface LegacyProcedureCallBlock {
 
 /** @internal */
 export function isLegacyProcedureCallBlock(
-  block: object,
-): block is LegacyProcedureCallBlock {
+  obj: any,
+): obj is LegacyProcedureCallBlock {
   return (
-    (block as any).getProcedureCall !== undefined &&
-    (block as any).renameProcedure !== undefined
+    obj &&
+    typeof obj.getProcedureCall === 'function' &&
+    typeof obj.renameProcedure === 'function'
   );
 }

--- a/core/interfaces/i_observable.ts
+++ b/core/interfaces/i_observable.ts
@@ -20,5 +20,8 @@ export interface IObservable {
  * @internal
  */
 export function isObservable(obj: any): obj is IObservable {
-  return obj.startPublishing !== undefined && obj.stopPublishing !== undefined;
+  return (
+    typeof obj.startPublishing === 'function' &&
+    typeof obj.stopPublishing === 'function'
+  );
 }

--- a/core/interfaces/i_observable.ts
+++ b/core/interfaces/i_observable.ts
@@ -21,6 +21,7 @@ export interface IObservable {
  */
 export function isObservable(obj: any): obj is IObservable {
   return (
+    obj &&
     typeof obj.startPublishing === 'function' &&
     typeof obj.stopPublishing === 'function'
   );

--- a/core/interfaces/i_paster.ts
+++ b/core/interfaces/i_paster.ts
@@ -21,5 +21,5 @@ export interface IPaster<U extends ICopyData, T extends ICopyable<U>> {
 export function isPaster(
   obj: any,
 ): obj is IPaster<ICopyData, ICopyable<ICopyData>> {
-  return typeof obj.paste === 'function';
+  return obj && typeof obj.paste === 'function';
 }

--- a/core/interfaces/i_paster.ts
+++ b/core/interfaces/i_paster.ts
@@ -21,5 +21,5 @@ export interface IPaster<U extends ICopyData, T extends ICopyable<U>> {
 export function isPaster(
   obj: any,
 ): obj is IPaster<ICopyData, ICopyable<ICopyData>> {
-  return obj.paste !== undefined;
+  return typeof obj.paste === 'function';
 }

--- a/core/interfaces/i_procedure_block.ts
+++ b/core/interfaces/i_procedure_block.ts
@@ -20,9 +20,10 @@ export interface IProcedureBlock {
 export function isProcedureBlock(
   block: Block | IProcedureBlock,
 ): block is IProcedureBlock {
+  block = block as IProcedureBlock;
   return (
-    (block as IProcedureBlock).getProcedureModel !== undefined &&
-    (block as IProcedureBlock).doProcedureUpdate !== undefined &&
-    (block as IProcedureBlock).isProcedureDef !== undefined
+    typeof block.getProcedureModel === 'function' &&
+    typeof block.doProcedureUpdate === 'function' &&
+    typeof block.isProcedureDef === 'function'
   );
 }

--- a/core/interfaces/i_rendered_element.ts
+++ b/core/interfaces/i_rendered_element.ts
@@ -15,5 +15,5 @@ export interface IRenderedElement {
  * @returns True if the given object is an IRenderedElement.
  */
 export function isRenderedElement(obj: any): obj is IRenderedElement {
-  return obj['getSvgRoot'] !== undefined;
+  return typeof obj.getSvgRoot === 'function';
 }

--- a/core/interfaces/i_rendered_element.ts
+++ b/core/interfaces/i_rendered_element.ts
@@ -15,5 +15,5 @@ export interface IRenderedElement {
  * @returns True if the given object is an IRenderedElement.
  */
 export function isRenderedElement(obj: any): obj is IRenderedElement {
-  return typeof obj.getSvgRoot === 'function';
+  return obj && typeof obj.getSvgRoot === 'function';
 }

--- a/core/interfaces/i_selectable.ts
+++ b/core/interfaces/i_selectable.ts
@@ -34,7 +34,7 @@ export function isSelectable(obj: any): obj is ISelectable {
   return (
     isFocusableNode(obj) &&
     typeof (obj as ISelectable).id === 'string' &&
-    typeof (obj as ISelectable).workspace === 'function' &&
+    typeof (obj as ISelectable).workspace === 'object' &&
     typeof (obj as ISelectable).select === 'function' &&
     typeof (obj as ISelectable).unselect === 'function'
   );

--- a/core/interfaces/i_selectable.ts
+++ b/core/interfaces/i_selectable.ts
@@ -32,10 +32,10 @@ export interface ISelectable extends IFocusableNode {
 /** Checks whether the given object is an ISelectable. */
 export function isSelectable(obj: any): obj is ISelectable {
   return (
-    typeof obj.id === 'string' &&
-    typeof obj.workspace === 'function' &&
-    typeof obj.select === 'function' &&
-    typeof obj.unselect === 'function' &&
-    isFocusableNode(obj)
+    isFocusableNode(obj) &&
+    typeof (obj as ISelectable).id === 'string' &&
+    typeof (obj as ISelectable).workspace === 'function' &&
+    typeof (obj as ISelectable).select === 'function' &&
+    typeof (obj as ISelectable).unselect === 'function'
   );
 }

--- a/core/interfaces/i_selectable.ts
+++ b/core/interfaces/i_selectable.ts
@@ -30,12 +30,12 @@ export interface ISelectable extends IFocusableNode {
 }
 
 /** Checks whether the given object is an ISelectable. */
-export function isSelectable(obj: object): obj is ISelectable {
+export function isSelectable(obj: any): obj is ISelectable {
   return (
-    typeof (obj as any).id === 'string' &&
-    (obj as any).workspace !== undefined &&
-    (obj as any).select !== undefined &&
-    (obj as any).unselect !== undefined &&
+    typeof obj.id === 'string' &&
+    typeof obj.workspace === 'function' &&
+    typeof obj.select === 'function' &&
+    typeof obj.unselect === 'function' &&
     isFocusableNode(obj)
   );
 }

--- a/core/interfaces/i_serializable.ts
+++ b/core/interfaces/i_serializable.ts
@@ -25,8 +25,8 @@ export interface ISerializable {
 /** Type guard that checks whether the given object is a ISerializable. */
 export function isSerializable(obj: any): obj is ISerializable {
   return (
-    typeof obj &&
-    obj.saveState === 'function' &&
+    obj &&
+    typeof obj.saveState === 'function' &&
     typeof obj.loadState === 'function'
   );
 }

--- a/core/interfaces/i_serializable.ts
+++ b/core/interfaces/i_serializable.ts
@@ -24,5 +24,7 @@ export interface ISerializable {
 
 /** Type guard that checks whether the given object is a ISerializable. */
 export function isSerializable(obj: any): obj is ISerializable {
-  return obj.saveState !== undefined && obj.loadState !== undefined;
+  return (
+    typeof obj.saveState === 'function' && typeof obj.loadState === 'function'
+  );
 }

--- a/core/interfaces/i_serializable.ts
+++ b/core/interfaces/i_serializable.ts
@@ -25,6 +25,8 @@ export interface ISerializable {
 /** Type guard that checks whether the given object is a ISerializable. */
 export function isSerializable(obj: any): obj is ISerializable {
   return (
-    typeof obj.saveState === 'function' && typeof obj.loadState === 'function'
+    typeof obj &&
+    obj.saveState === 'function' &&
+    typeof obj.loadState === 'function'
   );
 }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -8,6 +8,7 @@ import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {EventType} from '../../build/src/core/events/type.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
 import {EndRowInput} from '../../build/src/core/inputs/end_row_input.js';
+import {isCommentIcon} from '../../build/src/core/interfaces/i_comment_icon.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';
 import {
@@ -1462,6 +1463,10 @@ suite('Blocks', function () {
         }
 
         loadState() {}
+      }
+
+      if (!isCommentIcon(new MockComment())) {
+        throw new TypeError('MockComment not an ICommentIcon');
       }
 
       setup(function () {

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1453,6 +1453,10 @@ suite('Blocks', function () {
 
         setBubbleVisible() {}
 
+        getBubble() {
+          return null;
+        }
+
         saveState() {
           return {};
         }

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -7,8 +7,10 @@
 import {ConnectionType} from '../../build/src/core/connection_type.js';
 import {EventType} from '../../build/src/core/events/type.js';
 import * as eventUtils from '../../build/src/core/events/utils.js';
+import {IconType} from '../../build/src/core/icons/icon_types.js';
 import {EndRowInput} from '../../build/src/core/inputs/end_row_input.js';
 import {isCommentIcon} from '../../build/src/core/interfaces/i_comment_icon.js';
+import {Size} from '../../build/src/core/utils/size.js';
 import {assert} from '../../node_modules/chai/chai.js';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';
 import {
@@ -1429,7 +1431,7 @@ suite('Blocks', function () {
     suite('Constructing registered comment classes', function () {
       class MockComment extends MockIcon {
         getType() {
-          return Blockly.icons.IconType.COMMENT;
+          return IconType.COMMENT;
         }
 
         setText() {}
@@ -1441,7 +1443,7 @@ suite('Blocks', function () {
         setBubbleSize() {}
 
         getBubbleSize() {
-          return Blockly.utils.Size(0, 0);
+          return Size(0, 0);
         }
 
         setBubbleLocation() {}

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -1429,7 +1429,7 @@ suite('Blocks', function () {
     });
 
     suite('Constructing registered comment classes', function () {
-      class MockComment extends MockIcon {
+      class MockComment extends MockBubbleIcon {
         getType() {
           return IconType.COMMENT;
         }
@@ -1449,16 +1449,6 @@ suite('Blocks', function () {
         setBubbleLocation() {}
 
         getBubbleLocation() {}
-
-        bubbleIsVisible() {
-          return true;
-        }
-
-        setBubbleVisible() {}
-
-        getBubble() {
-          return null;
-        }
 
         saveState() {
           return {};

--- a/tests/mocha/test_helpers/icon_mocks.js
+++ b/tests/mocha/test_helpers/icon_mocks.js
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export class MockIcon {
+export class MockFocusable {
+  getFocusableElement() {}
+  getFocusableTree() {}
+  onNodeFocus() {}
+  onNodeBlur() {}
+  canBeFocused() {}
+}
+
+export class MockIcon extends MockFocusable {
+
   getType() {
     return new Blockly.icons.IconType('mock icon');
   }
@@ -94,4 +103,9 @@ export class MockBubbleIcon extends MockIcon {
   setBubbleVisible(visible) {
     this.visible = visible;
   }
+
+  getBubble() {
+    return null;
+  }
+}
 }

--- a/tests/mocha/test_helpers/icon_mocks.js
+++ b/tests/mocha/test_helpers/icon_mocks.js
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {isFocusableNode} from '../../../build/src/core/interfaces/i_focusable_node.js';
+import {hasBubble} from '../../../build/src/core/interfaces/i_has_bubble.js';
+import {isIcon} from '../../../build/src/core/interfaces/i_icon.js';
+import {isSerializable} from '../../../build/src/core/interfaces/i_serializable.js';
+
 export class MockFocusable {
   getFocusableElement() {}
   getFocusableTree() {}
@@ -12,8 +17,11 @@ export class MockFocusable {
   canBeFocused() {}
 }
 
-export class MockIcon extends MockFocusable {
+if (!isFocusableNode(new MockFocusable())) {
+  throw new TypeError('MockFocusable not an IFocuableNode');
+}
 
+export class MockIcon extends MockFocusable {
   getType() {
     return new Blockly.icons.IconType('mock icon');
   }
@@ -61,6 +69,10 @@ export class MockIcon extends MockFocusable {
   }
 }
 
+if (!isIcon(new MockIcon())) {
+  throw new TypeError('MockIcon not an IIcon');
+}
+
 export class MockSerializableIcon extends MockIcon {
   constructor() {
     super();
@@ -82,6 +94,10 @@ export class MockSerializableIcon extends MockIcon {
   loadState(state) {
     this.state = state;
   }
+}
+
+if (!isSerializable(new MockSerializableIcon())) {
+  throw new TypeError('MockSerializableIcon not an ISerializable');
 }
 
 export class MockBubbleIcon extends MockIcon {
@@ -108,4 +124,7 @@ export class MockBubbleIcon extends MockIcon {
     return null;
   }
 }
+
+if (!hasBubble(new MockBubbleIcon())) {
+  throw new TypeError('MockBubbleIcon not an IHasBubble');
 }


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Make type predicates for interface types more robust:

* Always use `typeof … === 'function'` when testing for presence of methods.
* Test for presence of all non-optional members.
* Accept input of type `any` but always check that the value is neither `null` nor `undefined`.

### Reason for Changes

Because many of these interfaces define developer-supplied types, making the corresponding type predicates more exacting will help ensure that we do not inadvertently accept a value that only partially conforms to the interface.

For example, given some object
```JS
const obj = {
  a: 0,
  b: 'hello',
  c() {
    console.log('hello');
  }
  d: undefined,
  // There is no e.
}
```
the typical tests we use will all return true for almost any non-missing value:
```JS
obj.a !== undefined  // true
obj.b !== undefined  // true
obj.c !== undefined  // true
obj.d !== undefined  // false
obj.e !== undefined  // false
```
while a lazier test might catch a primitive being supplied where a method was expected, at least if the primitive is falsey:
```JS
Boolean(obj.a)  // FALSE
Boolean(obj.b)  // true
Boolean(obj.c)  // true
Boolean(obj.d)  // false
Boolean(obj.e)  // false
```
whereas using `typeof` will ensure that, at least for primitive- or method-valued members of the interface, the type is approximately as expected:
```JS
typeof obj.a === 'number'  // true

typeof obj.a === 'string'  // false

typeof obj.a === 'function'  // false
typeof obj.b === 'function'  // false
typeof obj.c === 'function'  // true
typeof obj.d === 'function'  // false
typeof obj.e === 'function'  // false
```

Notably, the only values whose `typeof` is `'function'` that are _not_ callable as a method are ES6 class constructors (e.g., `class C {}`), which need to be invoked with `new`.

### Test Coverage

Passes `npm test`.

### Additional Information

One possible argument against this change might be that the type predicates will be slightly more expensive to invoke—though I suspect that in most situations the JIT will optimise away most of the actual checks.  Likely only use of these predicates inside hotspot inner loops is likely to be of any measurable effect, but it would be useful if we had some benchmarks so we could actually test to see what effect if any this change might have.
