### PR TITLE
fix: Add a label to the toolbox.

### DIFF
--- a/core/toolbox/toolbox.ts
+++ b/core/toolbox/toolbox.ts
@@ -35,6 +35,7 @@ import {isSelectableToolboxItem} from '../interfaces/i_selectable_toolbox_item.j
 import type {IStyleable} from '../interfaces/i_styleable.js';
 import type {IToolbox} from '../interfaces/i_toolbox.js';
 import type {IToolboxItem} from '../interfaces/i_toolbox_item.js';
+import {Msg} from '../msg.js';
 import * as registry from '../registry.js';
 import type {KeyboardShortcut} from '../shortcut_registry.js';
 import * as Touch from '../touch.js';
@@ -154,6 +155,7 @@ export class Toolbox
     this.flyout.init(workspace);
 
     aria.setRole(this.HtmlDiv, aria.Role.TREE);
+    aria.setState(this.HtmlDiv, aria.State.LABEL, Msg['TOOLBOX_ARIA_LABEL']);
 
     this.render(this.toolboxDef_);
     const themeManager = workspace.getThemeManager();

--- a/msg/json/en.json
+++ b/msg/json/en.json
@@ -1,7 +1,7 @@
 {
 	"@metadata": {
 		"author": "Ellen Spertus <ellen.spertus@gmail.com>",
-		"lastupdated": "2025-09-09 09:40:56.729862",
+		"lastupdated": "2025-09-22 11:22:54.733649",
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},
@@ -396,6 +396,7 @@
 	"PROCEDURES_IFRETURN_WARNING": "Warning: This block may be used only within a function definition.",
 	"WORKSPACE_COMMENT_DEFAULT_TEXT": "Say something...",
 	"WORKSPACE_ARIA_LABEL": "Blockly Workspace",
+	"TOOLBOX_ARIA_LABEL": "Toolbox",
 	"COLLAPSED_WARNINGS_WARNING": "Collapsed blocks contain warnings.",
 	"DIALOG_OK": "OK",
 	"DIALOG_CANCEL": "Cancel",

--- a/msg/json/qqq.json
+++ b/msg/json/qqq.json
@@ -403,6 +403,7 @@
 	"PROCEDURES_IFRETURN_WARNING": "warning - This appears if the user tries to use this block outside of a function definition.",
 	"WORKSPACE_COMMENT_DEFAULT_TEXT": "comment text - This text appears in a new workspace comment, to hint that the user can type here.",
 	"WORKSPACE_ARIA_LABEL": "workspace - This text is read out when a user navigates to the workspace while using a screen reader.",
+	"TOOLBOX_ARIA_LABEL": "This text is read out when a user navigates to the toolbox while using a screen reader.",
 	"COLLAPSED_WARNINGS_WARNING": "warning - This appears if the user collapses a block, and blocks inside that block have warnings attached to them. It should inform the user that the block they collapsed contains blocks that have warnings.",
 	"DIALOG_OK": "button label - Pressing this button closes help information.\n{{Identical|OK}}",
 	"DIALOG_CANCEL": "button label - Pressing this button cancels a proposed action.\n{{Identical|Cancel}}",

--- a/msg/messages.js
+++ b/msg/messages.js
@@ -1608,6 +1608,11 @@ Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = 'Say something...';
 Blockly.Msg.WORKSPACE_ARIA_LABEL = 'Blockly Workspace';
 
 /** @type {string} */
+/// This text is read out when a user navigates to the toolbox while using a
+/// screen reader.
+Blockly.Msg.TOOLBOX_ARIA_LABEL = 'Toolbox';
+
+/** @type {string} */
 /// warning - This appears if the user collapses a block, and blocks inside
 /// that block have warnings attached to them. It should inform the user that the
 /// block they collapsed contains blocks that have warnings.
@@ -1629,7 +1634,7 @@ Blockly.Msg.EDIT_BLOCK_CONTENTS = 'Edit Block contents';
 /// menu label - Contextual menu item that starts a keyboard-driven block move.
 Blockly.Msg.MOVE_BLOCK = 'Move Block';
 /** @type {string} */
-/// Name of the Microsoft Windows operating system displayed in a list of 
+/// Name of the Microsoft Windows operating system displayed in a list of
 /// keyboard shortcuts.
 Blockly.Msg.WINDOWS = 'Windows';
 /** @type {string} */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9292

### Proposed Changes
This PR adds a localizable ARIA label to the toolbox div to identify it to screenreader users.