### PR TITLE
refactor: Make `InsertionMarkerPreviewer`'s block serialization amenable to subclassing.

### DIFF
--- a/core/insertion_marker_previewer.ts
+++ b/core/insertion_marker_previewer.ts
@@ -150,8 +150,17 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
     return markerConn;
   }
 
-  private createInsertionMarker(origBlock: BlockSvg) {
-    const blockJson = blocks.save(origBlock, {
+  /**
+   * Transforms the given block into a JSON representation used to construct an
+   * insertion marker.
+   *
+   * @param block The block to serialize and use as an insertion marker.
+   * @returns A JSON-formatted string corresponding to a serialized
+   *     representation of the given block suitable for use as an insertion
+   *     marker.
+   */
+  protected serializeBlockToInsertionMarker(block: BlockSvg) {
+    const blockJson = blocks.save(block, {
       addCoordinates: false,
       addInputBlocks: false,
       addNextBlocks: false,
@@ -160,10 +169,15 @@ export class InsertionMarkerPreviewer implements IConnectionPreviewer {
 
     if (!blockJson) {
       throw new Error(
-        `Failed to serialize source block. ${origBlock.toDevString()}`,
+        `Failed to serialize source block. ${block.toDevString()}`,
       );
     }
 
+    return blockJson;
+  }
+
+  private createInsertionMarker(origBlock: BlockSvg) {
+    const blockJson = this.serializeBlockToInsertionMarker(origBlock);
     const result = blocks.append(blockJson, this.workspace) as BlockSvg;
 
     // Turn shadow blocks that are created programmatically during


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of https://github.com/gonfunko/scratch-blocks/issues/193

### Proposed Changes
This PR refactors `InsertionMarkerPreviewer` to make the serialization of a block to JSON for use as an insertion marker overridable in a subclass. Previously, this was done in a private method which also did various other setup tasks. This meant that subclasses could not practically change the configuration options passed to `serialization.blocks.save()`, whereas they can now override the new `serializeBlockToInsertionMarker()` method to do so.