### PR TITLE
fix: Improve focus handling when clicking outside injection div

### DIFF
--- a/packages/blockly/core/common.ts
+++ b/packages/blockly/core/common.ts
@@ -87,7 +87,7 @@ export function getMainWorkspace(): Workspace {
 export function setMainWorkspace(workspace: Workspace) {
   mainWorkspace = workspace;
   if (workspace.rendered) {
-    getFocusManager().setQuasiModalFocusRoot(
+    getFocusManager().setPopoverFocusRoot(
       (workspace as WorkspaceSvg).getInjectionDiv(),
     );
   }

--- a/packages/blockly/core/common.ts
+++ b/packages/blockly/core/common.ts
@@ -86,6 +86,11 @@ export function getMainWorkspace(): Workspace {
  */
 export function setMainWorkspace(workspace: Workspace) {
   mainWorkspace = workspace;
+  if (workspace.rendered) {
+    getFocusManager().setQuasiModalFocusRoot(
+      (workspace as WorkspaceSvg).getInjectionDiv(),
+    );
+  }
 }
 
 /**

--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -152,6 +152,19 @@ export function createDom() {
 }
 
 /**
+ * Deals with the root element that contains this and other quasi-modals losing
+ * focus by returning ephemeral focus if we hold it and hiding the DropDownDiv.
+ */
+function handleFocusLoss() {
+  if (returnEphemeralFocus) {
+    returnEphemeralFocus(false);
+    returnEphemeralFocus = null;
+  }
+
+  hide();
+}
+
+/**
  * Set an element to maintain bounds within. Drop-downs will appear
  * within the box of this element if possible.
  *
@@ -370,6 +383,8 @@ export function show<T>(
   manageEphemeralFocus: boolean,
   opt_onHide?: () => void,
 ): boolean {
+  getFocusManager().registerQuasiModalFocusLossHandler(handleFocusLoss);
+
   const parentDiv = common.getParentContainer();
   parentDiv?.appendChild(div);
 
@@ -669,6 +684,7 @@ export function hideIfOwner<T>(
 
 /** Hide the menu, triggering animation. */
 export function hide() {
+  getFocusManager().unregisterQuasiModalFocusLossHandler(handleFocusLoss);
   // Start the animation by setting the translation and fading out.
   // Reset to (initialX, initialY) - i.e., no translation.
   div.style.transform = 'translate(0, 0)';

--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -152,7 +152,7 @@ export function createDom() {
 }
 
 /**
- * Deals with the root element that contains this and other quasi-modals losing
+ * Deals with the root element that contains this and other popovers losing
  * focus by returning ephemeral focus if we hold it and hiding the DropDownDiv.
  */
 function handleFocusLoss() {
@@ -383,7 +383,7 @@ export function show<T>(
   manageEphemeralFocus: boolean,
   opt_onHide?: () => void,
 ): boolean {
-  getFocusManager().registerQuasiModalFocusLossHandler(handleFocusLoss);
+  getFocusManager().registerPopoverFocusLossHandler(handleFocusLoss);
 
   const parentDiv = common.getParentContainer();
   parentDiv?.appendChild(div);
@@ -684,7 +684,7 @@ export function hideIfOwner<T>(
 
 /** Hide the menu, triggering animation. */
 export function hide() {
-  getFocusManager().unregisterQuasiModalFocusLossHandler(handleFocusLoss);
+  getFocusManager().unregisterPopoverFocusLossHandler(handleFocusLoss);
   // Start the animation by setting the translation and fading out.
   // Reset to (initialX, initialY) - i.e., no translation.
   div.style.transform = 'translate(0, 0)';

--- a/packages/blockly/core/focus_manager.ts
+++ b/packages/blockly/core/focus_manager.ts
@@ -15,7 +15,7 @@ import {FocusableTreeTraverser} from './utils/focusable_tree_traverser.js';
  *
  * See FocusManager.takeEphemeralFocus for more details.
  */
-export type ReturnEphemeralFocus = () => void;
+export type ReturnEphemeralFocus = (restoreFocus?: boolean) => void;
 
 /**
  * Represents an IFocusableTree that has been registered for focus management in
@@ -82,6 +82,33 @@ export class FocusManager {
   private lockFocusStateChanges: boolean = false;
   private recentlyLostAllFocus: boolean = false;
   private isUpdatingFocusedNode: boolean = false;
+
+  /**
+   * Root element in which quasi-modals (WidgetDiv, DropDownDiv) currently live.
+   */
+  private quasiModalFocusRoot?: HTMLElement;
+
+  /**
+   * Set of callbacks to invoke if the quasi-modal focus root loses focus.
+   */
+  private quasiModalFocusLossHandlers: Set<() => void> = new Set();
+
+  /**
+   * Handler for focusout in the quasi-modal focus root that selectively
+   * invokes the quasi-modal focus loss handlers if focus has truly transitioned
+   * outside of the focus root, and not e.g. to a different quasi-modal.
+   */
+  private quasiModalFocusOutHandler = (e: FocusEvent) => {
+    const target = e.relatedTarget;
+    if (
+      target === null ||
+      (target instanceof Node && !this.quasiModalFocusRoot?.contains(target))
+    ) {
+      for (const handler of this.quasiModalFocusLossHandlers) {
+        handler();
+      }
+    }
+  };
 
   constructor(
     addGlobalEventListener: (type: string, listener: EventListener) => void,
@@ -446,7 +473,7 @@ export class FocusManager {
     focusableElement.focus({preventScroll: true});
 
     let hasFinishedEphemeralFocus = false;
-    return () => {
+    return (restoreFocus = true) => {
       if (hasFinishedEphemeralFocus) {
         throw Error(
           `Attempted to finish ephemeral focus twice for element: ` +
@@ -455,8 +482,7 @@ export class FocusManager {
       }
       hasFinishedEphemeralFocus = true;
       this.currentlyHoldsEphemeralFocus = false;
-
-      if (this.focusedNode) {
+      if (this.focusedNode && restoreFocus) {
         this.activelyFocusNode(this.focusedNode, null);
 
         // Even though focus was restored, check if it's lost again. It's
@@ -666,6 +692,50 @@ export class FocusManager {
       FocusManager.focusManager = new FocusManager(document.addEventListener);
     }
     return FocusManager.focusManager;
+  }
+
+  /**
+   * Sets the current quasi-modal focus root. Generally this is active
+   * workspace's injection div or the explicitly specified parent container for
+   * the WidgetDiv, DropDownDiv, etc.
+   *
+   * @internal
+   * @param newRoot The new element that contains all quasi-modals.
+   */
+  setQuasiModalFocusRoot(newRoot: HTMLElement) {
+    this.quasiModalFocusRoot?.removeEventListener(
+      'focusout',
+      this.quasiModalFocusOutHandler,
+    );
+    this.quasiModalFocusRoot = newRoot;
+    this.quasiModalFocusRoot.addEventListener(
+      'focusout',
+      this.quasiModalFocusOutHandler,
+    );
+  }
+
+  /**
+   * Registers a callback to be invoked if the quasi-modal focus root loses
+   * focus. This should only be called by quasi-modals that need to react to
+   * focus changes by e.g. hiding themselves and resigning ephemeral focus.
+   *
+   * @internal
+   * @param handler A callback function.
+   */
+  registerQuasiModalFocusLossHandler(handler: () => void) {
+    this.quasiModalFocusLossHandlers.add(handler);
+  }
+
+  /**
+   * Unregisters a previously-registered quasi-modal focus loss handler. This
+   * should only be invoked by quasi-modals when they no longer need to be
+   * notified of focus loss, typically when they are hidden.
+   *
+   * @internal
+   * @param handler A previously-registered callback function.
+   */
+  unregisterQuasiModalFocusLossHandler(handler: () => void) {
+    this.quasiModalFocusLossHandlers.delete(handler);
   }
 }
 

--- a/packages/blockly/core/focus_manager.ts
+++ b/packages/blockly/core/focus_manager.ts
@@ -11,7 +11,11 @@ import {FocusableTreeTraverser} from './utils/focusable_tree_traverser.js';
 
 /**
  * Type declaration for returning focus to FocusManager upon completing an
- * ephemeral UI flow (such as a dialog).
+ * ephemeral UI flow (such as a dialog). Normally, the FocusManager will refocus
+ * the previously-focused element. If callers do not wish for the FocusManager
+ * to do so, they may call this method with `restoreFocus` set to false to
+ * prevent automatic refocusing and leave focus where it is.
+ *
  *
  * See FocusManager.takeEphemeralFocus for more details.
  */

--- a/packages/blockly/core/focus_manager.ts
+++ b/packages/blockly/core/focus_manager.ts
@@ -84,27 +84,27 @@ export class FocusManager {
   private isUpdatingFocusedNode: boolean = false;
 
   /**
-   * Root element in which quasi-modals (WidgetDiv, DropDownDiv) currently live.
+   * Root element in which popovers (WidgetDiv, DropDownDiv) currently live.
    */
-  private quasiModalFocusRoot?: HTMLElement;
+  private popoverFocusRoot?: HTMLElement;
 
   /**
-   * Set of callbacks to invoke if the quasi-modal focus root loses focus.
+   * Set of callbacks to invoke if the popover focus root loses focus.
    */
-  private quasiModalFocusLossHandlers: Set<() => void> = new Set();
+  private popoverFocusLossHandlers: Set<() => void> = new Set();
 
   /**
-   * Handler for focusout in the quasi-modal focus root that selectively
-   * invokes the quasi-modal focus loss handlers if focus has truly transitioned
-   * outside of the focus root, and not e.g. to a different quasi-modal.
+   * Handler for focusout in the popover focus root that selectively
+   * invokes the popover focus loss handlers if focus has truly transitioned
+   * outside of the focus root, and not e.g. to a different popover.
    */
-  private quasiModalFocusOutHandler = (e: FocusEvent) => {
+  private popoverFocusOutHandler = (e: FocusEvent) => {
     const target = e.relatedTarget;
     if (
       target === null ||
-      (target instanceof Node && !this.quasiModalFocusRoot?.contains(target))
+      (target instanceof Node && !this.popoverFocusRoot?.contains(target))
     ) {
-      for (const handler of this.quasiModalFocusLossHandlers) {
+      for (const handler of this.popoverFocusLossHandlers) {
         handler();
       }
     }
@@ -695,47 +695,47 @@ export class FocusManager {
   }
 
   /**
-   * Sets the current quasi-modal focus root. Generally this is active
+   * Sets the current popover focus root. Generally this is active
    * workspace's injection div or the explicitly specified parent container for
    * the WidgetDiv, DropDownDiv, etc.
    *
    * @internal
-   * @param newRoot The new element that contains all quasi-modals.
+   * @param newRoot The new element that contains all popovers.
    */
-  setQuasiModalFocusRoot(newRoot: HTMLElement) {
-    this.quasiModalFocusRoot?.removeEventListener(
+  setPopoverFocusRoot(newRoot: HTMLElement) {
+    this.popoverFocusRoot?.removeEventListener(
       'focusout',
-      this.quasiModalFocusOutHandler,
+      this.popoverFocusOutHandler,
     );
-    this.quasiModalFocusRoot = newRoot;
-    this.quasiModalFocusRoot.addEventListener(
+    this.popoverFocusRoot = newRoot;
+    this.popoverFocusRoot.addEventListener(
       'focusout',
-      this.quasiModalFocusOutHandler,
+      this.popoverFocusOutHandler,
     );
   }
 
   /**
-   * Registers a callback to be invoked if the quasi-modal focus root loses
-   * focus. This should only be called by quasi-modals that need to react to
+   * Registers a callback to be invoked if the popover focus root loses
+   * focus. This should only be called by popovers that need to react to
    * focus changes by e.g. hiding themselves and resigning ephemeral focus.
    *
    * @internal
    * @param handler A callback function.
    */
-  registerQuasiModalFocusLossHandler(handler: () => void) {
-    this.quasiModalFocusLossHandlers.add(handler);
+  registerPopoverFocusLossHandler(handler: () => void) {
+    this.popoverFocusLossHandlers.add(handler);
   }
 
   /**
-   * Unregisters a previously-registered quasi-modal focus loss handler. This
-   * should only be invoked by quasi-modals when they no longer need to be
+   * Unregisters a previously-registered popover focus loss handler. This
+   * should only be invoked by popovers when they no longer need to be
    * notified of focus loss, typically when they are hidden.
    *
    * @internal
    * @param handler A previously-registered callback function.
    */
-  unregisterQuasiModalFocusLossHandler(handler: () => void) {
-    this.quasiModalFocusLossHandlers.delete(handler);
+  unregisterPopoverFocusLossHandler(handler: () => void) {
+    this.popoverFocusLossHandlers.delete(handler);
   }
 }
 

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -904,7 +904,8 @@ export function registerPerformAction() {
     preconditionFn: (workspace) =>
       !workspace.isDragging() &&
       !dropDownDiv.isVisible() &&
-      !widgetDiv.isVisible(),
+      !widgetDiv.isVisible() &&
+      !getFocusManager().ephemeralFocusTaken(),
     callback: (_workspace, e) => {
       keyboardNavigationController.setIsActive(true);
       const focusedNode = getFocusManager().getFocusedNode();

--- a/packages/blockly/core/widgetdiv.ts
+++ b/packages/blockly/core/widgetdiv.ts
@@ -62,6 +62,19 @@ export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
 }
 
 /**
+ * Deals with the root element that contains this and other quasi-modals losing
+ * focus by returning ephemeral focus if we hold it and hiding the WidgetDiv.
+ */
+function handleFocusLoss() {
+  if (returnEphemeralFocus) {
+    returnEphemeralFocus(false);
+    returnEphemeralFocus = null;
+  }
+
+  hide();
+}
+
+/**
  * Create the widget div and inject it onto the page.
  */
 export function createDom() {
@@ -137,6 +150,7 @@ export function show(
   if (manageEphemeralFocus) {
     returnEphemeralFocus = getFocusManager().takeEphemeralFocus(div);
   }
+  getFocusManager().registerQuasiModalFocusLossHandler(handleFocusLoss);
 }
 
 /**
@@ -150,6 +164,7 @@ export function hide() {
 
   const div = containerDiv;
   if (!div) return;
+  getFocusManager().unregisterQuasiModalFocusLossHandler(handleFocusLoss);
   div.style.display = 'none';
   div.style.left = '';
   div.style.top = '';

--- a/packages/blockly/core/widgetdiv.ts
+++ b/packages/blockly/core/widgetdiv.ts
@@ -62,7 +62,7 @@ export function testOnly_setDiv(newDiv: HTMLDivElement | null) {
 }
 
 /**
- * Deals with the root element that contains this and other quasi-modals losing
+ * Deals with the root element that contains this and other popovers losing
  * focus by returning ephemeral focus if we hold it and hiding the WidgetDiv.
  */
 function handleFocusLoss() {
@@ -150,7 +150,7 @@ export function show(
   if (manageEphemeralFocus) {
     returnEphemeralFocus = getFocusManager().takeEphemeralFocus(div);
   }
-  getFocusManager().registerQuasiModalFocusLossHandler(handleFocusLoss);
+  getFocusManager().registerPopoverFocusLossHandler(handleFocusLoss);
 }
 
 /**
@@ -164,7 +164,7 @@ export function hide() {
 
   const div = containerDiv;
   if (!div) return;
-  getFocusManager().unregisterQuasiModalFocusLossHandler(handleFocusLoss);
+  getFocusManager().unregisterPopoverFocusLossHandler(handleFocusLoss);
   div.style.display = 'none';
   div.style.left = '';
   div.style.top = '';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/563

### Proposed Changes
This PR improves focus management when focus transitions out of the injection div, either via click or tab, while the `WidgetDiv`, `DropDownDiv`, or both are open. Previously, this would get focus management into a bad wedged state. Now, the `WidgetDiv`/`DropDownDiv`(s) will be dismissed, the element that spawned them will get passive focus, and focus will transition to whatever the clicked/tabbed-to element is. When focus returns to the workspace, the element that spawned the `WidgetDiv`/`DropDownDiv` will regain active focus.

At a high level, this works by:
* Listening for `focusout` events on the div that holds the `WidgetDiv`/`DropDownDiv`
* When a `focusout` event is received, checks to make sure that the newly-focused element is actually outside of that div
* If so, notifies the `WidgetDiv` and `DropDownDiv`, which will (a) resign ephemeral focus if they hold it, while instructing the focus manager to *not* actively focus the previously-focused element, and (b) hide themselves
* Keeping tabs on the appropriate state, in the case of multiple workspaces and multiple `*Div`s, as focus moves around and the `*Div`s hide and show.

I manually verified that this worked for dropdowns, menus, and field editors with a single playground and in the multi-playground, and also that behavior is as expected for `FieldAngle` which uses both the `DropDownDiv` and the `WidgetDiv` simultaneously. The latter will need some slight tweaks (in general, for fields that use both, `WidgetDiv` should take ephemeral focus in preference to `DropDownDiv` so that the field editor is focused initially), but focus can move between the field editor and angle picker, both can be interacted with, and when the value is committed or focus leaves the workspace, the field becomes passively/actively focused as appropriate.

I have not added unit tests because (a) it would be a pain but more importantly (b) it'd be very useful to make sure that this is robust and works for MakeCode given the previous churn that attempts to resolve this issue have caused before investing the effort to put together a test suite given point (a).