### PR TITLE
fix: Fix bug that caused inadvertent scrolling when the `WidgetDiv` was shown.

### DIFF
--- a/core/focus_manager.ts
+++ b/core/focus_manager.ts
@@ -309,6 +309,8 @@ export class FocusManager {
    * Note that this may update the specified node's element's tabindex to ensure
    * that it can be properly read out by screenreaders while focused.
    *
+   * The focused node will not be automatically scrolled into view.
+   *
    * @param focusableNode The node that should receive active focus.
    */
   focusNode(focusableNode: IFocusableNode): void {
@@ -423,6 +425,8 @@ export class FocusManager {
    * the returned lambda is called. Additionally, only 1 ephemeral focus context
    * can be active at any given time (attempting to activate more than one
    * simultaneously will result in an error being thrown).
+   *
+   * This method does not scroll the ephemerally focused node into view.
    */
   takeEphemeralFocus(
     focusableElement: HTMLElement | SVGElement,
@@ -439,7 +443,7 @@ export class FocusManager {
     if (this.focusedNode) {
       this.passivelyFocusNode(this.focusedNode, null);
     }
-    focusableElement.focus();
+    focusableElement.focus({preventScroll: true});
 
     let hasFinishedEphemeralFocus = false;
     return () => {
@@ -574,7 +578,7 @@ export class FocusManager {
     }
 
     this.setNodeToVisualActiveFocus(node);
-    elem.focus();
+    elem.focus({preventScroll: true});
   }
 
   /**

--- a/core/focus_manager.ts
+++ b/core/focus_manager.ts
@@ -426,7 +426,7 @@ export class FocusManager {
    * can be active at any given time (attempting to activate more than one
    * simultaneously will result in an error being thrown).
    *
-   * This method does not scroll the ephemerally focused node into view.
+   * This method does not scroll the ephemerally focused element into view.
    */
   takeEphemeralFocus(
     focusableElement: HTMLElement | SVGElement,

--- a/core/interfaces/i_focusable_node.ts
+++ b/core/interfaces/i_focusable_node.ts
@@ -59,6 +59,9 @@ export interface IFocusableNode {
    * they should avoid the following:
    * - Creating or removing DOM elements (including via the renderer or drawer).
    * - Affecting focus via DOM focus() calls or the FocusManager.
+   *
+   * Implementations should consider scrolling themselves into view here; that
+   * is not handled by the focus manager.
    */
   onNodeFocus(): void;
 

--- a/core/interfaces/i_focusable_node.ts
+++ b/core/interfaces/i_focusable_node.ts
@@ -60,8 +60,8 @@ export interface IFocusableNode {
    * - Creating or removing DOM elements (including via the renderer or drawer).
    * - Affecting focus via DOM focus() calls or the FocusManager.
    *
-   * Implementations should consider scrolling themselves into view here; that
-   * is not handled by the focus manager.
+   * Implementations may consider scrolling themselves into view here; that is
+   * not handled by the focus manager.
    */
   onNodeFocus(): void;
 

--- a/tests/browser/test/basic_playground_test.mjs
+++ b/tests/browser/test/basic_playground_test.mjs
@@ -61,7 +61,7 @@ suite('Testing Connecting Blocks', function () {
  * These tests have to run together. Each test acts on the state left by the
  * previous test, and each test has a single assertion.
  */
-suite.only('Right Clicking on Blocks', function () {
+suite('Right Clicking on Blocks', function () {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
   this.timeout(0);
 

--- a/tests/browser/test/basic_playground_test.mjs
+++ b/tests/browser/test/basic_playground_test.mjs
@@ -61,7 +61,7 @@ suite('Testing Connecting Blocks', function () {
  * These tests have to run together. Each test acts on the state left by the
  * previous test, and each test has a single assertion.
  */
-suite('Right Clicking on Blocks', function () {
+suite.only('Right Clicking on Blocks', function () {
   // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
   this.timeout(0);
 
@@ -102,7 +102,7 @@ suite('Right Clicking on Blocks', function () {
     chai.assert.isNull(await getCommentText(this.browser, this.block.id));
   });
 
-  test('does not scroll the page', async function () {
+  test('does not scroll the page when node is ephemerally focused', async function () {
     const initialScroll = await this.browser.execute(() => {
       return window.scrollY;
     });
@@ -118,6 +118,27 @@ suite('Right Clicking on Blocks', function () {
     });
 
     chai.assert.equal(initialScroll, finalScroll);
+  });
+
+  test('does not scroll the page when node is actively focused', async function () {
+    await this.browser.setWindowSize(500, 300);
+    await this.browser.setViewport({width: 500, height: 300});
+    const initialScroll = await this.browser.execute((blockId) => {
+      window.scrollTo(0, document.body.scrollHeight);
+      return window.scrollY;
+    }, this.block.id);
+    await this.browser.execute(() => {
+      Blockly.getFocusManager().focusNode(
+        Blockly.getMainWorkspace().getToolbox(),
+      );
+    });
+    const finalScroll = await this.browser.execute(() => {
+      return window.scrollY;
+    });
+
+    chai.assert.equal(initialScroll, finalScroll);
+    await this.browser.setWindowSize(800, 600);
+    await this.browser.setViewport({width: 800, height: 600});
   });
 });
 

--- a/tests/browser/test/basic_playground_test.mjs
+++ b/tests/browser/test/basic_playground_test.mjs
@@ -101,6 +101,24 @@ suite('Right Clicking on Blocks', function () {
     await contextMenuSelect(this.browser, this.block, 'Remove Comment');
     chai.assert.isNull(await getCommentText(this.browser, this.block.id));
   });
+
+  test.only('does not scroll the page', async function () {
+    const initialScroll = await this.browser.execute(() => {
+      return window.scrollY;
+    });
+    // This left-right-left sequence was necessary to reproduce unintended
+    // scrolling; regardless of the number of clicks/context menu activations,
+    // the page should not scroll.
+    this.block.click({button: 2});
+    this.block.click({button: 0});
+    this.block.click({button: 2});
+    await this.browser.pause(250);
+    const finalScroll = await this.browser.execute(() => {
+      return window.scrollY;
+    });
+
+    chai.assert.equal(initialScroll, finalScroll);
+  });
 });
 
 suite('Disabling', function () {

--- a/tests/browser/test/basic_playground_test.mjs
+++ b/tests/browser/test/basic_playground_test.mjs
@@ -102,7 +102,7 @@ suite('Right Clicking on Blocks', function () {
     chai.assert.isNull(await getCommentText(this.browser, this.block.id));
   });
 
-  test.only('does not scroll the page', async function () {
+  test('does not scroll the page', async function () {
     const initialScroll = await this.browser.execute(() => {
       return window.scrollY;
     });


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9246

### Proposed Changes
This PR updates the `FocusManager` to not automatically scroll focused nodes into view (the default browser behavior). This was causing shifts in the top-level page when the `WidgetDiv` was shown, and may have caused inadvertent scrolling in other contexts as well.