### PR TITLE
fix: tweak redo shortcut order to match convention

### DIFF
--- a/core/shortcut_items.ts
+++ b/core/shortcut_items.ts
@@ -344,12 +344,12 @@ export function registerUndo() {
  */
 export function registerRedo() {
   const ctrlShiftZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
-    KeyCodes.SHIFT,
     KeyCodes.CTRL,
+    KeyCodes.SHIFT,
   ]);
   const metaShiftZ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Z, [
-    KeyCodes.SHIFT,
     KeyCodes.META,
+    KeyCodes.SHIFT,
   ]);
   // Ctrl-y is redo in Windows.  Command-y is never valid on Macs.
   const ctrlY = ShortcutRegistry.registry.createSerializedKey(KeyCodes.Y, [


### PR DESCRIPTION
The order of the modifiers is not significant to Blockly but it's conventional to say e.g. Cmd+Shift+Z. Following that order here means that UI like the keyboard navigation plugin shortcut dialog and MakeCode gets the correct order without having to sort. This is the only such shortcut in Blockly.

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-keyboard-experimentation/issues/621