### PR TITLE
fix: Correct the alignment of narrow text in input fields.

### DIFF
--- a/core/field.ts
+++ b/core/field.ts
@@ -852,8 +852,7 @@ export abstract class Field<T = any>
       totalHeight = Math.max(totalHeight, constants!.FIELD_BORDER_RECT_HEIGHT);
     }
 
-    this.size_.height = totalHeight;
-    this.size_.width = totalWidth;
+    this.size_ = new Size(totalWidth, totalHeight);
 
     this.positionTextElement_(xOffset, contentWidth);
     this.positionBorderRect_();

--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -29,6 +29,7 @@ import * as aria from './utils/aria.js';
 import {Coordinate} from './utils/coordinate.js';
 import * as dom from './utils/dom.js';
 import * as parsing from './utils/parsing.js';
+import {Size} from './utils/size.js';
 import * as utilsString from './utils/string.js';
 import {Svg} from './utils/svg.js';
 
@@ -553,8 +554,7 @@ export class FieldDropdown extends Field<string> {
     } else {
       arrowWidth = dom.getTextWidth(this.arrow as SVGTSpanElement);
     }
-    this.size_.width = imageWidth + arrowWidth + xPadding * 2;
-    this.size_.height = height;
+    this.size_ = new Size(imageWidth + arrowWidth + xPadding * 2, height);
 
     let arrowX = 0;
     if (block.RTL) {
@@ -595,8 +595,7 @@ export class FieldDropdown extends Field<string> {
         height / 2 - this.getConstants()!.FIELD_DROPDOWN_SVG_ARROW_SIZE / 2,
       );
     }
-    this.size_.width = textWidth + arrowWidth + xPadding * 2;
-    this.size_.height = height;
+    this.size_ = new Size(textWidth + arrowWidth + xPadding * 2, height);
 
     this.positionTextElement_(xPadding, textWidth);
   }

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -46,6 +46,11 @@ import type {WorkspaceSvg} from './workspace_svg.js';
 type InputTypes = string | number;
 
 /**
+ * The minimum width of an input field.
+ */
+const MINIMUM_WIDTH = 14;
+
+/**
  * Abstract class for an editable input field.
  *
  * @typeParam T - The value stored on the field.
@@ -115,8 +120,8 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    */
   protected override get size_() {
     const s = super.size_;
-    if (s.width < 14) {
-      s.width = 14;
+    if (s.width < MINIMUM_WIDTH) {
+      s.width = MINIMUM_WIDTH;
     }
 
     return s;
@@ -730,6 +735,23 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
     if (!bumped) this.resizeEditor_();
 
     return true;
+  }
+
+  /**
+   * Position a field's text element after a size change.  This handles both LTR
+   * and RTL positioning.
+   *
+   * @param xOffset x offset to use when positioning the text element.
+   * @param contentWidth The content width.
+   */
+  protected override positionTextElement_(
+    xOffset: number,
+    contentWidth: number,
+  ) {
+    const effectiveWidth = xOffset * 2 + contentWidth;
+    const delta =
+      effectiveWidth < MINIMUM_WIDTH ? (MINIMUM_WIDTH - effectiveWidth) / 2 : 0;
+    super.positionTextElement_(xOffset + delta, contentWidth);
   }
 
   /**

--- a/core/field_input.ts
+++ b/core/field_input.ts
@@ -741,17 +741,17 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
    * Position a field's text element after a size change.  This handles both LTR
    * and RTL positioning.
    *
-   * @param xOffset x offset to use when positioning the text element.
+   * @param xMargin x offset to use when positioning the text element.
    * @param contentWidth The content width.
    */
   protected override positionTextElement_(
-    xOffset: number,
+    xMargin: number,
     contentWidth: number,
   ) {
-    const effectiveWidth = xOffset * 2 + contentWidth;
+    const effectiveWidth = xMargin * 2 + contentWidth;
     const delta =
       effectiveWidth < MINIMUM_WIDTH ? (MINIMUM_WIDTH - effectiveWidth) / 2 : 0;
-    super.positionTextElement_(xOffset + delta, contentWidth);
+    super.positionTextElement_(xMargin + delta, contentWidth);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9069

### Proposed Changes
This PR fixes a bug that caused narrow text values in Zelos input fields to be slightly misaligned horizontally from the center. Input fields have a minimum width, and if the measured width of the text was less than that, it was positioned incorrectly. I also adjusted a couple places that were manually setting the `width` attribute of the field size and bypassing the minimum size enforcement as a result; this wasn't a root cause, but could lead to tricky bugs down the line.