### PR TITLE
fix: clear touch identifier on comment text area pointerdown

### DIFF
--- a/core/bubbles/textinput_bubble.ts
+++ b/core/bubbles/textinput_bubble.ts
@@ -176,6 +176,7 @@ export class TextInputBubble extends Bubble {
     // Don't let the pointerdown event get to the workspace.
     browserEvents.conditionalBind(textArea, 'pointerdown', this, (e: Event) => {
       e.stopPropagation();
+      touch.clearTouchIdentifier();
     });
 
     browserEvents.conditionalBind(textArea, 'change', this, this.onTextChange);

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -8,6 +8,7 @@ import * as browserEvents from '../browser_events.js';
 import {getFocusManager} from '../focus_manager.js';
 import {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {IFocusableTree} from '../interfaces/i_focusable_tree.js';
+import * as touch from '../touch.js';
 import * as dom from '../utils/dom.js';
 import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
@@ -80,6 +81,7 @@ export class CommentEditor implements IFocusableNode {
         // and steal focus away from the editor/comment.
         e.stopPropagation();
         getFocusManager().focusNode(this);
+        touch.clearTouchIdentifier();
       },
     );
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly/issues/9170
Fixes #9108 

### Proposed Changes

Clear the cached touch identifier inside the pointerdown event handler inside the `CommentView`

### Reason for Changes

The pointerdown event handler inside of `CommentView` uses `conditionalBind` to bind the event listener. Inside that event listener, it then calls `stopPropagation` to prevent the event from bubbling. As a result a touch identifier is registered but it never gets cleared which prevents all further pointer events from firing on the workspace

### Test Coverage

Tested in playground locally.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

@microbit-matt-hillsdon FYI
