### PR TITLE
fix: Allow reregistering fields.

### DIFF
--- a/core/field_registry.ts
+++ b/core/field_registry.ts
@@ -56,11 +56,11 @@ export interface RegistrableField {
  * @param type The field type name as used in the JSON definition.
  * @param fieldClass The field class containing a fromJson function that can
  *     construct an instance of the field.
- * @throws {Error} if the type name is empty, the field is already registered,
- *     or the fieldClass is not an object containing a fromJson function.
+ * @throws {Error} if the type name is empty or the fieldClass is not an object
+ *     containing a fromJson function.
  */
 export function register(type: string, fieldClass: RegistrableField) {
-  registry.register(registry.Type.FIELD, type, fieldClass);
+  registry.register(registry.Type.FIELD, type, fieldClass, true);
 }
 
 /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2587

### Proposed Changes
This PR updates field registration to not throw if a field is registered twice. This behavior is optional on the main registry, but is not exposed on the field registry. I considered making it optional here as well and propagating that value through, but I can't think of a reasonable case where, when you register a field, you want it to throw. I assume this was done to warn in case of accidental conflicts, but throwing seems aggressive for that vs a `console.log()`, and in the case of fields in particular where e.g. a field might be subclassed with the subclasses distributed as packages with no knowledge of each other, the registration code may not even be aware that it would need to allow re-registration.