### PR TITLE
Use 4-space indention for Python

### DIFF
--- a/generators/python/python_generator.ts
+++ b/generators/python/python_generator.ts
@@ -76,6 +76,8 @@ export class PythonGenerator extends CodeGenerator {
     [Order.LOGICAL_OR, Order.LOGICAL_OR],
   ];
 
+  INDENT = '    '; // 4 spaces as per PEP-8.
+
   /**
    * Empty loops or conditionals are not allowed in Python.
    */


### PR DESCRIPTION
As per PEP-8.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

Change the indention for Python code from 2 spaces to 4 spaces.

### Reason for Changes

The convention for indention in the Python community is [4 spaces as per PEP-8](https://peps.python.org/pep-0008/#indentation).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
