### PR TITLE
fix: use workspace variable instead of block.workspace in RTL coordinate conversion

### DIFF
--- a/core/clipboard/block_paster.ts
+++ b/core/clipboard/block_paster.ts
@@ -83,10 +83,10 @@ export function moveBlockToNotConflict(
   block: BlockSvg,
   originalPosition: Coordinate,
 ) {
-  if (block.workspace.RTL) {
-    originalPosition.x = block.workspace.getWidth() - originalPosition.x;
-  }
   const workspace = block.workspace;
+  if (workspace.RTL) {
+    originalPosition.x = workspace.getWidth() - originalPosition.x;
+  }
   const snapRadius = config.snapRadius;
   const bumpOffset = Coordinate.difference(
     originalPosition,


### PR DESCRIPTION
change pull: https://github.com/google/blockly/pull/9302

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
