### PR TITLE
feat: Add aria APIs to Field base class

### DIFF
--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -98,7 +98,8 @@ export abstract class Field<T = any>
   /** Validation function called when user edits an editable field. */
   protected validator_: FieldValidator<T> | null = null;
 
-  protected ariaTypeName_: string | null = null;
+  /** The ARIA-friendly label representation of this field's type. */
+  protected ariaTypeName: string | null = null;
 
   /**
    * Used to cache the field's tooltip value if setTooltip is called when the
@@ -253,7 +254,7 @@ export abstract class Field<T = any>
       this.setTooltip(parsing.replaceMessageReferences(config.tooltip));
     }
     if (config.ariaTypeName) {
-      this.ariaTypeName_ = config.ariaTypeName;
+      this.ariaTypeName = config.ariaTypeName;
     }
   }
 
@@ -315,7 +316,7 @@ export abstract class Field<T = any>
    *     unspecified.
    */
   getAriaTypeName(): string | null {
-    return this.ariaTypeName_;
+    return this.ariaTypeName;
   }
 
   /**

--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -98,6 +98,8 @@ export abstract class Field<T = any>
   /** Validation function called when user edits an editable field. */
   protected validator_: FieldValidator<T> | null = null;
 
+  protected ariaTypeName_: string | null = null;
+
   /**
    * Used to cache the field's tooltip value if setTooltip is called when the
    * field is not yet initialized. Is *not* guaranteed to be accurate.
@@ -250,6 +252,9 @@ export abstract class Field<T = any>
     if (config.tooltip) {
       this.setTooltip(parsing.replaceMessageReferences(config.tooltip));
     }
+    if (config.ariaTypeName) {
+      this.ariaTypeName_ = config.ariaTypeName;
+    }
   }
 
   /**
@@ -298,6 +303,88 @@ export abstract class Field<T = any>
    */
   getSourceBlock(): Block | null {
     return this.sourceBlock_;
+  }
+
+  /**
+   * Gets an ARIA-friendly label representation of this field's type.
+   *
+   * Implementations are responsible for, and encouraged to, return a localized
+   * version of the ARIA representation of the field's type.
+   *
+   * @returns An ARIA representation of the field's type or null if it is
+   *     unspecified.
+   */
+  getAriaTypeName(): string | null {
+    return this.ariaTypeName_;
+  }
+
+  /**
+   * Gets an ARIA-friendly label representation of this field's value.
+   *
+   * Note that implementations should generally always override this value to
+   * ensure a non-null value is returned since the default implementation relies
+   * on 'getValue' which may return null, and a null return value for this
+   * function will prompt ARIA label generation to skip the field's value
+   * entirely when there may be a better contextual placeholder to use, instead,
+   * specific to the field.
+   *
+   * Implementations are responsible for, and encouraged to, return a localized
+   * version of the ARIA representation of the field's value.
+   *
+   * @returns An ARIA representation of the field's value, or null if no value
+   *     is currently defined or known for the field.
+   */
+  getAriaValue(): string | null {
+    const value = this.getValue();
+
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return String(value);
+  }
+
+  /**
+   * Computes a descriptive ARIA label to represent this field with configurable
+   * verbosity.
+   *
+   * A 'verbose' label includes type information, if available, whereas a
+   * non-verbose label only contains the field's value.
+   *
+   * Note that this will always return the latest representation of the field's
+   * label which may differ from any previously set ARIA label for the field
+   * itself. Implementations are largely responsible for ensuring that the
+   * field's ARIA label is set correctly at relevant moments in the field's
+   * lifecycle (such as when its value changes).
+   *
+   * Finally, it is never guaranteed that implementations use the label returned
+   * by this method for their actual ARIA label. Some implementations may rely
+   * on other contexts to convey information like the field's value. Example:
+   * checkboxes represent their checked/non-checked status (i.e. value) through
+   * a separate ARIA property.
+   *
+   * It's possible this returns an empty string if the field doesn't supply type
+   * or value information for certain cases (such as a null value). This can
+   * lead to the field being potentially COMPLETELY HIDDEN for screen reader
+   * navigation so it's crucial for implementations to ensure a non-empty value
+   * is returned here.
+   *
+   * @param includeTypeInfo Whether to include the field's type information in
+   *     the returned label, if available.
+   */
+  computeAriaLabel(includeTypeInfo: boolean = false): string {
+    const ariaTypeName = includeTypeInfo ? this.getAriaTypeName() : null;
+    const ariaValue = this.getAriaValue();
+
+    if (!ariaTypeName && !ariaValue) {
+      return '';
+    }
+
+    if (ariaTypeName && ariaValue) {
+      return `${ariaTypeName}: ${ariaValue}`;
+    }
+
+    return ariaTypeName ?? ariaValue ?? '';
   }
 
   /**
@@ -1417,6 +1504,7 @@ export abstract class Field<T = any>
  */
 export interface FieldConfig {
   tooltip?: string;
+  ariaTypeName?: string;
 }
 
 /**

--- a/packages/blockly/tests/mocha/field_test.js
+++ b/packages/blockly/tests/mocha/field_test.js
@@ -818,4 +818,131 @@ suite('Abstract Fields', function () {
       });
     });
   });
+
+  suite('Aria', function () {
+    class TestField extends Blockly.Field {
+      constructor(value, config = undefined) {
+        super(value, null, config);
+      }
+    }
+
+    suite('getAriaTypeName', function () {
+      test('Default returns null', function () {
+        const field = new TestField();
+        assert.isNull(field.getAriaTypeName());
+      });
+
+      test('Returns configured ariaTypeName (JS)', function () {
+        const field = new TestField('value', {ariaTypeName: 'number'});
+        assert.equal(field.getAriaTypeName(), 'number');
+      });
+
+      test('Returns configured ariaTypeName (JSON)', function () {
+        class CustomField extends Blockly.Field {
+          constructor(opt_config) {
+            super('value', null, opt_config);
+          }
+
+          static fromJson(options) {
+            return new CustomField(options);
+          }
+        }
+
+        const field = CustomField.fromJson({ariaTypeName: 'text input'});
+        assert.equal(field.getAriaTypeName(), 'text input');
+      });
+    });
+
+    suite('getAriaValue', function () {
+      test('Returns string value', function () {
+        const field = new TestField('hello');
+        assert.equal(field.getAriaValue(), 'hello');
+      });
+
+      test('Returns stringified number', function () {
+        const field = new TestField(123);
+        assert.equal(field.getAriaValue(), '123');
+      });
+
+      test('Returns null for null value', function () {
+        const field = new TestField(null);
+        assert.isNull(field.getAriaValue());
+      });
+
+      test('Returns null for undefined value', function () {
+        const field = new TestField(undefined);
+        assert.isNull(field.getAriaValue());
+      });
+    });
+
+    suite('computeAriaLabel', function () {
+      test('Value only (default)', function () {
+        const field = new TestField('hello');
+        assert.equal(field.computeAriaLabel(), 'hello');
+      });
+
+      test('Value only when includeTypeInfo=false', function () {
+        const field = new TestField('hello', {ariaTypeName: 'text'});
+        assert.equal(field.computeAriaLabel(false), 'hello');
+      });
+
+      test('Type and value when includeTypeInfo=true', function () {
+        const field = new TestField('hello', {ariaTypeName: 'text'});
+        assert.equal(field.computeAriaLabel(true), 'text: hello');
+      });
+
+      test('Type only when value is null', function () {
+        const field = new TestField(null, {ariaTypeName: 'text'});
+        assert.equal(field.computeAriaLabel(true), 'text');
+      });
+
+      test('Empty string when no type or value', function () {
+        const field = new TestField(null);
+        assert.equal(field.computeAriaLabel(true), '');
+      });
+
+      test('Handles missing type with includeTypeInfo=true', function () {
+        const field = new TestField('hello');
+        assert.equal(field.computeAriaLabel(true), 'hello');
+      });
+    });
+
+    suite('Subclass overrides', function () {
+      class CustomValueField extends TestField {
+        getAriaValue() {
+          return 'custom value';
+        }
+      }
+
+      class CustomTypeField extends TestField {
+        getAriaTypeName() {
+          return 'custom type';
+        }
+      }
+
+      class FullCustomField extends TestField {
+        getAriaValue() {
+          return 'custom value';
+        }
+        getAriaTypeName() {
+          return 'custom type';
+        }
+      }
+
+      test('Uses overridden getAriaValue', function () {
+        const field = new CustomValueField('ignored');
+        assert.equal(field.computeAriaLabel(), 'custom value');
+      });
+
+      test('Uses overridden getAriaTypeName', function () {
+        const field = new CustomTypeField('value');
+        assert.equal(field.computeAriaLabel(true), 'custom type: value');
+      });
+
+      test('Uses both overrides', function () {
+        const field = new FullCustomField();
+        assert.equal(field.computeAriaLabel(true), 'custom type: custom value');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9654

### Proposed Changes

This PR introduces new ARIA helper APIs on the base `Field` class to support accessible label generation:

- Adds:
  - `getAriaTypeName(): string | null`
  - `getAriaValue(): string | null`
  - `computeAriaLabel(includeTypeInfo?: boolean): string`
- Extends `FieldConfig` with optional `ariaTypeName` to allow block definitions to configure ARIA type labels
- Implements safe default behavior in the base class:
  - `getAriaTypeName` returns configured value (if present)
  - `getAriaValue` falls back to `getValue()` stringification
  - `computeAriaLabel` composes type/value with optional verbosity
- Adds unit tests covering:
  - Default behavior
  - Config-driven type names
  - Label composition logic
  - Null/undefined edge cases
  - Subclass override behavior

These changes establish a consistent foundation for ARIA labeling across all fields.

### Reason for Changes

Blockly currently lacks a standardized way for fields to expose ARIA-friendly labels. 

### Test Coverage

Added a new Aria test suite covering:

- `getAriaTypeName`
  - Default (`null`)
  - JS constructor config
  - JSON config
- `getAriaValue`
  - Strings, numbers
  - `null` and `undefined`
- `computeAriaLabel`
  - Value-only output
  - Type + value composition
  - Type-only cases
  - Empty output when both are missing
- Subclass overrides
  - Custom `getAriaValue`
  - Custom `getAriaTypeName`
  - Combined overrides

Tests ensure correct fallback behavior and verify that subclasses can override these methods as intended.

### Documentation

Inline JSDoc comments were added for all new APIs.

No external documentation updates yet.

### Additional Information

Follow-up PRs are planned to adopt the new APIs across built-in fields.