### PR TITLE
fix: Focus the first element in flyouts.

### DIFF
--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2729,12 +2729,15 @@ export class WorkspaceSvg
       const flyout = this.targetWorkspace?.getFlyout();
       if (this.isFlyout && flyout) {
         // Return the first focusable item of the flyout.
-        for (const flyoutItem of flyout.getContents()) {
-          const elem = flyoutItem.getElement();
-          if (isFocusableNode(elem) && elem.canBeFocused()) {
-            return elem;
-          }
-        }
+        return (
+          flyout
+            .getContents()
+            .find((flyoutItem) => {
+              const element = flyoutItem.getElement();
+              return isFocusableNode(element) && element.canBeFocused();
+            })
+            ?.getElement() ?? null
+        );
       }
       return this.getTopBlocks(true)[0] ?? null;
     } else return null;

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -2726,6 +2726,16 @@ export class WorkspaceSvg
     previousNode: IFocusableNode | null,
   ): IFocusableNode | null {
     if (!previousNode) {
+      const flyout = this.targetWorkspace?.getFlyout();
+      if (this.isFlyout && flyout) {
+        // Return the first focusable item of the flyout.
+        for (const flyoutItem of flyout.getContents()) {
+          const elem = flyoutItem.getElement();
+          if (isFocusableNode(elem) && elem.canBeFocused()) {
+            return elem;
+          }
+        }
+      }
       return this.getTopBlocks(true)[0] ?? null;
     } else return null;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9103

### Proposed Changes
This PR returns the first focusable node of a flyout workspace when `getRestoredFocusableNode()` is called, regardless of whether that element is a block or some other type of entity.