### PR TITLE
fix!: Fix types on `BlockSvg` connections

### DIFF
--- a/packages/blockly/blocks/text.ts
+++ b/packages/blockly/blocks/text.ts
@@ -757,13 +757,15 @@ const JOIN_MUTATOR_MIXIN = {
       'text_create_join_container',
     ) as BlockSvg;
     containerBlock.initSvg();
-    let connection = containerBlock.getInput('STACK')!.connection!;
+    let connection = containerBlock.getInput('STACK')?.connection;
     for (let i = 0; i < this.itemCount_; i++) {
       const itemBlock = workspace.newBlock(
         'text_create_join_item',
       ) as JoinItemBlock;
       itemBlock.initSvg();
-      connection.connect(itemBlock.previousConnection);
+      if (itemBlock.previousConnection) {
+        connection?.connect(itemBlock.previousConnection);
+      }
       connection = itemBlock.nextConnection;
     }
     return containerBlock;

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -160,12 +160,9 @@ export class BlockSvg
   private visuallyDisabled = false;
 
   override workspace: WorkspaceSvg;
-  // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
-  override outputConnection!: RenderedConnection;
-  // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
-  override nextConnection!: RenderedConnection;
-  // TODO(b/109816955): remove '!', see go/strict-prop-init-fix.
-  override previousConnection!: RenderedConnection;
+  override outputConnection: RenderedConnection | null = null;
+  override nextConnection: RenderedConnection | null = null;
+  override previousConnection: RenderedConnection | null = null;
 
   private translation = '';
 

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -366,7 +366,7 @@ export class BlockDragStrategy implements IDragStrategy {
           };
         }
 
-        this.startChildConn = nextTargetConn;
+        this.startChildConn = nextTargetConn ?? null;
       }
     }
   }
@@ -627,7 +627,7 @@ export class BlockDragStrategy implements IDragStrategy {
       draggingBlock.outputConnection,
       draggingBlock.previousConnection,
       draggingBlock.nextConnection,
-    ].filter(Boolean); // Removes falsy (null) values.
+    ].filter((c) => !!c); // Removes falsy (null) values.
     const inputConnections: RenderedConnection[] = [];
 
     for (const conn of available) {
@@ -727,14 +727,20 @@ export class BlockDragStrategy implements IDragStrategy {
     this.connectionPreviewer?.hidePreview();
     this.connectionCandidate = null;
 
-    this.startChildConn?.connect(this.block.nextConnection);
+    if (this.block.nextConnection) {
+      this.startChildConn?.connect(this.block.nextConnection);
+    }
     if (this.startParentConn) {
       switch (this.startParentConn.type) {
         case ConnectionType.INPUT_VALUE:
-          this.startParentConn.connect(this.block.outputConnection);
+          if (this.block.outputConnection) {
+            this.startParentConn.connect(this.block.outputConnection);
+          }
           break;
         case ConnectionType.NEXT_STATEMENT:
-          this.startParentConn.connect(this.block.previousConnection);
+          if (this.block.previousConnection) {
+            this.startParentConn.connect(this.block.previousConnection);
+          }
       }
     } else {
       this.block.moveTo(this.startLoc!, ['drag']);

--- a/packages/blockly/core/renderers/common/drawer.ts
+++ b/packages/blockly/core/renderers/common/drawer.ts
@@ -422,7 +422,7 @@ export class Drawer {
       const x =
         this.info_.startX + this.info_.outputConnection.connectionOffsetX;
       const connX = this.info_.RTL ? -x : x;
-      this.block_.outputConnection.setOffsetInBlock(
+      this.block_.outputConnection?.setOffsetInBlock(
         connX,
         this.info_.outputConnection.connectionOffsetY,
       );


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
This PR corrects the types for the connection fields on BlockSvg to indicate that they are nullable. It also fixes locations in the code that were assuming that these fields were always present.


### Breaking Changes
This change is purely related to typings, not behavioral; these fields have always been nullable, the types were simply inaccurate. Code that accesses these fields should be updated to ensure that they are set or otherwise handle the case where they are not, as not all blocks have all types of connections.