### PR TITLE
Zelos: normalize workspace comment font weight to match block comments

### DIFF
--- a/core/comments/comment_view.ts
+++ b/core/comments/comment_view.ts
@@ -672,6 +672,8 @@ css.register(`
   border: 1px solid var(--commentBorderColour);
   box-sizing: border-box;
   display: block;
+  /* Match Zelos block comment bubbles: do not inherit bold label weight */
+  font-weight: normal;
   outline: 0;
   padding: 5px;
   resize: none;
@@ -713,6 +715,8 @@ css.register(`
 .blocklyComment .blocklyCommentPreview.blocklyText {
   fill: #000;
   dominant-baseline: middle;
+  /* Ensure preview text uses normal weight for consistency with textarea */
+  font-weight: normal;
   visibility: hidden;
 }
 


### PR DESCRIPTION
This change makes workspace comments use a normal font weight, aligning them with block comments in the Zelos renderer.

What changed
- Add `font-weight: normal;` to the workspace comment textarea rule (`.blocklyComment .blocklyTextarea`).
- Add `font-weight: normal;` to the workspace comment preview text rule (`.blocklyComment .blocklyCommentPreview.blocklyText`).

Why
- In Zelos, block comment bubbles already set `font-weight: normal` via `${selector} .blocklyTextInputBubble textarea { font-weight: normal; }` (constants.ts).
- Workspace comments lacked an explicit rule and inherited the bold weight used for labels, creating a visual mismatch.

Scope
- Keeps behavior consistent across renderers by applying the normal weight at the workspace comment CSS layer.
- No functional behavior changes; only visual consistency.

Fixes #9348.
