### PR TITLE
fix: Show the delete cursor when dragging a block by an editable field.

### DIFF
--- a/core/css.ts
+++ b/core/css.ts
@@ -181,7 +181,8 @@ let content = `
   cursor: -webkit-grabbing;
 }
 
-.blocklyDragging.blocklyDraggingDelete {
+.blocklyDragging.blocklyDraggingDelete,
+.blocklyDragging.blocklyDraggingDelete .blocklyField {
   cursor: url("<<<PATH>>>/handdelete.cur"), auto;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8999

### Proposed Changes
This PR fixes a bug where dragging a block by an editable field to a delete area did not show the delete cursor. Now, the delete cursor is shown regardless of whether the block is being dragged by its body/a label or an editable field.