### PR TITLE
fix: Allow cross origin requests for Blockly assets.

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -70,6 +70,8 @@ handlers:
 # Blockly files.
 - url: /static
   static_dir: static
+  http_headers:
+    Access-Control-Allow-Origin: "*"
   secure: always
 
 # Storage API.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR adds a `Access-Control-Allow-Origin: *` to the HTTP headers served on responses from the /static directory of the Blockly App Engine service where the stock assets are served from. Ideally, developers would serve these themselves, but many don't. When generating screenshots of Blockly, these assets are necessary (drag handles, icons, etc), but since they are cross-origin in many cases relative to the page from which a screenshot is being generated, they are inaccessible in that context.