### PR TITLE
fix: Fix positioning of pasted blocks and comments in RTL.

### DIFF
--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -83,6 +83,9 @@ export function moveBlockToNotConflict(
   block: BlockSvg,
   originalPosition: Coordinate,
 ) {
+  if (block.workspace.RTL) {
+    originalPosition.x = block.workspace.getWidth() - originalPosition.x;
+  }
   const workspace = block.workspace;
   const snapRadius = config.snapRadius;
   const bumpOffset = Coordinate.difference(

--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -368,7 +368,10 @@ export class CommentView implements IRenderedElement {
 
     const textPreviewWidth =
       size.width - foldoutSize.getWidth() - deleteSize.getWidth();
-    this.textPreview.setAttribute('x', `${foldoutSize.getWidth()}`);
+    this.textPreview.setAttribute(
+      'x',
+      `${(this.workspace.RTL ? -1 : 1) * foldoutSize.getWidth()}`,
+    );
     this.textPreview.setAttribute(
       'y',
       `${textPreviewMargin + textPreviewSize.height / 2}`,

--- a/core/xml.ts
+++ b/core/xml.ts
@@ -68,7 +68,7 @@ export function saveWorkspaceComment(
   if (!skipId) elem.setAttribute('id', comment.id);
 
   const workspace = comment.workspace;
-  const loc = comment.getRelativeToSurfaceXY();
+  const loc = comment.getRelativeToSurfaceXY().clone();
   loc.x = workspace.RTL ? workspace.getWidth() - loc.x : loc.x;
   elem.setAttribute('x', `${loc.x}`);
   elem.setAttribute('y', `${loc.y}`);

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -236,5 +236,28 @@ suite('Clipboard', function () {
         new Blockly.utils.Coordinate(40, 40),
       );
     });
+
+    test('pasted comments are bumped to not overlap in RTL', function () {
+      this.workspace.dispose();
+      this.workspace = Blockly.inject('blocklyDiv', {rtl: true});
+      Blockly.Xml.domToWorkspace(
+        Blockly.utils.xml.textToDom(
+          '<xml><comment id="test" x=10 y=10/></xml>',
+        ),
+        this.workspace,
+      );
+      const comment = this.workspace.getTopComments(false)[0];
+      const data = comment.toCopyData();
+
+      const newComment = Blockly.clipboard.paste(data, this.workspace);
+      const oldCommentXY = comment.getRelativeToSurfaceXY();
+      assert.deepEqual(
+        newComment.getRelativeToSurfaceXY(),
+        new Blockly.utils.Coordinate(oldCommentXY.x - 30, oldCommentXY.y + 30),
+      );
+      // Restore an LTR workspace.
+      this.workspace.dispose();
+      this.workspace = Blockly.inject('blocklyDiv');
+    });
   });
 });

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -14,7 +14,7 @@ import {
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
 
-suite('Clipboard', function () {
+suite.only('Clipboard', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     this.workspace = Blockly.inject('blocklyDiv');
@@ -179,6 +179,10 @@ suite('Clipboard', function () {
             oldBlockXY.y + Blockly.config.snapRadius * 2,
           ),
         );
+
+        // Restore an LTR workspace.
+        this.workspace.dispose();
+        this.workspace = Blockly.inject('blocklyDiv');
       });
 
       test('pasted blocks are bumped to be outside the connection snap radius', function () {

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -14,7 +14,7 @@ import {
   sharedTestTeardown,
 } from './test_helpers/setup_teardown.js';
 
-suite.only('Clipboard', function () {
+suite('Clipboard', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     this.workspace = Blockly.inject('blocklyDiv');

--- a/tests/mocha/clipboard_test.js
+++ b/tests/mocha/clipboard_test.js
@@ -157,6 +157,30 @@ suite('Clipboard', function () {
         );
       });
 
+      test('pasted blocks are bumped to not overlap in RTL', function () {
+        this.workspace.dispose();
+        this.workspace = Blockly.inject('blocklyDiv', {rtl: true});
+        const block = Blockly.serialization.blocks.append(
+          {
+            'type': 'controls_if',
+            'x': 38,
+            'y': 13,
+          },
+          this.workspace,
+        );
+        const data = block.toCopyData();
+
+        const newBlock = Blockly.clipboard.paste(data, this.workspace);
+        const oldBlockXY = block.getRelativeToSurfaceXY();
+        assert.deepEqual(
+          newBlock.getRelativeToSurfaceXY(),
+          new Blockly.utils.Coordinate(
+            oldBlockXY.x - Blockly.config.snapRadius,
+            oldBlockXY.y + Blockly.config.snapRadius * 2,
+          ),
+        );
+      });
+
       test('pasted blocks are bumped to be outside the connection snap radius', function () {
         Blockly.serialization.workspaces.load(
           {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9138

### Proposed Changes
This PR fixes the positioning of newly-pasted blocks in RTL mode to be left and down from the original block by following the same coordinate-adjustment procedure as is used in `Blockly.serialization.blocks`. It also adds a test to exercise this behavior.

It also resolves an unreported issue with pasting workspace comments in RTL such that only the first paste would be bumped, with successive pasted comments spawning atop the first one that was pasted, and with all of the pasted comments becoming offset from their initial position when dragged, due to the XML serializer (invoked by the CommentCreate event) inadvertently mutating the comment's location.

It also-also fixes the positioning of the truncated text in the top bar on collapsed comments in RTL.