### PR TITLE
fix: Fix bug that could cause errant line when rendering.

### DIFF
--- a/core/renderers/common/drawer.ts
+++ b/core/renderers/common/drawer.ts
@@ -122,9 +122,12 @@ export class Drawer {
       } else if (Types.isSpacer(elem)) {
         this.outlinePath_ += svgPaths.lineOnAxis('h', elem.width);
       }
+      // No branch for a square corner, because it's a no-op.
     }
-    // No branch for a square corner, because it's a no-op.
-    this.outlinePath_ += svgPaths.lineOnAxis('v', topRow.height);
+    this.outlinePath_ += svgPaths.lineOnAxis(
+      'v',
+      topRow.height - topRow.ascenderHeight,
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #6028

### Proposed Changes
This PR updates the drawer to not include the ascender height (which goes negative/above the starting point of a top row, e.g. for hats) when drawing a vertical path downwards to complete the right edge of the top row. Under certain circumstances, this could exceed the total height of the block and appear as a stray dangly line on the bottom right corner.

There is actually at least 3x redundancy for parts of the right edge of a block path in practice, since the top/bottom rows don't have additional height beyond that caused by their rounded corners/notches/hat. However, because they could, the top and bottom rows draw a vertical line corresponding to the row's total height along the right edge of the block. These generally overlap the middle rows of blocks and are thus not visible, but #6469 tracks cleaning them up. In theory the top/bottom row drawing methods could track the vertical delta between the starting point and ending point when drawing each element in the row, and subtract that from the overall row height to draw the exact amount needed, but this would be a large refactor and I think requires either writing an SVG path parser to evaluate the height of a path fragment, or making breaking changes to the interfaces for e.g. hats, which currently don't know their height outside of what is encoded in the path.