### PR TITLE
fix: Drag immovable and shadow blocks along with their parent.

### DIFF
--- a/core/block.ts
+++ b/core/block.ts
@@ -501,22 +501,32 @@ export class Block {
       // Detach this block from the parent's tree.
       this.previousConnection.disconnect();
     }
-    const nextBlock = this.getNextBlock();
-    if (opt_healStack && nextBlock && !nextBlock.isShadow()) {
-      // Disconnect the next statement.
-      const nextTarget = this.nextConnection?.targetConnection ?? null;
-      nextTarget?.disconnect();
-      if (
-        previousTarget &&
-        this.workspace.connectionChecker.canConnect(
-          previousTarget,
-          nextTarget,
-          false,
-        )
-      ) {
-        // Attach the next statement to the previous statement.
-        previousTarget.connect(nextTarget!);
-      }
+
+    if (!opt_healStack) return;
+
+    // Immovable or shadow next blocks need to move along with the block; keep
+    // going until we encounter a normal block or run off the end of the stack.
+    let nextBlock = this.getNextBlock();
+    while (nextBlock && (nextBlock.isShadow() || !nextBlock.isMovable())) {
+      nextBlock = nextBlock.getNextBlock();
+    }
+    if (!nextBlock) return;
+
+    // Disconnect the next statement.
+    const nextTarget =
+      nextBlock.previousConnection?.targetBlock()?.nextConnection
+        ?.targetConnection ?? null;
+    nextTarget?.disconnect();
+    if (
+      previousTarget &&
+      this.workspace.connectionChecker.canConnect(
+        previousTarget,
+        nextTarget,
+        false,
+      )
+    ) {
+      // Attach the next statement to the previous statement.
+      previousTarget.connect(nextTarget!);
     }
   }
 

--- a/tests/mocha/block_test.js
+++ b/tests/mocha/block_test.js
@@ -201,6 +201,35 @@ suite('Blocks', function () {
 
         assertUnpluggedHealFailed(blocks);
       });
+      test('Disconnect top of stack with immovable sibling', function () {
+        this.blocks.B.setMovable(false);
+        this.blocks.A.unplug(true);
+        assert.equal(this.blocks.A.nextConnection.targetBlock(), this.blocks.B);
+        assert.isNull(this.blocks.B.nextConnection.targetBlock());
+        assert.isNull(this.blocks.C.previousConnection.targetBlock());
+      });
+      test('Heal with immovable sibling mid-stack', function () {
+        const blockD = this.workspace.newBlock('stack_block', 'd');
+        this.blocks.C.nextConnection.connect(blockD.previousConnection);
+        this.blocks.C.setMovable(false);
+        this.blocks.B.unplug(true);
+        assert.equal(this.blocks.A.nextConnection.targetBlock(), blockD);
+        assert.equal(this.blocks.B.nextConnection.targetBlock(), this.blocks.C);
+        assert.isNull(this.blocks.C.nextConnection.targetBlock());
+      });
+      test('Heal with immovable sibling and shadow sibling mid-stack', function () {
+        const blockD = this.workspace.newBlock('stack_block', 'd');
+        const blockE = this.workspace.newBlock('stack_block', 'e');
+        this.blocks.C.nextConnection.connect(blockD.previousConnection);
+        blockD.nextConnection.connect(blockE.previousConnection);
+        this.blocks.C.setMovable(false);
+        blockD.setShadow(true);
+        this.blocks.B.unplug(true);
+        assert.equal(this.blocks.A.nextConnection.targetBlock(), blockE);
+        assert.equal(this.blocks.B.nextConnection.targetBlock(), this.blocks.C);
+        assert.equal(this.blocks.C.nextConnection.targetBlock(), blockD);
+        assert.isNull(blockD.nextConnection.targetBlock());
+      });
       test('Child is shadow', function () {
         const blocks = this.blocks;
         blocks.C.setShadow(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/678

### Proposed Changes
This PR fixes a bug that could cause a dragged block to disconnect from its immovable/shadow next sibling(s), rather than bring them along for the ride. This could happen in core while holding command/control to drag a single block vs the entire stack, and in the keyboard experiment repo when entering move mode for a block with such siblings. Now, in single-block-drag or keyboard-experiment move mode, moving a "single" block will bring along all contiguous subsequent siblings that are immovable or shadows, and, if stack healing is on, connect the previous block and the first normal next-sibling around the group of blocks that was detached.