### PR TITLE
fix: Avoid creating redundant a11y tree nodes when selecting a block.

### DIFF
--- a/core/renderers/zelos/path_object.ts
+++ b/core/renderers/zelos/path_object.ts
@@ -8,8 +8,8 @@
 
 import type {BlockSvg} from '../../block_svg.js';
 import type {Connection} from '../../connection.js';
-import {FocusManager} from '../../focus_manager.js';
 import type {BlockStyle} from '../../theme.js';
+import * as aria from '../../utils/aria.js';
 import * as dom from '../../utils/dom.js';
 import {Svg} from '../../utils/svg.js';
 import {PathObject as BasePathObject} from '../common/path_object.js';
@@ -90,20 +90,17 @@ export class PathObject extends BasePathObject {
     this.setClass_('blocklySelected', enable);
     if (enable) {
       if (!this.svgPathSelected) {
-        this.svgPathSelected = this.svgPath.cloneNode(true) as SVGElement;
-        this.svgPathSelected.classList.add('blocklyPathSelected');
-        // Ensure focus-specific properties don't overlap with the block's path.
-        dom.removeClass(
-          this.svgPathSelected,
-          FocusManager.ACTIVE_FOCUS_NODE_CSS_CLASS_NAME,
+        this.svgPathSelected = dom.createSvgElement(
+          Svg.PATH,
+          {
+            'class': 'blocklyPath blocklyPathSelected',
+            'stroke': this.svgPath.getAttribute('stroke') ?? '',
+            'fill': this.svgPath.getAttribute('fill') ?? '',
+            'd': this.svgPath.getAttribute('d') ?? '',
+            'role': aria.Role.PRESENTATION,
+          },
+          this.svgRoot,
         );
-        dom.removeClass(
-          this.svgPathSelected,
-          FocusManager.PASSIVE_FOCUS_NODE_CSS_CLASS_NAME,
-        );
-        this.svgPathSelected.removeAttribute('tabindex');
-        this.svgPathSelected.removeAttribute('id');
-        this.svgRoot.appendChild(this.svgPathSelected);
       }
     } else {
       if (this.svgPathSelected) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9295

### Proposed Changes
This PR updates the Zelos `PathObject` selection code to not clone the block's path to create a selection outline, but instead create a new path with only the intended attributes duplicated. This prevents duplicate nodes from becoming part of the accessibility tree by marking this path as `role="presentation"` rather than bringing over their existing role and ARIA attribute values.