### PR TITLE
feat: Update zelos path object to allowlist attributes

### DIFF
--- a/packages/blockly/core/renderers/zelos/path_object.ts
+++ b/packages/blockly/core/renderers/zelos/path_object.ts
@@ -7,8 +7,8 @@
 // Former goog.module ID: Blockly.zelos.PathObject
 
 import type {BlockSvg} from '../../block_svg.js';
-import {FocusManager} from '../../focus_manager.js';
 import type {BlockStyle} from '../../theme.js';
+import {Role} from '../../utils/aria.js';
 import * as dom from '../../utils/dom.js';
 import {Svg} from '../../utils/svg.js';
 import {PathObject as BasePathObject} from '../common/path_object.js';
@@ -89,19 +89,18 @@ export class PathObject extends BasePathObject {
     this.setClass_('blocklySelected', enable);
     if (enable) {
       if (!this.svgPathSelected) {
-        this.svgPathSelected = this.svgPath.cloneNode(true) as SVGElement;
-        this.svgPathSelected.classList.add('blocklyPathSelected');
-        // Ensure focus-specific properties don't overlap with the block's path.
-        dom.removeClass(
-          this.svgPathSelected,
-          FocusManager.ACTIVE_FOCUS_NODE_CSS_CLASS_NAME,
+        // Create a shallow copy with only the attributes we need to carry over.
+        this.svgPathSelected = dom.createSvgElement(
+          Svg.PATH,
+          {
+            'class': 'blocklyPath blocklyPathSelected',
+            'stroke': this.svgPath.getAttribute('stroke') || '',
+            'fill': this.svgPath.getAttribute('fill') || '',
+            'd': this.svgPath.getAttribute('d') || '',
+            'role': Role.PRESENTATION,
+          },
+          this.svgRoot,
         );
-        dom.removeClass(
-          this.svgPathSelected,
-          FocusManager.PASSIVE_FOCUS_NODE_CSS_CLASS_NAME,
-        );
-        this.svgPathSelected.removeAttribute('tabindex');
-        this.svgPathSelected.removeAttribute('id');
         this.svgRoot.appendChild(this.svgPathSelected);
       }
     } else {


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9665

### Proposed Changes

In the Zelos renderer, the `updateSelected()` method now creates a new element to assign to the `svgPathSelected` element rather than cloning the `svgPath`. 

### Reason for Changes

This allows us to create an allowlist of attributes we want to copy rather than a denylist of attributes, which was how we previously handled it. Ultimately, this allows us to avoid inadvertently copying attributes that may cause issues in the accessibility tree.

### Test Coverage

I have tested these changes manually by comparing the functionality before and after these changes in Chrome. Keyboard navigation and focus control all continued to work when using the Zelos renderer in the Advanced Blockly Playground after these changes were applied.

Accessibility tree before:
<img width="953" height="155" alt="Screenshot 2026-04-20 at 3 07 14 PM" src="https://github.com/user-attachments/assets/1a50b5f9-24fa-4267-9fc3-82b3c7ffd37f" />

Accessibility tree after:
<img width="972" height="158" alt="Screenshot 2026-04-20 at 3 05 53 PM" src="https://github.com/user-attachments/assets/566616b7-7838-485c-ae71-29af76f5cad1" />