### PR TITLE
feat: Add initial support for screen readers (experimental)

### DIFF
--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -1941,7 +1941,6 @@ export class BlockSvg
    * they need to be determined and announced using an ARIA live region
    * (see aria.announceDynamicAriaState).
    *
-   * @param block The block whose dynamic state should maybe be announced.
    * @param isMoving Whether the specified block is currently being moved.
    * @param isCanceled Whether the previous movement operation has been canceled.
    * @param newLoc The new location the block is moving to (if unconstrained).

--- a/core/block_svg.ts
+++ b/core/block_svg.ts
@@ -220,11 +220,13 @@ export class BlockSvg
 
     aria.setState(svgPath, aria.State.ROLEDESCRIPTION, 'block');
     aria.setRole(svgPath, aria.Role.TREEITEM);
-    this.recomputeAriaLabel();
     svgPath.tabIndex = -1;
     this.currentConnectionCandidate = null;
 
     this.doInit_();
+
+    // Note: This must be done after initialization of the block's fields.
+    this.recomputeAriaLabel();
   }
 
   private recomputeAriaLabel() {

--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -15,6 +15,7 @@ import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import {ISelectable} from '../interfaces/i_selectable.js';
 import {ContainerRegion} from '../metrics_manager.js';
 import {Scrollbar} from '../scrollbar.js';
+import * as aria from '../utils/aria.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
 import * as idGenerator from '../utils/idgenerator.js';
@@ -23,7 +24,6 @@ import {Rect} from '../utils/rect.js';
 import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
-import * as aria from '../utils/aria.js';
 
 /**
  * The abstract pop-up bubble class. This creates a UI that looks like a speech

--- a/core/bubbles/bubble.ts
+++ b/core/bubbles/bubble.ts
@@ -23,6 +23,7 @@ import {Rect} from '../utils/rect.js';
 import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
+import * as aria from '../utils/aria.js';
 
 /**
  * The abstract pop-up bubble class. This creates a UI that looks like a speech
@@ -142,6 +143,8 @@ export abstract class Bubble implements IBubble, ISelectable, IFocusableNode {
 
     this.focusableElement = overriddenFocusableElement ?? this.svgRoot;
     this.focusableElement.setAttribute('id', this.id);
+    aria.setRole(this.focusableElement, aria.Role.GROUP);
+    aria.setState(this.focusableElement, aria.State.LABEL, 'Bubble');
 
     browserEvents.conditionalBind(
       this.background,

--- a/core/comments/collapse_comment_bar_button.ts
+++ b/core/comments/collapse_comment_bar_button.ts
@@ -6,11 +6,11 @@
 
 import * as browserEvents from '../browser_events.js';
 import * as touch from '../touch.js';
+import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
 import {Svg} from '../utils/svg.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
 import {CommentBarButton} from './comment_bar_button.js';
-import * as aria from '../utils/aria.js';
 
 /**
  * Magic string appended to the comment ID to create a unique ID for this button.

--- a/core/comments/collapse_comment_bar_button.ts
+++ b/core/comments/collapse_comment_bar_button.ts
@@ -10,6 +10,7 @@ import * as dom from '../utils/dom.js';
 import {Svg} from '../utils/svg.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
 import {CommentBarButton} from './comment_bar_button.js';
+import * as aria from '../utils/aria.js';
 
 /**
  * Magic string appended to the comment ID to create a unique ID for this button.
@@ -67,6 +68,11 @@ export class CollapseCommentBarButton extends CommentBarButton {
    */
   dispose() {
     browserEvents.unbind(this.bindId);
+  }
+
+  override initAria(): void {
+    aria.setRole(this.icon, aria.Role.BUTTON);
+    aria.setState(this.icon, aria.State.LABEL, 'DoNotDefine?');
   }
 
   /**

--- a/core/comments/comment_bar_button.ts
+++ b/core/comments/comment_bar_button.ts
@@ -52,6 +52,8 @@ export abstract class CommentBarButton implements IFocusableNode {
     return comment;
   }
 
+  abstract initAria(): void;
+
   /** Adjusts the position of this button within its parent container. */
   abstract reposition(): void;
 

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -9,11 +9,11 @@ import {getFocusManager} from '../focus_manager.js';
 import {IFocusableNode} from '../interfaces/i_focusable_node.js';
 import {IFocusableTree} from '../interfaces/i_focusable_tree.js';
 import * as touch from '../touch.js';
+import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
 import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
-import * as aria from '../utils/aria.js';
 
 /**
  * String added to the ID of a workspace comment to identify

--- a/core/comments/comment_editor.ts
+++ b/core/comments/comment_editor.ts
@@ -13,6 +13,7 @@ import * as dom from '../utils/dom.js';
 import {Size} from '../utils/size.js';
 import {Svg} from '../utils/svg.js';
 import {WorkspaceSvg} from '../workspace_svg.js';
+import * as aria from '../utils/aria.js';
 
 /**
  * String added to the ID of a workspace comment to identify
@@ -54,6 +55,8 @@ export class CommentEditor implements IFocusableNode {
     ) as HTMLTextAreaElement;
     this.textArea.setAttribute('tabindex', '-1');
     this.textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
+    aria.setRole(this.textArea, aria.Role.TEXTBOX);
+    aria.setState(this.textArea, aria.State.LABEL, 'DoNotDefine?');
     dom.addClass(this.textArea, 'blocklyCommentText');
     dom.addClass(this.textArea, 'blocklyTextarea');
     dom.addClass(this.textArea, 'blocklyText');

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -10,6 +10,7 @@ import type {IFocusableNode} from '../interfaces/i_focusable_node';
 import {IRenderedElement} from '../interfaces/i_rendered_element.js';
 import * as layers from '../layers.js';
 import * as touch from '../touch.js';
+import * as aria from '../utils/aria.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
 import * as drag from '../utils/drag.js';
@@ -107,6 +108,9 @@ export class CommentView implements IRenderedElement {
     this.svgRoot = dom.createSvgElement(Svg.G, {
       'class': 'blocklyComment blocklyEditable blocklyDraggable',
     });
+
+    aria.setRole(this.svgRoot, aria.Role.TEXTBOX);
+    aria.setState(this.svgRoot, aria.State.LABEL, 'DoNotOverride?');
 
     this.highlightRect = this.createHighlightRect(this.svgRoot);
 

--- a/core/comments/delete_comment_bar_button.ts
+++ b/core/comments/delete_comment_bar_button.ts
@@ -11,6 +11,7 @@ import * as dom from '../utils/dom.js';
 import {Svg} from '../utils/svg.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
 import {CommentBarButton} from './comment_bar_button.js';
+import * as aria from '../utils/aria.js';
 
 /**
  * Magic string appended to the comment ID to create a unique ID for this button.
@@ -67,6 +68,11 @@ export class DeleteCommentBarButton extends CommentBarButton {
    */
   dispose() {
     browserEvents.unbind(this.bindId);
+  }
+
+  override initAria(): void {
+    aria.setRole(this.icon, aria.Role.BUTTON);
+    aria.setState(this.icon, aria.State.LABEL, 'DoNotDefine?');
   }
 
   /**

--- a/core/comments/delete_comment_bar_button.ts
+++ b/core/comments/delete_comment_bar_button.ts
@@ -7,11 +7,11 @@
 import * as browserEvents from '../browser_events.js';
 import {getFocusManager} from '../focus_manager.js';
 import * as touch from '../touch.js';
+import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
 import {Svg} from '../utils/svg.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
 import {CommentBarButton} from './comment_bar_button.js';
-import * as aria from '../utils/aria.js';
 
 /**
  * Magic string appended to the comment ID to create a unique ID for this button.

--- a/core/css.ts
+++ b/core/css.ts
@@ -507,4 +507,12 @@ input[type=number] {
 ) {
   outline: none;
 }
+
+#blocklyAriaAnnounce {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: px;
+  overflow: hidden;
+}
 `;

--- a/core/dragging/block_drag_strategy.ts
+++ b/core/dragging/block_drag_strategy.ts
@@ -50,7 +50,7 @@ export class BlockDragStrategy implements IDragStrategy {
 
   private startLoc: Coordinate | null = null;
 
-  private connectionCandidate: ConnectionCandidate | null = null;
+  public connectionCandidate: ConnectionCandidate | null = null;
 
   private connectionPreviewer: IConnectionPreviewer | null = null;
 

--- a/core/field.ts
+++ b/core/field.ts
@@ -31,6 +31,7 @@ import {ISerializable} from './interfaces/i_serializable.js';
 import type {ConstantProvider} from './renderers/common/constants.js';
 import type {KeyboardShortcut} from './shortcut_registry.js';
 import * as Tooltip from './tooltip.js';
+import * as aria from './utils/aria.js';
 import type {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import * as idGenerator from './utils/idgenerator.js';
@@ -403,6 +404,7 @@ export abstract class Field<T = any>
     }
     this.textContent_ = document.createTextNode('');
     this.textElement_.appendChild(this.textContent_);
+    aria.setState(this.textElement_, aria.State.HIDDEN, true);
   }
 
   /**

--- a/core/field_checkbox.ts
+++ b/core/field_checkbox.ts
@@ -16,6 +16,7 @@ import './events/events_block_change.js';
 
 import {Field, FieldConfig, FieldValidator} from './field.js';
 import * as fieldRegistry from './field_registry.js';
+import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
 
 type BoolString = 'TRUE' | 'FALSE';
@@ -111,6 +112,14 @@ export class FieldCheckbox extends Field<CheckboxBool> {
     const textElement = this.getTextElement();
     dom.addClass(this.fieldGroup_!, 'blocklyCheckboxField');
     textElement.style.display = this.value_ ? 'block' : 'none';
+
+    const element = this.getFocusableElement();
+    aria.setRole(element, aria.Role.CHECKBOX);
+    aria.setState(
+      element,
+      aria.State.LABEL,
+      this.name ? `Checkbox ${this.name}` : 'Checkbox',
+    );
   }
 
   override render_() {

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -196,6 +196,14 @@ export class FieldDropdown extends Field<string> {
       dom.addClass(this.fieldGroup_, 'blocklyField');
       dom.addClass(this.fieldGroup_, 'blocklyDropdownField');
     }
+
+    const element = this.getFocusableElement();
+    aria.setRole(element, aria.Role.LISTBOX);
+    aria.setState(
+      element,
+      aria.State.LABEL,
+      this.name ? `Item ${this.name}` : 'Item',
+    );
   }
 
   /**

--- a/core/field_image.ts
+++ b/core/field_image.ts
@@ -13,6 +13,7 @@
 
 import {Field, FieldConfig} from './field.js';
 import * as fieldRegistry from './field_registry.js';
+import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
 import * as parsing from './utils/parsing.js';
 import {Size} from './utils/size.js';
@@ -157,6 +158,14 @@ export class FieldImage extends Field<string> {
     if (this.clickHandler) {
       this.imageElement.style.cursor = 'pointer';
     }
+
+    const element = this.getFocusableElement();
+    aria.setRole(element, aria.Role.IMAGE);
+    aria.setState(
+      element,
+      aria.State.LABEL,
+      this.name ? `Image ${this.name}` : 'Image',
+    );
   }
 
   override updateSize_() {}

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -172,6 +172,14 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     if (this.fieldGroup_) {
       dom.addClass(this.fieldGroup_, 'blocklyInputField');
     }
+
+    const element = this.getFocusableElement();
+    aria.setRole(element, aria.Role.TEXTBOX);
+    aria.setState(
+      element,
+      aria.State.LABEL,
+      this.name ? `Text ${this.name}` : 'Text',
+    );
   }
 
   override isFullBlockField(): boolean {

--- a/core/field_label.ts
+++ b/core/field_label.ts
@@ -14,6 +14,7 @@
 
 import {Field, FieldConfig} from './field.js';
 import * as fieldRegistry from './field_registry.js';
+import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
 import * as parsing from './utils/parsing.js';
 
@@ -77,6 +78,12 @@ export class FieldLabel extends Field<string> {
     if (this.fieldGroup_) {
       dom.addClass(this.fieldGroup_, 'blocklyLabelField');
     }
+
+    this.recomputeAriaLabel();
+  }
+
+  private recomputeAriaLabel() {
+    aria.setState(this.getFocusableElement(), aria.State.LABEL, this.getText());
   }
 
   /**
@@ -109,6 +116,13 @@ export class FieldLabel extends Field<string> {
       }
     }
     this.class = cssClass;
+  }
+
+  override setValue(newValue: any, fireChangeEvent?: boolean): void {
+    super.setValue(newValue, fireChangeEvent);
+    if (this.fieldGroup_) {
+      this.recomputeAriaLabel();
+    }
   }
 
   /**

--- a/core/flyout_button.ts
+++ b/core/flyout_button.ts
@@ -18,6 +18,7 @@ import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import type {IFocusableTree} from './interfaces/i_focusable_tree.js';
 import type {IRenderedElement} from './interfaces/i_rendered_element.js';
 import {idGenerator} from './utils.js';
+import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import * as parsing from './utils/parsing.js';
@@ -116,6 +117,9 @@ export class FlyoutButton
       {'id': this.id, 'class': cssClass},
       this.workspace.getCanvas(),
     );
+
+    aria.setRole(this.svgGroup, aria.Role.BUTTON);
+    aria.setState(this.svgGroup, aria.State.LABEL, 'Button');
 
     let shadow;
     if (!this.isFlyoutLabel) {

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -15,6 +15,7 @@ import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import type {ISerializable} from '../interfaces/i_serializable.js';
 import * as renderManagement from '../render_management.js';
 import {Coordinate} from '../utils.js';
+import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
 import {Rect} from '../utils/rect.js';
 import {Size} from '../utils/size.js';
@@ -112,6 +113,16 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
       this.svgRoot,
     );
     dom.addClass(this.svgRoot!, 'blocklyCommentIcon');
+
+    this.recomputeAriaLabel();
+  }
+
+  private recomputeAriaLabel() {
+    aria.setState(
+      this.svgRoot!,
+      aria.State.LABEL,
+      this.bubbleIsVisible() ? 'Close Comment' : 'Open Comment',
+    );
   }
 
   override dispose() {
@@ -336,6 +347,8 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
         'comment',
       ),
     );
+
+    this.recomputeAriaLabel();
   }
 
   /** See IHasBubble.getBubble. */

--- a/core/icons/comment_icon.ts
+++ b/core/icons/comment_icon.ts
@@ -118,11 +118,13 @@ export class CommentIcon extends Icon implements IHasBubble, ISerializable {
   }
 
   private recomputeAriaLabel() {
-    aria.setState(
-      this.svgRoot!,
-      aria.State.LABEL,
-      this.bubbleIsVisible() ? 'Close Comment' : 'Open Comment',
-    );
+    if (this.svgRoot) {
+      aria.setState(
+        this.svgRoot,
+        aria.State.LABEL,
+        this.bubbleIsVisible() ? 'Close Comment' : 'Open Comment',
+      );
+    }
   }
 
   override dispose() {

--- a/core/icons/icon.ts
+++ b/core/icons/icon.ts
@@ -11,6 +11,7 @@ import type {IFocusableTree} from '../interfaces/i_focusable_tree.js';
 import {hasBubble} from '../interfaces/i_has_bubble.js';
 import type {IIcon} from '../interfaces/i_icon.js';
 import * as tooltip from '../tooltip.js';
+import * as aria from '../utils/aria.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
 import * as idGenerator from '../utils/idgenerator.js';
@@ -71,6 +72,9 @@ export abstract class Icon implements IIcon {
     );
     (this.svgRoot as any).tooltip = this;
     tooltip.bindMouseEvents(this.svgRoot);
+
+    aria.setRole(this.svgRoot, aria.Role.FIGURE);
+    aria.setState(this.svgRoot, aria.State.LABEL, 'Icon');
   }
 
   dispose(): void {

--- a/core/icons/mutator_icon.ts
+++ b/core/icons/mutator_icon.ts
@@ -16,6 +16,7 @@ import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import * as renderManagement from '../render_management.js';
+import * as aria from '../utils/aria.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
 import {Rect} from '../utils/rect.js';
@@ -119,6 +120,16 @@ export class MutatorIcon extends Icon implements IHasBubble {
       this.svgRoot,
     );
     dom.addClass(this.svgRoot!, 'blocklyMutatorIcon');
+
+    this.recomputeAriaLabel();
+  }
+
+  private recomputeAriaLabel() {
+    aria.setState(
+      this.svgRoot!,
+      aria.State.LABEL,
+      this.bubbleIsVisible() ? 'Close Mutator' : 'Open Mutator',
+    );
   }
 
   override dispose(): void {
@@ -201,6 +212,8 @@ export class MutatorIcon extends Icon implements IHasBubble {
         'mutator',
       ),
     );
+
+    this.recomputeAriaLabel();
   }
 
   /** See IHasBubble.getBubble. */

--- a/core/icons/warning_icon.ts
+++ b/core/icons/warning_icon.ts
@@ -14,6 +14,7 @@ import type {IBubble} from '../interfaces/i_bubble.js';
 import type {IHasBubble} from '../interfaces/i_has_bubble.js';
 import * as renderManagement from '../render_management.js';
 import {Size} from '../utils.js';
+import * as aria from '../utils/aria.js';
 import {Coordinate} from '../utils/coordinate.js';
 import * as dom from '../utils/dom.js';
 import {Rect} from '../utils/rect.js';
@@ -92,6 +93,16 @@ export class WarningIcon extends Icon implements IHasBubble {
       this.svgRoot,
     );
     dom.addClass(this.svgRoot!, 'blocklyWarningIcon');
+
+    this.recomputeAriaLabel();
+  }
+
+  private recomputeAriaLabel() {
+    aria.setState(
+      this.svgRoot!,
+      aria.State.LABEL,
+      this.bubbleIsVisible() ? 'Close Warning' : 'Open Warning',
+    );
   }
 
   override dispose() {
@@ -196,6 +207,8 @@ export class WarningIcon extends Icon implements IHasBubble {
         'warning',
       ),
     );
+
+    this.recomputeAriaLabel();
   }
 
   /** See IHasBubble.getBubble. */

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -17,6 +17,7 @@ import {Options} from './options.js';
 import {ScrollbarPair} from './scrollbar_pair.js';
 import * as Tooltip from './tooltip.js';
 import * as Touch from './touch.js';
+import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
 import {Svg} from './utils/svg.js';
 import * as WidgetDiv from './widgetdiv.js';
@@ -53,6 +54,12 @@ export function inject(
   if (opt_options?.rtl) {
     dom.addClass(subContainer, 'blocklyRTL');
   }
+
+  // See: https://stackoverflow.com/a/48590836 for a reference.
+  const ariaAnnouncementSpan = document.createElement('span');
+  ariaAnnouncementSpan.id = 'blocklyAriaAnnounce';
+  aria.setState(ariaAnnouncementSpan, aria.State.LIVE, 'polite');
+  subContainer.appendChild(ariaAnnouncementSpan);
 
   containerElement!.appendChild(subContainer);
   const svg = createDom(subContainer, options);

--- a/core/inject.ts
+++ b/core/inject.ts
@@ -55,12 +55,6 @@ export function inject(
     dom.addClass(subContainer, 'blocklyRTL');
   }
 
-  // See: https://stackoverflow.com/a/48590836 for a reference.
-  const ariaAnnouncementSpan = document.createElement('span');
-  ariaAnnouncementSpan.id = 'blocklyAriaAnnounce';
-  aria.setState(ariaAnnouncementSpan, aria.State.LIVE, 'polite');
-  subContainer.appendChild(ariaAnnouncementSpan);
-
   containerElement!.appendChild(subContainer);
   const svg = createDom(subContainer, options);
 
@@ -84,6 +78,12 @@ export function inject(
     null,
     common.globalShortcutHandler,
   );
+
+  // See: https://stackoverflow.com/a/48590836 for a reference.
+  const ariaAnnouncementSpan = document.createElement('span');
+  ariaAnnouncementSpan.id = 'blocklyAriaAnnounce';
+  aria.setState(ariaAnnouncementSpan, aria.State.LIVE, 'polite');
+  subContainer.appendChild(ariaAnnouncementSpan);
 
   return workspace;
 }

--- a/core/rendered_connection.ts
+++ b/core/rendered_connection.ts
@@ -25,6 +25,7 @@ import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import type {IFocusableTree} from './interfaces/i_focusable_tree.js';
 import {hasBubble} from './interfaces/i_has_bubble.js';
 import * as internalConstants from './internal_constants.js';
+import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as svgMath from './utils/svg_math.js';
 import {WorkspaceSvg} from './workspace_svg.js';
@@ -332,6 +333,8 @@ export class RenderedConnection
     const highlightSvg = this.findHighlightSvg();
     if (highlightSvg) {
       highlightSvg.style.display = '';
+      aria.setRole(highlightSvg, aria.Role.FIGURE);
+      aria.setState(highlightSvg, aria.State.LABEL, 'Open connection');
     }
   }
 

--- a/core/toolbox/category.ts
+++ b/core/toolbox/category.ts
@@ -30,6 +30,7 @@ import type {
   StaticCategoryInfo,
 } from '../utils/toolbox.js';
 import * as toolbox from '../utils/toolbox.js';
+import {Toolbox} from './toolbox.js';
 import {ToolboxItem} from './toolbox_item.js';
 
 /**
@@ -192,6 +193,7 @@ export class ToolboxCategory
     aria.setRole(this.htmlDiv_, aria.Role.TREEITEM);
     aria.setState(this.htmlDiv_, aria.State.SELECTED, false);
     aria.setState(this.htmlDiv_, aria.State.LEVEL, this.level_ + 1);
+    (this.parentToolbox_ as Toolbox).recomputeAriaOwners();
 
     this.rowDiv_ = this.createRowContainer_();
     this.rowDiv_.style.pointerEvents = 'auto';

--- a/core/toolbox/collapsible_category.ts
+++ b/core/toolbox/collapsible_category.ts
@@ -20,6 +20,7 @@ import * as dom from '../utils/dom.js';
 import * as toolbox from '../utils/toolbox.js';
 import {ToolboxCategory} from './category.js';
 import {ToolboxSeparator} from './separator.js';
+import {Toolbox} from './toolbox.js';
 
 /**
  * Class for a category in a toolbox that can be collapsed.
@@ -132,10 +133,24 @@ export class CollapsibleToolboxCategory
 
     const subCategories = this.getChildToolboxItems();
     this.subcategoriesDiv_ = this.createSubCategoriesDom_(subCategories);
-    aria.setRole(this.subcategoriesDiv_, aria.Role.GROUP);
     this.htmlDiv_!.appendChild(this.subcategoriesDiv_);
     this.closeIcon_(this.iconDom_);
     aria.setState(this.htmlDiv_ as HTMLDivElement, aria.State.EXPANDED, false);
+
+    aria.setRole(this.htmlDiv_!, aria.Role.GROUP);
+
+    // Ensure this group has properly set children.
+    const selectableChildren =
+      this.getChildToolboxItems().filter((item) => item.isSelectable()) ?? null;
+    const focusableChildIds = selectableChildren.map(
+      (selectable) => selectable.getFocusableElement().id,
+    );
+    aria.setState(
+      this.htmlDiv_!,
+      aria.State.OWNS,
+      [...new Set(focusableChildIds)].join(' '),
+    );
+    (this.parentToolbox_ as Toolbox).recomputeAriaOwners();
 
     return this.htmlDiv_!;
   }

--- a/core/toolbox/separator.ts
+++ b/core/toolbox/separator.ts
@@ -14,8 +14,10 @@
 import * as Css from '../css.js';
 import type {IToolbox} from '../interfaces/i_toolbox.js';
 import * as registry from '../registry.js';
+import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
 import type * as toolbox from '../utils/toolbox.js';
+import {Toolbox} from './toolbox.js';
 import {ToolboxItem} from './toolbox_item.js';
 
 /**
@@ -63,6 +65,10 @@ export class ToolboxSeparator extends ToolboxItem {
       dom.addClass(container, className);
     }
     this.htmlDiv = container;
+
+    aria.setRole(this.htmlDiv, aria.Role.SEPARATOR);
+    (this.parentToolbox_ as Toolbox).recomputeAriaOwners();
+
     return container;
   }
 

--- a/core/utils/aria.ts
+++ b/core/utils/aria.ts
@@ -17,11 +17,6 @@ const ROLE_ATTRIBUTE = 'role';
  * Copied from Closure's goog.a11y.aria.Role
  */
 export enum Role {
-  // ARIA role for an interactive control of tabular data.
-  GRID = 'grid',
-
-  // ARIA role for a cell in a grid.
-  GRIDCELL = 'gridcell',
   // ARIA role for a group of related elements like tree item siblings.
   GROUP = 'group',
 
@@ -33,16 +28,12 @@ export enum Role {
 
   // ARIA role for menu item elements.
   MENUITEM = 'menuitem',
-  // ARIA role for a checkbox box element inside a menu.
-  MENUITEMCHECKBOX = 'menuitemcheckbox',
   // ARIA role for option items that are  children of combobox, listbox, menu,
   // radiogroup, or tree elements.
   OPTION = 'option',
   // ARIA role for ignorable cosmetic elements with no semantic significance.
   PRESENTATION = 'presentation',
 
-  // ARIA role for a row of cells in a grid.
-  ROW = 'row',
   // ARIA role for a tree.
   TREE = 'tree',
 
@@ -54,6 +45,12 @@ export enum Role {
 
   // ARIA role for a live region providing information.
   STATUS = 'status',
+
+  IMAGE = 'image',
+  FIGURE = 'figure',
+  BUTTON = 'button',
+  CHECKBOX = 'checkbox',
+  TEXTBOX = 'textbox',
 }
 
 /**
@@ -64,10 +61,6 @@ export enum State {
   // ARIA property for setting the currently active descendant of an element,
   // for example the selected item in a list box. Value: ID of an element.
   ACTIVEDESCENDANT = 'activedescendant',
-  // ARIA property defines the total number of columns in a table, grid, or
-  // treegrid.
-  // Value: integer.
-  COLCOUNT = 'colcount',
   // ARIA state for a disabled item. Value: one of {true, false}.
   DISABLED = 'disabled',
 
@@ -89,18 +82,10 @@ export enum State {
   // ARIA property for setting the level of an element in the hierarchy.
   // Value: integer.
   LEVEL = 'level',
-  // ARIA property indicating if the element is horizontal or vertical.
-  // Value: one of {'vertical', 'horizontal'}.
-  ORIENTATION = 'orientation',
 
   // ARIA property that defines an element's number of position in a list.
   // Value: integer.
   POSINSET = 'posinset',
-
-  // ARIA property defines the total number of rows in a table, grid, or
-  // treegrid.
-  // Value: integer.
-  ROWCOUNT = 'rowcount',
 
   // ARIA state for setting the currently selected item in the list.
   // Value: one of {true, false, undefined}.
@@ -121,29 +106,52 @@ export enum State {
   // ARIA property for removing elements from the accessibility tree.
   // Value: one of {true, false, undefined}.
   HIDDEN = 'hidden',
+
+  ROLEDESCRIPTION = 'roledescription',
+  OWNS = 'owns',
 }
 
 /**
- * Sets the role of an element.
+ * Updates the specific role for the specified element.
  *
- * Similar to Closure's goog.a11y.aria
- *
- * @param element DOM node to set role of.
- * @param roleName Role name.
+ * @param element The element whose ARIA role should be changed.
+ * @param roleName The new role for the specified element, or null if its role
+ *     should be cleared.
  */
-export function setRole(element: Element, roleName: Role) {
-  element.setAttribute(ROLE_ATTRIBUTE, roleName);
+export function setRole(element: Element, roleName: Role | null) {
+  if (roleName) {
+    element.setAttribute(ROLE_ATTRIBUTE, roleName);
+  } else element.removeAttribute(ROLE_ATTRIBUTE);
 }
 
 /**
- * Sets the state or property of an element.
- * Copied from Closure's goog.a11y.aria
+ * Returns the ARIA role of the specified element, or null if it either doesn't
+ * have a designated role or if that role is unknown.
  *
- * @param element DOM node where we set state.
- * @param stateName State attribute being set.
- *     Automatically adds prefix 'aria-' to the state name if the attribute is
- * not an extra attribute.
- * @param value Value for the state attribute.
+ * @param element The element from which to retrieve its ARIA role.
+ * @returns The ARIA role of the element, or null if undefined or unknown.
+ */
+export function getRole(element: Element): Role | null {
+  // This is an unsafe cast which is why it needs to be checked to ensure that
+  // it references a valid role.
+  const currentRoleName = element.getAttribute(ROLE_ATTRIBUTE) as Role;
+  if (Object.values(Role).includes(currentRoleName)) {
+    return currentRoleName;
+  }
+  return null;
+}
+
+/**
+ * Sets the specified ARIA state by its name and value for the specified
+ * element.
+ *
+ * Note that the type of value is not validated against the specific type of
+ * state being changed, so it's up to callers to ensure the correct value is
+ * used for the given state.
+ *
+ * @param element The element whose ARIA state may be changed.
+ * @param stateName The state to change.
+ * @param value The new value to specify for the provided state.
  */
 export function setState(
   element: Element,
@@ -155,4 +163,45 @@ export function setState(
   }
   const attrStateName = ARIA_PREFIX + stateName;
   element.setAttribute(attrStateName, `${value}`);
+}
+
+/**
+ * Returns a string representation of the specified state for the specified
+ * element, or null if it's not defined or specified.
+ *
+ * Note that an explicit set state of 'null' will return the 'null' string, not
+ * the value null.
+ *
+ * @param element The element whose state is being retrieved.
+ * @param stateName The state to retrieve.
+ * @returns The string representation of the requested state for the specified
+ *     element, or null if not defined.
+ */
+export function getState(element: Element, stateName: State): string | null {
+  const attrStateName = ARIA_PREFIX + stateName;
+  return element.getAttribute(attrStateName);
+}
+
+/**
+ * Softly requests that the specified text be read to the user if a screen
+ * reader is currently active.
+ *
+ * This relies on a centrally managed ARIA live region that should not interrupt
+ * existing announcements (that is, this is what's considered a polite
+ * announcement).
+ *
+ * Callers should use this judiciously. It's often considered bad practice to
+ * over announce information that can be inferred from other sources on the
+ * page, so this ought to only be used when certain context cannot be easily
+ * determined (such as dynamic states that may not have perfect ARIA
+ * representations or indications).
+ *
+ * @param text The text to politely read to the user.
+ */
+export function announceDynamicAriaState(text: string) {
+  const ariaAnnouncementSpan = document.getElementById('blocklyAriaAnnounce');
+  if (!ariaAnnouncementSpan) {
+    throw new Error('Expected element with id blocklyAriaAnnounce to exist.');
+  }
+  ariaAnnouncementSpan.innerHTML = text;
 }

--- a/core/utils/dom.ts
+++ b/core/utils/dom.ts
@@ -6,7 +6,8 @@
 
 // Former goog.module ID: Blockly.utils.dom
 
-import type {Svg} from './svg.js';
+import * as aria from './aria.js';
+import {Svg} from './svg.js';
 
 /**
  * Required name space for SVG elements.
@@ -61,6 +62,9 @@ export function createSvgElement<T extends SVGElement>(
   }
   if (opt_parent) {
     opt_parent.appendChild(e);
+  }
+  if (name === Svg.SVG || name === Svg.G) {
+    aria.setRole(e, aria.Role.PRESENTATION);
   }
   return e;
 }

--- a/core/workspace_svg.ts
+++ b/core/workspace_svg.ts
@@ -773,7 +773,9 @@ export class WorkspaceSvg
     } else if (this.isMutator) {
       ariaLabel = 'Mutator';
     } else {
-      throw new Error('Cannot determine ARIA label for workspace.');
+      // This case can happen in some test scenarios.
+      // TODO: Figure out when this can happen in non-test scenarios (if ever).
+      ariaLabel = 'Workspace';
     }
     aria.setState(this.svgGroup_, aria.State.LABEL, ariaLabel);
     aria.setRole(this.svgGroup_, aria.Role.TREE);


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes part of #8207
Fixes part of #3370

### Proposed Changes

This introduces initial broad ARIA integration in order to enable at least basic screen reader support when using keyboard navigation.

Largely this involves introducing ARIA roles and labels in a bunch of places, sometimes done in a way to override normal built-in behaviors of the accessibility node tree in order to get a richer first-class output for Blockly (such as for blocks and workspaces).

### Reason for Changes

ARIA is the fundamental basis for configuring how focusable nodes in Blockly are represented to the user when using a screen reader. As such, all focusable nodes requires labels and roles in order to correctly communicate their contexts.

The specific approach taken in this PR is to simply add labels and roles to all nodes where obvious with some extra work done for `WorkspaceSvg` and `BlockSvg` in order to represent blocks as a tree (since that seems to be the best fitting ARIA role per those available: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles). The custom work specifically for blocks includes:
- Overriding the role description to be 'block' rather than 'tree item' (which is the default).
- Overriding the position, level, and number of sibling counts since those are normally determined based on the DOM tree and blocks are not laid out in the tree the same way they are visually or logically (so these computations were incorrect). This is also the reason for a bunch of extra computation logic being introduced.

One note on some of the labels being nonsensical (e.g. 'DoNotOverride?'): this was done intentionally to try and ensure _all_ focusable nodes (that can be focused) have labels, even when the specifics of what that label should be aren't yet clear. More components had these temporary labels until testing revealed how exactly they would behave from a screen reader perspective (at which point their roles and labels were updated as needed). The temporary labels act as an indicator when navigating through the UI, and some of the nodes can't easily be reached (for reasons) and thus may never actually need a label. More work is needed in understanding both what components need labels and what those labels should be, but that will be done beyond this PR.

### Test Coverage

No tests are added to this as it's experimental and not a final implementation.

The keyboard navigation tests are failing due to a visibility expansion of `connectionCandidate` in `BlockDragStrategy`. There's no way to avoid this breakage, unfortunately. Instead, this PR will be merged and then https://github.com/google/blockly-keyboard-experimentation/pull/684 will be finalized and merged to fix it. There's some additional work that will happen both in that branch and in a later PR in core Blockly to integrate the two experimentation branches as part of #9283 so that CI passes correctly for both branches.

### Documentation

No documentation is needed at this time.

### Additional Information

This work is experimental and is meant to serve two purposes:
- Provide a foundation for testing and iterating the core screen reader experience in Blockly.
- Provide a reference point for designing a long-term solution that accounts for all requirements collected during user testing.

This code should never be merged into `develop` as it stands. Instead, it will be redesigned with maintainability, testing, and correctness in mind at a future date (see https://github.com/google/blockly-keyboard-experimentation/discussions/673).