### PR TITLE
feat: i shortcut on workspace gives overview

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -19,7 +19,9 @@ import {type IDraggable, isDraggable} from './interfaces/i_draggable.js';
 import {type IFocusableNode} from './interfaces/i_focusable_node.js';
 import {Direction, KeyboardMover} from './keyboard_nav/keyboard_mover.js';
 import {keyboardNavigationController} from './keyboard_navigation_controller.js';
+import {Msg} from './msg.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
+import {aria} from './utils.js';
 import {Coordinate} from './utils/coordinate.js';
 import {KeyCodes} from './utils/keycodes.js';
 import {Rect} from './utils/rect.js';
@@ -53,6 +55,7 @@ export enum names {
   NAVIGATE_UP = 'up',
   NAVIGATE_DOWN = 'down',
   DISCONNECT = 'disconnect',
+  INFORMATION = 'information',
 }
 
 /**
@@ -635,20 +638,20 @@ export function registerArrowNavigation() {
   }
 }
 
+const resolveWorkspace = (workspace: WorkspaceSvg) => {
+  if (workspace.isFlyout) {
+    const target = workspace.targetWorkspace;
+    if (target) {
+      return resolveWorkspace(target);
+    }
+  }
+  return workspace.getRootWorkspace() ?? workspace;
+};
+
 /**
  * Registers keyboard shortcut to focus the workspace.
  */
 export function registerFocusWorkspace() {
-  const resolveWorkspace = (workspace: WorkspaceSvg) => {
-    if (workspace.isFlyout) {
-      const target = workspace.targetWorkspace;
-      if (target) {
-        return resolveWorkspace(target);
-      }
-    }
-    return workspace.getRootWorkspace() ?? workspace;
-  };
-
   const focusWorkspaceShortcut: KeyboardShortcut = {
     name: names.FOCUS_WORKSPACE,
     preconditionFn: (workspace) => !workspace.isDragging(),
@@ -687,6 +690,55 @@ export function registerFocusToolbox() {
     keyCodes: [KeyCodes.T],
   };
   ShortcutRegistry.registry.register(focusToolboxShortcut);
+}
+
+/**
+ * Registers keyboard shortcut to get count of block stacks and comments.
+ */
+export function registerWorkspaceOverview() {
+  const shortcut: KeyboardShortcut = {
+    name: names.INFORMATION,
+    preconditionFn: (workspace, scope) => {
+      const focused = scope.focusedNode;
+      return focused === workspace;
+    },
+    callback: (_workspace) => {
+      const workspace = resolveWorkspace(_workspace);
+      const stacks = workspace.getTopBlocks().length;
+      const comments = workspace.getTopComments().length;
+
+      // Build base string with block stack count.
+      let baseMsgKey;
+      if (stacks === 0) {
+        baseMsgKey = 'ARIA_WORKSPACE_BLOCKS_ZERO';
+      } else if (stacks === 1) {
+        baseMsgKey = 'ARIA_WORKSPACE_BLOCKS_ONE';
+      } else {
+        baseMsgKey = 'ARIA_WORKSPACE_BLOCKS_MANY';
+      }
+
+      // Build comment suffix.
+      let suffix = '';
+      if (comments > 0) {
+        suffix = Msg[
+          comments === 1
+            ? 'ARIA_WORKSPACE_COMMENTS_ONE'
+            : 'ARIA_WORKSPACE_COMMENTS_MANY'
+        ].replace('%1', String(comments));
+      }
+
+      // Build final message.
+      const msg = Msg[baseMsgKey]
+        .replace('%1', String(stacks))
+        .replace('%2', suffix);
+
+      aria.announceDynamicAriaState(msg);
+
+      return true;
+    },
+    keyCodes: [KeyCodes.I],
+  };
+  ShortcutRegistry.registry.register(shortcut);
 }
 
 /**
@@ -745,5 +797,13 @@ export function registerKeyboardNavigationShortcuts() {
   registerDisconnectBlock();
 }
 
+/**
+ * Registers keyboard shortcuts used to announce screen reader information.
+ */
+export function registerScreenReaderShortcuts() {
+  registerWorkspaceOverview();
+}
+
 registerDefaultShortcuts();
 registerKeyboardNavigationShortcuts();
+registerScreenReaderShortcuts();

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -707,32 +707,32 @@ export function registerWorkspaceOverview() {
     },
     callback: (_workspace) => {
       const workspace = resolveWorkspace(_workspace);
-      const stacks = workspace.getTopBlocks().length;
-      const comments = workspace.getTopComments().length;
+      const stackCount = workspace.getTopBlocks().length;
+      const commentCount = workspace.getTopComments().length;
 
       // Build base string with block stack count.
       let baseMsgKey;
-      if (stacks === 0) {
-        baseMsgKey = 'ARIA_WORKSPACE_BLOCKS_ZERO';
-      } else if (stacks === 1) {
-        baseMsgKey = 'ARIA_WORKSPACE_BLOCKS_ONE';
+      if (stackCount === 0) {
+        baseMsgKey = 'WORKSPACE_CONTENTS_BLOCKS_ZERO';
+      } else if (stackCount === 1) {
+        baseMsgKey = 'WORKSPACE_CONTENTS_BLOCKS_ONE';
       } else {
-        baseMsgKey = 'ARIA_WORKSPACE_BLOCKS_MANY';
+        baseMsgKey = 'WORKSPACE_CONTENTS_BLOCKS_MANY';
       }
 
       // Build comment suffix.
       let suffix = '';
-      if (comments > 0) {
+      if (commentCount > 0) {
         suffix = Msg[
-          comments === 1
-            ? 'ARIA_WORKSPACE_COMMENTS_ONE'
-            : 'ARIA_WORKSPACE_COMMENTS_MANY'
-        ].replace('%1', String(comments));
+          commentCount === 1
+            ? 'WORKSPACE_CONTENTS_COMMENTS_ONE'
+            : 'WORKSPACE_CONTENTS_COMMENTS_MANY'
+        ].replace('%1', String(commentCount));
       }
 
       // Build final message.
       const msg = Msg[baseMsgKey]
-        .replace('%1', String(stacks))
+        .replace('%1', String(stackCount))
         .replace('%2', suffix);
 
       aria.announceDynamicAriaState(msg);

--- a/packages/blockly/core/utils/aria.ts
+++ b/packages/blockly/core/utils/aria.ts
@@ -188,7 +188,6 @@ export function removeRole(element: Element) {
  */
 export function setRole(element: Element, roleName: Role | null) {
   if (!roleName) {
-    console.log('Removing role from element', element, roleName);
     removeRole(element);
   } else {
     element.setAttribute(ROLE_ATTRIBUTE, roleName);

--- a/packages/blockly/msg/json/en.json
+++ b/packages/blockly/msg/json/en.json
@@ -1,7 +1,7 @@
 {
 	"@metadata": {
 		"author": "Ellen Spertus <ellen.spertus@gmail.com>",
-		"lastupdated": "2026-04-01 11:22:00.739918",
+		"lastupdated": "2026-04-03 10:36:19.846436",
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},
@@ -421,9 +421,9 @@
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Use the arrow keys to move, then %1 to accept the position",
 	"KEYBOARD_NAV_COPIED_HINT": "Copied. Press %1 to paste.",
 	"KEYBOARD_NAV_CUT_HINT": "Cut. Press %1 to paste.",
-	"ARIA_WORKSPACE_BLOCKS_MANY": "%1 stacks of blocks%2 in workspace.",
-	"ARIA_WORKSPACE_BLOCKS_ONE": "One stack of blocks%2 in workspace.",
-	"ARIA_WORKSPACE_BLOCKS_ZERO": "No blocks%2 in workspace.",
-	"ARIA_WORKSPACE_COMMENTS_MANY": " and %1 comments",
-	"ARIA_WORKSPACE_COMMENTS_ONE": " and one comment"
+	"WORKSPACE_CONTENTS_BLOCKS_MANY": "%1 stacks of blocks%2 in workspace.",
+	"WORKSPACE_CONTENTS_BLOCKS_ONE": "One stack of blocks%2 in workspace.",
+	"WORKSPACE_CONTENTS_BLOCKS_ZERO": "No blocks%2 in workspace.",
+	"WORKSPACE_CONTENTS_COMMENTS_MANY": " and %1 comments",
+	"WORKSPACE_CONTENTS_COMMENTS_ONE": " and one comment"
 }

--- a/packages/blockly/msg/json/en.json
+++ b/packages/blockly/msg/json/en.json
@@ -1,7 +1,7 @@
 {
 	"@metadata": {
 		"author": "Ellen Spertus <ellen.spertus@gmail.com>",
-		"lastupdated": "2026-02-12 13:23:33.999357",
+		"lastupdated": "2026-04-01 11:22:00.739918",
 		"locale": "en",
 		"messagedocumentation" : "qqq"
 	},
@@ -420,5 +420,10 @@
 	"KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT": "Hold %1 and use arrow keys to move freely, then %2 to accept the position",
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Use the arrow keys to move, then %1 to accept the position",
 	"KEYBOARD_NAV_COPIED_HINT": "Copied. Press %1 to paste.",
-	"KEYBOARD_NAV_CUT_HINT": "Cut. Press %1 to paste."
+	"KEYBOARD_NAV_CUT_HINT": "Cut. Press %1 to paste.",
+	"ARIA_WORKSPACE_BLOCKS_MANY": "%1 stacks of blocks%2 in workspace.",
+	"ARIA_WORKSPACE_BLOCKS_ONE": "One stack of blocks%2 in workspace.",
+	"ARIA_WORKSPACE_BLOCKS_ZERO": "No blocks%2 in workspace.",
+	"ARIA_WORKSPACE_COMMENTS_MANY": " and %1 comments",
+	"ARIA_WORKSPACE_COMMENTS_ONE": " and one comment"
 }

--- a/packages/blockly/msg/json/qqq.json
+++ b/packages/blockly/msg/json/qqq.json
@@ -427,5 +427,10 @@
 	"KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks to arbitrary locations with the keyboard.",
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks with the keyboard.",
 	"KEYBOARD_NAV_COPIED_HINT": "Message shown when an item is copied in keyboard navigation mode.",
-	"KEYBOARD_NAV_CUT_HINT": "Message shown when an item is cut in keyboard navigation mode."
+	"KEYBOARD_NAV_CUT_HINT": "Message shown when an item is cut in keyboard navigation mode.",
+	"ARIA_WORKSPACE_BLOCKS_MANY": "ARIA live region message announcing the number of stacks of blocks in the workspace, optionally including comments. \n\nParameters:\n* %1 - the number of stacks (integer greater than 1)\n* %2 - optional phrase announcing comments, including leading space",
+	"ARIA_WORKSPACE_BLOCKS_ONE": "ARIA live region message announcing there is one stack of blocks in the workspace, optionally including comments. \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space",
+	"ARIA_WORKSPACE_BLOCKS_ZERO": "ARIA live region message announcing there are no blocks in the workspace, optionally including comments. \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space",
+	"ARIA_WORKSPACE_COMMENTS_MANY": "ARIA live region phrase appended when there are multiple workspace comments. \n\nParameters:\n* %1 - the number of comments (integer greater than 1)",
+	"ARIA_WORKSPACE_COMMENTS_ONE": "ARIA live region phrase appended when there is exactly one workspace comment."
 }

--- a/packages/blockly/msg/json/qqq.json
+++ b/packages/blockly/msg/json/qqq.json
@@ -428,9 +428,9 @@
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks with the keyboard.",
 	"KEYBOARD_NAV_COPIED_HINT": "Message shown when an item is copied in keyboard navigation mode.",
 	"KEYBOARD_NAV_CUT_HINT": "Message shown when an item is cut in keyboard navigation mode.",
-	"ARIA_WORKSPACE_BLOCKS_MANY": "ARIA live region message announcing the number of stacks of blocks in the workspace, optionally including comments. \n\nParameters:\n* %1 - the number of stacks (integer greater than 1)\n* %2 - optional phrase announcing comments, including leading space",
-	"ARIA_WORKSPACE_BLOCKS_ONE": "ARIA live region message announcing there is one stack of blocks in the workspace, optionally including comments. \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space",
-	"ARIA_WORKSPACE_BLOCKS_ZERO": "ARIA live region message announcing there are no blocks in the workspace, optionally including comments. \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space",
-	"ARIA_WORKSPACE_COMMENTS_MANY": "ARIA live region phrase appended when there are multiple workspace comments. \n\nParameters:\n* %1 - the number of comments (integer greater than 1)",
-	"ARIA_WORKSPACE_COMMENTS_ONE": "ARIA live region phrase appended when there is exactly one workspace comment."
+	"WORKSPACE_CONTENTS_BLOCKS_MANY": "ARIA live region message announcing the number of stacks of blocks in the workspace, optionally including comments. \n\nParameters:\n* %1 - the number of stacks (integer greater than 1)\n* %2 - optional phrase announcing comments, including leading space \n\nExamples:\n* '5 stacks of blocks in workspace.'\n* '5 stacks of blocks and 2 comments in workspace.'",
+	"WORKSPACE_CONTENTS_BLOCKS_ONE": "ARIA live region message announcing there is one stack of blocks in the workspace, optionally including a count of comments. \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space \n\nExamples:\n* 'One stack of blocks in workspace.'\n* 'One stack of blocks and 1 comment in workspace.'",
+	"WORKSPACE_CONTENTS_BLOCKS_ZERO": "ARIA live region message announcing there are no blocks in the workspace, optionally including a count of comments. \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space \n\nExamples:\n* 'No blocks in workspace.'\n* 'No blocks and 3 comments in workspace.'",
+	"WORKSPACE_CONTENTS_COMMENTS_MANY": "ARIA live region phrase appended when there are multiple workspace comments. \n\nParameters:\n* %1 - the number of comments (integer greater than 1)",
+	"WORKSPACE_CONTENTS_COMMENTS_ONE": "ARIA live region phrase appended when there is exactly one workspace comment."
 }

--- a/packages/blockly/msg/messages.js
+++ b/packages/blockly/msg/messages.js
@@ -1696,3 +1696,22 @@ Blockly.Msg.KEYBOARD_NAV_COPIED_HINT = 'Copied. Press %1 to paste.';
 /** @type {string} */
 /// Message shown when an item is cut in keyboard navigation mode.
 Blockly.Msg.KEYBOARD_NAV_CUT_HINT = 'Cut. Press %1 to paste.';
+/** @type {string} */
+/// ARIA live region message announcing the number of stacks of blocks in the workspace, optionally including comments.
+/// \n\nParameters:\n* %1 - the number of stacks (integer greater than 1)\n* %2 - optional phrase announcing comments, including leading space
+Blockly.Msg.ARIA_WORKSPACE_BLOCKS_MANY = '%1 stacks of blocks%2 in workspace.';
+/** @type {string} */
+/// ARIA live region message announcing there is one stack of blocks in the workspace, optionally including comments.
+/// \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space
+Blockly.Msg.ARIA_WORKSPACE_BLOCKS_ONE = 'One stack of blocks%2 in workspace.';
+/** @type {string} */
+/// ARIA live region message announcing there are no blocks in the workspace, optionally including comments.
+/// \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space
+Blockly.Msg.ARIA_WORKSPACE_BLOCKS_ZERO = 'No blocks%2 in workspace.';
+/** @type {string} */
+/// ARIA live region phrase appended when there are multiple workspace comments.
+/// \n\nParameters:\n* %1 - the number of comments (integer greater than 1)
+Blockly.Msg.ARIA_WORKSPACE_COMMENTS_MANY = ' and %1 comments';
+/** @type {string} */
+/// ARIA live region phrase appended when there is exactly one workspace comment.
+Blockly.Msg.ARIA_WORKSPACE_COMMENTS_ONE = ' and one comment';

--- a/packages/blockly/msg/messages.js
+++ b/packages/blockly/msg/messages.js
@@ -1699,19 +1699,22 @@ Blockly.Msg.KEYBOARD_NAV_CUT_HINT = 'Cut. Press %1 to paste.';
 /** @type {string} */
 /// ARIA live region message announcing the number of stacks of blocks in the workspace, optionally including comments.
 /// \n\nParameters:\n* %1 - the number of stacks (integer greater than 1)\n* %2 - optional phrase announcing comments, including leading space
-Blockly.Msg.ARIA_WORKSPACE_BLOCKS_MANY = '%1 stacks of blocks%2 in workspace.';
+/// \n\nExamples:\n* "5 stacks of blocks in workspace."\n* "5 stacks of blocks and 2 comments in workspace."
+Blockly.Msg.WORKSPACE_CONTENTS_BLOCKS_MANY = '%1 stacks of blocks%2 in workspace.';
 /** @type {string} */
-/// ARIA live region message announcing there is one stack of blocks in the workspace, optionally including comments.
+/// ARIA live region message announcing there is one stack of blocks in the workspace, optionally including a count of comments.
 /// \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space
-Blockly.Msg.ARIA_WORKSPACE_BLOCKS_ONE = 'One stack of blocks%2 in workspace.';
+/// \n\nExamples:\n* "One stack of blocks in workspace."\n* "One stack of blocks and 1 comment in workspace."
+Blockly.Msg.WORKSPACE_CONTENTS_BLOCKS_ONE = 'One stack of blocks%2 in workspace.';
 /** @type {string} */
-/// ARIA live region message announcing there are no blocks in the workspace, optionally including comments.
+/// ARIA live region message announcing there are no blocks in the workspace, optionally including a count of comments.
 /// \n\nParameters:\n* %2 - optional phrase announcing comments, including leading space
-Blockly.Msg.ARIA_WORKSPACE_BLOCKS_ZERO = 'No blocks%2 in workspace.';
+/// \n\nExamples:\n* "No blocks in workspace."\n* "No blocks and 3 comments in workspace."
+Blockly.Msg.WORKSPACE_CONTENTS_BLOCKS_ZERO = 'No blocks%2 in workspace.';
 /** @type {string} */
 /// ARIA live region phrase appended when there are multiple workspace comments.
 /// \n\nParameters:\n* %1 - the number of comments (integer greater than 1)
-Blockly.Msg.ARIA_WORKSPACE_COMMENTS_MANY = ' and %1 comments';
+Blockly.Msg.WORKSPACE_CONTENTS_COMMENTS_MANY = ' and %1 comments';
 /** @type {string} */
 /// ARIA live region phrase appended when there is exactly one workspace comment.
-Blockly.Msg.ARIA_WORKSPACE_COMMENTS_ONE = ' and one comment';
+Blockly.Msg.WORKSPACE_CONTENTS_COMMENTS_ONE = ' and one comment';

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -552,6 +552,81 @@ suite('Keyboard Shortcut Items', function () {
     });
   });
 
+  suite('Workspace Information (I)', function () {
+    setup(function () {
+      const keyEvent = createKeyDownEvent(Blockly.utils.KeyCodes.I);
+      // Helper to trigger the shortcut and assert the live region text.
+      this.assertAnnouncement = (expected) => {
+        this.injectionDiv.dispatchEvent(keyEvent);
+        // Wait for the live region to update after the event.
+        this.clock.tick(11);
+        // The announcement may include an additional non-breaking space.
+        assert.include(this.liveRegion.textContent, expected);
+      };
+      this.liveRegion = document.getElementById('blocklyAriaAnnounce');
+    });
+
+    test('Announces block stacks and comments', function () {
+      // Start with empty workspace.
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('No blocks in workspace.');
+
+      // Add one block.
+      const block1 = this.workspace.newBlock('stack_block');
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('One stack of blocks in workspace.');
+
+      // Add second block.
+      const block2 = this.workspace.newBlock('stack_block');
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('2 stacks of blocks in workspace.');
+
+      // Add one comment.
+      const comment1 = this.workspace.newComment();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement(
+        '2 stacks of blocks and one comment in workspace.',
+      );
+
+      // Add second comment.
+      const comment2 = this.workspace.newComment();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement(
+        '2 stacks of blocks and 2 comments in workspace.',
+      );
+
+      // Remove second block stack.
+      block2.dispose();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement(
+        'One stack of blocks and 2 comments in workspace.',
+      );
+
+      // Remove last block.
+      block1.dispose();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('No blocks and 2 comments in workspace.');
+
+      // Remove second comment.
+      comment2.dispose();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('No blocks and one comment in workspace.');
+
+      // Remove last comment.
+      comment1.dispose();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('No blocks in workspace.');
+    });
+
+    suite('Preconditions', function () {
+      test('Not called when focus is not on workspace', function () {
+        this.block = this.workspace.newBlock('stack_block');
+        Blockly.getFocusManager().focusNode(this.block);
+        this.assertAnnouncement('');
+      });
+    });
+  });
+
   suite('Focus Toolbox (T)', function () {
     setup(function () {
       Blockly.defineBlocksWithJsonArray([

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -566,56 +566,56 @@ suite('Keyboard Shortcut Items', function () {
       this.liveRegion = document.getElementById('blocklyAriaAnnounce');
     });
 
-    test('Announces block stacks and comments', function () {
+    test('Empty workspace', function () {
       // Start with empty workspace.
       Blockly.getFocusManager().focusNode(this.workspace);
       this.assertAnnouncement('No blocks in workspace.');
+    });
 
-      // Add one block.
-      const block1 = this.workspace.newBlock('stack_block');
+    test('One block', function () {
+      this.workspace.newBlock('stack_block');
       Blockly.getFocusManager().focusNode(this.workspace);
       this.assertAnnouncement('One stack of blocks in workspace.');
+    });
 
-      // Add second block.
-      const block2 = this.workspace.newBlock('stack_block');
+    test('Two blocks', function () {
+      this.workspace.newBlock('stack_block');
+      this.workspace.newBlock('stack_block');
       Blockly.getFocusManager().focusNode(this.workspace);
       this.assertAnnouncement('2 stacks of blocks in workspace.');
+    });
 
-      // Add one comment.
-      const comment1 = this.workspace.newComment();
+    test('One comment', function () {
+      this.workspace.newComment();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('No blocks and one comment in workspace.');
+    });
+
+    test('Two comments', function () {
+      this.workspace.newComment();
+      this.workspace.newComment();
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.assertAnnouncement('No blocks and 2 comments in workspace.');
+    });
+
+    test('One block, one comment', function () {
+      this.workspace.newBlock('stack_block');
+      this.workspace.newComment();
       Blockly.getFocusManager().focusNode(this.workspace);
       this.assertAnnouncement(
-        '2 stacks of blocks and one comment in workspace.',
+        'One stack of blocks and one comment in workspace.',
       );
+    });
 
-      // Add second comment.
-      const comment2 = this.workspace.newComment();
+    test('Two blocks, two comments', function () {
+      this.workspace.newBlock('stack_block');
+      this.workspace.newBlock('stack_block');
+      this.workspace.newComment();
+      this.workspace.newComment();
       Blockly.getFocusManager().focusNode(this.workspace);
       this.assertAnnouncement(
         '2 stacks of blocks and 2 comments in workspace.',
       );
-
-      // Remove second block stack.
-      block2.dispose();
-      Blockly.getFocusManager().focusNode(this.workspace);
-      this.assertAnnouncement(
-        'One stack of blocks and 2 comments in workspace.',
-      );
-
-      // Remove last block.
-      block1.dispose();
-      Blockly.getFocusManager().focusNode(this.workspace);
-      this.assertAnnouncement('No blocks and 2 comments in workspace.');
-
-      // Remove second comment.
-      comment2.dispose();
-      Blockly.getFocusManager().focusNode(this.workspace);
-      this.assertAnnouncement('No blocks and one comment in workspace.');
-
-      // Remove last comment.
-      comment1.dispose();
-      Blockly.getFocusManager().focusNode(this.workspace);
-      this.assertAnnouncement('No blocks in workspace.');
     });
 
     suite('Preconditions', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/issues/assigned?issue=RaspberryPiFoundation%7Cblockly%7C9622#:~:text=give%20workspace%20overview-,%239622,-Edit

### Proposed Changes

This adds a new 'i' shortcut for workspaces. If the workspace is focused, the shortcut will trigger an announcement of the current total of block stacks and workspace comments. New translation strings were added to facilitate communicating the number of stacks and comments in a grammatically accurate way. The new strings were intentionally phrased to front-load the most important information (ie. actual quantity) over contextual description (ie. "on the workspace").
See tests for sample announcement strings created using the new messages.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

From linked issue:
>when focused on workspace, i shortcut should tell how many stacks of blocks, how many comments, etc are on the workspace. stacks are more useful than total block count.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

The main new test performs a round trip through the different permutations of messages. The other test checks that the precondition logic works as expected (the workspace must be focused).

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

N/A

### Additional Information

<!-- Anything else we should know? -->
I expect we'll want to make sure this new shortcut gets added to the keyboard navigation help menu/shortcuts list once that has been ported over.