### PR TITLE
fix: Scroll `CommentBarButton`s into view on selection.

### DIFF
--- a/core/keyboard_nav/line_cursor.ts
+++ b/core/keyboard_nav/line_cursor.ts
@@ -14,6 +14,7 @@
  */
 
 import {BlockSvg} from '../block_svg.js';
+import {CommentBarButton} from '../comments/comment_bar_button.js';
 import {RenderedWorkspaceComment} from '../comments/rendered_workspace_comment.js';
 import {Field} from '../field.js';
 import {getFocusManager} from '../focus_manager.js';
@@ -403,6 +404,9 @@ export class LineCursor extends Marker {
       );
     } else if (newNode instanceof RenderedWorkspaceComment) {
       newNode.workspace.scrollBoundsIntoView(newNode.getBoundingRectangle());
+    } else if (newNode instanceof CommentBarButton) {
+      const comment = newNode.getParentComment();
+      comment.workspace.scrollBoundsIntoView(comment.getBoundingRectangle());
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/670

### Proposed Changes
This PR scrolls `CommentBarButton` instances into view when they are selected by the cursor.