### PR TITLE
fix: Refer to correct replacement method in deprecation warning.

### DIFF
--- a/core/workspace.ts
+++ b/core/workspace.ts
@@ -469,7 +469,7 @@ export class Workspace {
       'Blockly.Workspace.getVariableUsesById',
       'v12',
       'v13',
-      'Blockly.Workspace.getVariableMap().getVariableUsesById',
+      'Blockly.Variables.getVariableUsesById',
     );
     return getVariableUsesById(this, id);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9184

### Proposed Changes
This PR updates the deprecation warning on `Workspace.getVariableUsesById()` to point users to `Blockly.Variables.getVariableUsesById()`, rather than `Blockly.Workspace.getVariableMap().getVariableUsesById()`. Although the latter exists on Blockly's `VariableMap`, it is deprecated there as well and is not present on `IVariableMap`, so using the suggested replacement would result in a type error. The function that this PR suggests developers use is the same as the `VariableMap.getVariableUsesById()` deprecation warning suggests, and is indeed not deprecated.