### PR TITLE
fix: add group when cutting workspace comments

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -217,7 +217,9 @@ export function registerCut() {
       if (focused instanceof BlockSvg) {
         focused.checkAndDelete();
       } else if (isIDeletable(focused)) {
+        eventUtils.setGroup(true);
         focused.dispose();
+        eventUtils.setGroup(true);
       }
       return !!copyData;
     },

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -219,7 +219,7 @@ export function registerCut() {
       } else if (isIDeletable(focused)) {
         eventUtils.setGroup(true);
         focused.dispose();
-        eventUtils.setGroup(true);
+        eventUtils.setGroup(false);
       }
       return !!copyData;
     },

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -295,6 +295,11 @@ suite('Keyboard Shortcut Items', function () {
       this.disposeSpy = sinon.spy(this.comment, 'dispose');
 
       this.injectionDiv.dispatchEvent(keyEvent);
+
+      const deleteEvents = this.workspace
+        .getUndoStack()
+        .filter((e) => e.type === 'comment_delete');
+      assert(deleteEvents[0].group !== ''); // Group string is not empty
       sinon.assert.calledOnce(this.copySpy);
       sinon.assert.calledOnce(this.disposeSpy);
     });


### PR DESCRIPTION
## The basics

- [ x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9164

### Proposed Changes

Adds an event group when the `cut` action is performed from a keyboard shortcut for a non-block entity.
<img width="514" height="60" alt="image" src="https://github.com/user-attachments/assets/31952f58-65f0-476e-b871-56c02f98b690" />


### Reason for Changes

Without this functionality, events fired from the `cut` keyboard shortcut cannot be grouped together.
