### PR TITLE
fix: Fix order of arguments in `IVariableMap.createVariable()`.

### DIFF
--- a/core/interfaces/i_variable_map.ts
+++ b/core/interfaces/i_variable_map.ts
@@ -43,7 +43,7 @@ export interface IVariableMap<T extends IVariableModel<IVariableState>> {
    * Creates a new variable with the given name. If ID is not specified, the
    * variable map should create one. Returns the new variable.
    */
-  createVariable(name: string, id?: string, type?: string | null): T;
+  createVariable(name: string, type?: string, id?: string | null): T;
 
   /* Adds a variable to this variable map. */
   addVariable(variable: T): void;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9218

### Proposed Changes
This PR flips the names of the second and third arguments to `IVariableMap.createVariable()` to reflect the ordering used in the built-in `VariableMap` class.

### NOT-QUITE-BREAKING CHANGE
This PR changes the API, but (a) the previous interface was incorrect relative to the actual implementation provided, and the types of the arguments did not change. As a result, this will not result in build failures, but if you were using the old argument order your code wasn't doing what you intended.