### PR TITLE
fix: Fix displaying HTML elements in `FieldDropdown`.

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -699,25 +699,30 @@ export class FieldDropdown extends Field<string> {
     prefix?: string;
     suffix?: string;
   } {
-    let hasImages = false;
+    let hasNonTextContent = false;
     const trimmedOptions = options.map((option): MenuOption => {
-      if (option === FieldDropdown.SEPARATOR) return option;
+      if (option === FieldDropdown.SEPARATOR) {
+        hasNonTextContent = true;
+        return option;
+      }
 
       const [label, value] = option;
       if (typeof label === 'string') {
         return [parsing.replaceMessageReferences(label), value];
       }
 
-      hasImages = true;
+      hasNonTextContent = true;
       // Copy the image properties so they're not influenced by the original.
       // NOTE: No need to deep copy since image properties are only 1 level deep.
       const imageLabel = isImageProperties(label)
         ? {...label, alt: parsing.replaceMessageReferences(label.alt)}
-        : {...label};
+        : label;
       return [imageLabel, value];
     });
 
-    if (hasImages || options.length < 2) return {options: trimmedOptions};
+    if (hasNonTextContent || options.length < 2) {
+      return {options: trimmedOptions};
+    }
 
     const stringOptions = trimmedOptions as [string, string][];
     const stringLabels = stringOptions.map(([label]) => label);
@@ -793,7 +798,7 @@ export class FieldDropdown extends Field<string> {
       } else if (typeof option[1] !== 'string') {
         foundError = true;
         console.error(
-          `Invalid option[${i}]: Each FieldDropdown option id must be a string. 
+          `Invalid option[${i}]: Each FieldDropdown option id must be a string.
           Found ${option[1]} in: ${option}`,
         );
       } else if (
@@ -806,7 +811,7 @@ export class FieldDropdown extends Field<string> {
       ) {
         foundError = true;
         console.error(
-          `Invalid option[${i}]: Each FieldDropdown option must have a string 
+          `Invalid option[${i}]: Each FieldDropdown option must have a string
           label, image description, or HTML element. Found ${option[0]} in: ${option}`,
         );
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9247

### Proposed Changes
This PR fixes `FieldDropdown` to not attempt to spread `HTMLElement` menu options, which caused later checks for `instanceof HTMLElement` to fail. This allows HTML elements to be properly displayed in dropdown fields. 