### PR TITLE
refactor: Ensure that the workspace cursor is never null.

### DIFF
--- a/core/marker_manager.ts
+++ b/core/marker_manager.ts
@@ -11,7 +11,7 @@
  */
 // Former goog.module ID: Blockly.MarkerManager
 
-import type {LineCursor} from './keyboard_nav/line_cursor.js';
+import {LineCursor} from './keyboard_nav/line_cursor.js';
 import type {Marker} from './keyboard_nav/marker.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -23,7 +23,7 @@ export class MarkerManager {
   static readonly LOCAL_MARKER = 'local_marker_1';
 
   /** The cursor. */
-  private cursor: LineCursor | null = null;
+  private cursor: LineCursor;
 
   /** The map of markers for the workspace. */
   private markers = new Map<string, Marker>();
@@ -32,7 +32,9 @@ export class MarkerManager {
    * @param workspace The workspace for the marker manager.
    * @internal
    */
-  constructor(private readonly workspace: WorkspaceSvg) {}
+  constructor(private readonly workspace: WorkspaceSvg) {
+    this.cursor = new LineCursor(this.workspace);
+  }
 
   /**
    * Register the marker by adding it to the map of markers.
@@ -72,7 +74,7 @@ export class MarkerManager {
    *
    * @returns The cursor for this workspace.
    */
-  getCursor(): LineCursor | null {
+  getCursor(): LineCursor {
     return this.cursor;
   }
 
@@ -109,9 +111,6 @@ export class MarkerManager {
       this.unregisterMarker(markerId);
     }
     this.markers.clear();
-    if (this.cursor) {
-      this.cursor.dispose();
-      this.cursor = null;
-    }
+    this.cursor.dispose();
   }
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -480,10 +480,7 @@ export class WorkspaceSvg
    * @internal
    */
   getMarker(id: string): Marker | null {
-    if (this.markerManager) {
-      return this.markerManager.getMarker(id);
-    }
-    return null;
+    return this.markerManager.getMarker(id);
   }
 
   /**
@@ -491,11 +488,8 @@ export class WorkspaceSvg
    *
    * @returns The cursor for the workspace.
    */
-  getCursor(): LineCursor | null {
-    if (this.markerManager) {
-      return this.markerManager.getCursor();
-    }
-    return null;
+  getCursor(): LineCursor {
+    return this.markerManager.getCursor();
   }
 
   /**
@@ -899,10 +893,7 @@ export class WorkspaceSvg
     }
 
     this.renderer.dispose();
-
-    if (this.markerManager) {
-      this.markerManager.dispose();
-    }
+    this.markerManager.dispose();
 
     super.dispose();
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR fixes part of https://github.com/google/blockly-keyboard-experimentation/issues/471 by ensuring that the workspace's cursor is never null. This was defacto the case before, but this PR updates the types and default values to enforce it.