### PR TITLE
feat: Add an option to copy subsequent blocks when getting copy data from a block.

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -951,9 +951,12 @@ export class BlockSvg
   /**
    * Encode a block for copying.
    *
+   * @param addNextBlocks If true, copy subsequent blocks attached to this one
+   *     as well.
+   *
    * @returns Copy metadata, or null if the block is an insertion marker.
    */
-  toCopyData(): BlockCopyData | null {
+  toCopyData(addNextBlocks = false): BlockCopyData | null {
     if (this.isInsertionMarker_) {
       return null;
     }
@@ -961,7 +964,7 @@ export class BlockSvg
       paster: BlockPaster.TYPE,
       blockState: blocks.save(this, {
         addCoordinates: true,
-        addNextBlocks: false,
+        addNextBlocks,
         saveIds: false,
       }) as blocks.State,
       typeCounts: common.getBlockTypeCounts(this, true),

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -61,6 +61,31 @@ suite('Clipboard', function () {
       );
     });
 
+    test('pasting blocks includes next blocks if requested', function () {
+      const block = Blockly.serialization.blocks.append(
+        {
+          'type': 'controls_if',
+          'id': 'blockId',
+          'next': {
+            'block': {
+              'type': 'controls_if',
+              'id': 'blockId2',
+            },
+          },
+        },
+        this.workspace,
+      );
+      assert.equal(this.workspace.getBlocksByType('controls_if').length, 2);
+      // Both blocks should be copied
+      const data = block.toCopyData(true);
+      this.clock.runAll();
+
+      Blockly.clipboard.paste(data, this.workspace);
+      this.clock.runAll();
+      // After pasting, we should have gone from 2 to 4 blocks.
+      assert.equal(this.workspace.getBlocksByType('controls_if').length, 4);
+    });
+
     test('copied from a mutator pastes them into the mutator', async function () {
       const block = Blockly.serialization.blocks.append(
         {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes part of https://github.com/gonfunko/scratch-blocks/issues/237. It adds an optional argument to `BlockSvg.toCopyData()` to specify whether subsequent/next blocks should be included in the returned copy data. 