### PR TITLE
fix: Improve workspace comment keyboard navigation behavior. 

### DIFF
--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -52,6 +52,7 @@ export class CommentEditor implements IFocusableNode {
       dom.HTML_NS,
       'textarea',
     ) as HTMLTextAreaElement;
+    this.textArea.setAttribute('tabindex', '-1');
     dom.addClass(this.textArea, 'blocklyCommentText');
     dom.addClass(this.textArea, 'blocklyTextarea');
     dom.addClass(this.textArea, 'blocklyText');

--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -401,6 +401,8 @@ export class LineCursor extends Marker {
       block.workspace.scrollBoundsIntoView(
         block.getBoundingRectangleWithoutChildren(),
       );
+    } else if (newNode instanceof RenderedWorkspaceComment) {
+      newNode.workspace.scrollBoundsIntoView(newNode.getBoundingRectangle());
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR addresses two points of feedback raised in https://github.com/google/blockly-keyboard-experimentation/pull/625:

* The workspace comment textarea has its tabindex set to -1, preventing tabbing into it. It remains accessible via keyboard navigation.
* When workspace comments are focused, they will be scrolled into view on the workspace.