### PR TITLE
fix: Fix exception thrown when `FieldDropdown` subclasses don't have a textual label.

### DIFF
--- a/core/field_dropdown.ts
+++ b/core/field_dropdown.ts
@@ -217,11 +217,13 @@ export class FieldDropdown extends Field<string> {
 
     // Ensure the selected item has its correct label presented since it may be
     // different than the actual text presented to the user.
-    aria.setState(
-      this.getTextElement(),
-      aria.State.LABEL,
-      this.computeLabelForOption(this.selectedOption),
-    );
+    if (this.textElement_) {
+      aria.setState(
+        this.textElement_,
+        aria.State.LABEL,
+        this.computeLabelForOption(this.selectedOption),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9400

### Proposed Changes
This PR checks for the presence of `this.textElement_` before attempting to set ARIA attributes on it in `FieldDropdown`. The getter it had been using throws if there is no text element, and some `FieldDropdown` subclasses (namely `FieldColour`) do not have one, in this particular case because a colour swatch is shown rather than a textual label.