### PR TITLE
fix: Allow overriding `VariableModel` via `options.plugins`.

### DIFF
--- a/core/registry.ts
+++ b/core/registry.ts
@@ -119,9 +119,9 @@ export class Type<_T> {
   /** @internal */
   static PASTER = new Type<IPaster<ICopyData, ICopyable<ICopyData>>>('paster');
 
-  static VARIABLE_MODEL = new Type<IVariableModelStatic<IVariableState>>(
-    'variableModel',
-  );
+  static VARIABLE_MODEL = new Type<
+    IVariableModelStatic<IVariableState> & IVariableModel<IVariableState>
+  >('variableModel');
 
   static VARIABLE_MAP = new Type<IVariableMap<IVariableModel<IVariableState>>>(
     'variableMap',

--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -255,9 +255,9 @@ export class VariableMap
     }
     const id = opt_id || idGenerator.genUid();
     const type = opt_type || '';
-    const VariableModel = registry.getObject(
+    const VariableModel = registry.getClassFromOptions(
       registry.Type.VARIABLE_MODEL,
-      registry.DEFAULT,
+      this.workspace.options,
       true,
     );
     if (!VariableModel) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9256

### Proposed Changes
This PR updates `VariableMap` to retrieve the `VariableModel` class to be used based on the injection `options.plugins`. Previously, this could only be overridden by manually registering an alternative implementation with the registry as the default implementation.