### PR TITLE
fix: Prevent mocha tests failures when window does not have focus.

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -45,7 +45,11 @@ import {
   publishBeta,
   recompile,
 } from './scripts/gulpfiles/release_tasks.mjs';
-import {generators, test} from './scripts/gulpfiles/test_tasks.mjs';
+import {
+  generators,
+  interactiveMocha,
+  test,
+} from './scripts/gulpfiles/test_tasks.mjs';
 
 const clean = parallel(cleanBuildDir, cleanReleaseDir);
 
@@ -80,6 +84,7 @@ export {
   clean,
   test,
   generators as testGenerators,
+  interactiveMocha,
   buildAdvancedCompilationTest,
   createRC as gitCreateRC,
   docs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
         "prettier-plugin-organize-imports": "^4.0.0",
+        "puppeteer-core": "^24.17.0",
         "readline-sync": "^1.4.10",
         "rimraf": "^5.0.0",
         "typescript": "^5.3.3",
@@ -1290,18 +1291,18 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.4.tgz",
-      "integrity": "sha512-9DxbZx+XGMNdjBynIs4BRSz+M3iRDeB7qRcAr6UORFLphCIM2x3DXgOucvADiifcqCE4XePFUKcnaAMyGbrDlQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.7.tgz",
+      "integrity": "sha512-wHWLkQWBjHtajZeqCB74nsa/X70KheyOhySYBRmVQDJiNj0zjZR/naPCvdWjMhcG1LmjaMV/9WtTo5mpe8qWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.1",
-        "tar-fs": "^3.0.8",
+        "semver": "^7.7.2",
+        "tar-fs": "^3.1.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -2967,6 +2968,20 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
+      "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -3618,6 +3633,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1475386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
+      "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -6901,6 +6923,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -7929,6 +7958,24 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.17.0.tgz",
+      "integrity": "sha512-RYOBKFiF+3RdwIZTEacqNpD567gaFcBAOKTT7742FdB1icXudrPI7BlZbYTYWK2wgGQUXt9Zi1Yn+D5PmCs4CA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.7",
+        "chromium-bidi": "8.0.0",
+        "debug": "^4.4.1",
+        "devtools-protocol": "0.0.1475386",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/qs": {
@@ -8999,9 +9046,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9217,6 +9264,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
@@ -9779,9 +9833,10 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10034,6 +10089,16 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "gulp test",
     "test:browser": "cd tests/browser && npx mocha",
     "test:generators": "gulp testGenerators",
-    "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"http-server ./ -o /tests/mocha/index.html -c-1\"",
+    "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"gulp interactiveMocha\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
     "updateGithubPages": "npm ci && gulp gitUpdateGithubPages"
   },

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.0.0",
+    "puppeteer-core": "^24.17.0",
     "readline-sync": "^1.4.10",
     "rimraf": "^5.0.0",
     "typescript": "^5.3.3",

--- a/scripts/gulpfiles/test_tasks.mjs
+++ b/scripts/gulpfiles/test_tasks.mjs
@@ -257,9 +257,9 @@ async function metadata() {
  * Run Mocha tests inside a browser.
  * @return {Promise} Asynchronous result.
  */
-async function mocha() {
+async function mocha(exitOnCompletion = true) {
   return runTestTask('mocha', async () => {
-    const result = await runMochaTestsInBrowser().catch(e => {
+    const result = await runMochaTestsInBrowser(exitOnCompletion).catch(e => {
       throw e;
     });
     if (result) {
@@ -267,6 +267,14 @@ async function mocha() {
     }
     console.log('Mocha tests passed');
   });
+}
+
+/**
+ * Run Mocha tests inside a browser and keep the browser open upon completion.
+ * @return {Promise} Asynchronous result.
+ */
+export async function interactiveMocha() {
+  return mocha(false);
 }
 
 /**

--- a/tests/mocha/webdriver.js
+++ b/tests/mocha/webdriver.js
@@ -45,6 +45,17 @@ async function runMochaTestsInBrowser() {
   console.log('Loading URL: ' + url);
   await browser.url(url);
 
+  // Toggle the devtools setting to emulate focus, so that the window will
+  // always act as if it has focus regardless of the state of the window manager
+  // or operating system. This improves the reliability of FocusManager-related
+  // tests.
+  const puppeteer = await browser.getPuppeteer();
+  await browser.call(async () => {
+    const page = (await puppeteer.pages())[0];
+    const session = await page.createCDPSession();
+    await session.send('Emulation.setFocusEmulationEnabled', { enabled: true });
+  });
+
   await browser.waitUntil(async() => {
     const elem = await browser.$('#failureCount');
     const text = await elem.getAttribute('tests_failed');

--- a/tests/mocha/webdriver.js
+++ b/tests/mocha/webdriver.js
@@ -15,9 +15,12 @@ const {posixPath} = require('../../scripts/helpers');
  * Runs the Mocha tests in this directory in Chrome. It uses webdriverio to
  * launch Chrome and load index.html. Outputs a summary of the test results
  * to the console.
+ *
+ * @param {boolean} exitOnCompletetion True if the browser should automatically
+ *     quit after tests have finished running.
  * @return {number} 0 on success, 1 on failure.
  */
-async function runMochaTestsInBrowser() {
+async function runMochaTestsInBrowser(exitOnCompletion = true) {
   const options = {
     capabilities: {
       browserName: 'chrome',
@@ -85,7 +88,7 @@ async function runMochaTestsInBrowser() {
   if (parseInt(numOfFailure) !== 0) {
     return 1;
   }
-  await browser.deleteSession();
+  if (exitOnCompletion) await browser.deleteSession();
   return 0;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8937

### Proposed Changes
This PR uses the Chrome devtools "Emulate a focused page" option to make the window that the Mocha tests run in always behave as if it is focused, regardless of whether or not it actually does in the window manager/OS. This makes the test environment more consistent and prevents intermittent flakes based on the window having focus or not. Additionally, the `test:mocha:interactive` command has been updated to use the same Gulp codepath as the `test` command; previously, it just opened a window, but didn't run the code that configured Webdriver/Chrome options.