### PR TITLE
fix: Fix bug that could caused variable map to be left in an inconsistent state.

### DIFF
--- a/core/variable_map.ts
+++ b/core/variable_map.ts
@@ -112,7 +112,11 @@ export class VariableMap
     const oldType = variable.getType();
     if (oldType === newType) return variable;
 
-    this.variableMap.get(variable.getType())?.delete(variable.getId());
+    const oldTypeVariables = this.variableMap.get(oldType);
+    oldTypeVariables?.delete(variable.getId());
+    if (oldTypeVariables?.size === 0) {
+      this.variableMap.delete(oldType);
+    }
     variable.setType(newType);
     const newTypeVariables =
       this.variableMap.get(newType) ??

--- a/tests/mocha/variable_map_test.js
+++ b/tests/mocha/variable_map_test.js
@@ -258,6 +258,13 @@ suite('Variable Map', function () {
         assert.deepEqual(newTypeVariables, [variable]);
         assert.equal(variable.getType(), '');
       });
+
+      test('removes the type from the map when the last instance is changed', function () {
+        const var1 = this.variableMap.createVariable('name1', 'type1');
+        const var2 = this.variableMap.createVariable('name2', 'type2');
+        this.variableMap.changeVariableType(var1, 'type2');
+        assert.deepEqual(this.variableMap.getTypes(), ['type2']);
+      });
     },
   );
 


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9337

### Proposed Changes
This PR cleans up the entry in the underlying variable map when changing the type of a variable such that no variables with its original type exist. Before, a record for the type would remain, mapped to an empty array. Now, the type will be removed entirely in this situation. I also added a test to exercise this behavior. Thanks to @michaelnixonau for reporting this issue and providing a fix in their report.