### PR TITLE
fix: Keyboard nav CI workflows by pointing to experimentation branch (experimental)

### DIFF
--- a/.github/workflows/keyboard_plugin_test.yml
+++ b/.github/workflows/keyboard_plugin_test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches:
-      - develop
+      - add-screen-reader-support-experimental
 
 permissions:
   contents: read
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly-keyboard-experimentation'
-          ref: 'main'
+          ref: 'add-screen-reader-support-experimental'
           path: blockly-keyboard-experimentation
 
       - name: Use Node.js 20.x


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9283

### Proposed Changes

Updates the keyboard navigation plugin workflow to point to the screen reader experimentation branch.

### Reason for Changes

This ensures that both the plugin (via https://github.com/google/blockly-keyboard-experimentation/pull/684) and core Blockly correctly link their experimental screen reader branches against each other to ensure CI passes correctly for both.

### Test Coverage

No new tests are needed here.

### Documentation

N/A

### Additional Information

Similar to #9280, this PR will never be merged directly into `develop` so the workflow changes will remain isolated to the experimental branch.