### PR TITLE
refactor(CSS): move `box-sizing` from keyboard nav plugin to `core/css.ts`

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -1172,6 +1172,7 @@ Css.register(`
 
 /* Category tree in Toolbox. */
 .blocklyToolbox {
+  box-sizing: border-box;
   user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Part of google/blockly-keyboard-experimentation#595

### Proposed Changes

Add `box-sizing: border-box` to the existing `.blocklyToolbox` styling in `core/css.ts`.

### Reason for Changes

The following "CSS reset" was added to the plugin playground by @microbit-matt-hillsdon in google/blockly-keyboard-experimentation#511 to fix an issue with the toolbox focus indicator border being misplaced:
```
* {
  box-sizing: border-box;
}
```

This would be a pretty good default ([explanation](https://www.joshwcomeau.com/css/custom-css-reset/#one-box-sizing-model-2)) for Blockly but that would definitely be a breaking change, so for now apply it only to the `blocklyToolbox` div.

### Test Coverage

Manually verified it has the desired effect on the toolbox focus indicator (after removing corresponding styling from plugin's `test/index.html`, of course).

### Additional Information

* `box-sizing` styling to be removed from the keyboard-nav plugin by google/blockly-keyboard-experimentation#637
* #9205
