### PR TITLE
fix: Use `button` as the `aria-role` for icons.

### DIFF
--- a/core/icons/icon.ts
+++ b/core/icons/icon.ts
@@ -74,7 +74,7 @@ export abstract class Icon implements IIcon {
     (this.svgRoot as any).tooltip = this;
     tooltip.bindMouseEvents(this.svgRoot);
 
-    aria.setRole(this.svgRoot, aria.Role.FIGURE);
+    aria.setRole(this.svgRoot, aria.Role.BUTTON);
     aria.setState(this.svgRoot, aria.State.LABEL, 'Icon');
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9310

### Proposed Changes
This PR updates the default `aria-role` for icons to be `button` instead of `figure`. This better reflects the common case of icons being clickable. Custom icon subclasses may need to override this, but it seems to be the most appropriate role for all of the built-in icons.
