### PR TITLE
feat: Added keyboard shortcut for displaying tooltip

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -23,6 +23,7 @@ import {Direction, KeyboardMover} from './keyboard_nav/keyboard_mover.js';
 import {keyboardNavigationController} from './keyboard_navigation_controller.js';
 import {Msg} from './msg.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
+import * as Tooltip from './tooltip.js';
 import {aria} from './utils.js';
 import {Coordinate} from './utils/coordinate.js';
 import {KeyCodes} from './utils/keycodes.js';
@@ -64,6 +65,7 @@ export enum names {
   PERFORM_ACTION = 'perform_action',
   DUPLICATE = 'duplicate',
   CLEANUP = 'cleanup',
+  SHOW_TOOLTIP = 'show_tooltip',
 }
 
 /**
@@ -973,6 +975,30 @@ export function registerCleanup() {
 }
 
 /**
+ * Registers keyboard shortcut to display the tooltip for the focused element.
+ */
+export function registerShowTooltip() {
+  const ctrlJ = ShortcutRegistry.registry.createSerializedKey(KeyCodes.J, [
+    KeyCodes.CTRL_CMD,
+  ]);
+
+  const showTooltip: KeyboardShortcut = {
+    name: names.SHOW_TOOLTIP,
+    preconditionFn: (workspace) => !workspace.isDragging(),
+    callback: (workspace) => {
+      const target = getFocusManager().getFocusedNode();
+      keyboardNavigationController.setIsActive(true);
+      Tooltip.display(target, workspace);
+      return true;
+    },
+    keyCodes: [ctrlJ],
+    allowCollision: true,
+    displayText: () => Msg['SHORTCUTS_SHOW_TOOLTIP'],
+  };
+  ShortcutRegistry.registry.register(showTooltip);
+}
+
+/**
  * Registers all default keyboard shortcut item. This should be called once per
  * instance of KeyboardShortcutRegistry.
  *
@@ -1003,6 +1029,7 @@ export function registerKeyboardNavigationShortcuts() {
   registerPerformAction();
   registerDuplicate();
   registerCleanup();
+  registerShowTooltip();
 }
 
 /**

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -987,8 +987,10 @@ export function registerShowTooltip() {
     preconditionFn: (workspace) => !workspace.isDragging(),
     callback: (workspace) => {
       const target = getFocusManager().getFocusedNode();
-      keyboardNavigationController.setIsActive(true);
-      Tooltip.display(target, workspace);
+      if (target !== null) {
+        keyboardNavigationController.setIsActive(true);
+        Tooltip.display(target, workspace);
+      }
       return true;
     },
     keyCodes: [ctrlJ],

--- a/packages/blockly/core/tooltip.ts
+++ b/packages/blockly/core/tooltip.ts
@@ -8,6 +8,7 @@
 
 import * as browserEvents from './browser_events.js';
 import * as common from './common.js';
+import type {IFocusableNode} from './interfaces/i_focusable_node.js';
 import * as blocklyString from './utils/string.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -365,8 +366,12 @@ export function hide() {
 
 /**
  * Display the tooltip for a given target.
+ *
+ * @internal
+ * @param target The node upon which the tooltip should be displayed.
+ * @param workspace The target node's workspace.
  */
-export function display(target: AnyDuringMigration, workspace?: WorkspaceSvg) {
+export function display(target: IFocusableNode, workspace?: WorkspaceSvg) {
   // If the target is not the same element currently displaying a tooltip, hide
   // the existing tooltip and set the target as our element.
   if (element !== target) {
@@ -383,6 +388,14 @@ export function display(target: AnyDuringMigration, workspace?: WorkspaceSvg) {
     // user gesture, such as a click or drag.
     return;
   }
+
+  // Set the position to just below the element with horizontal alignment based
+  // on the target's RTL/LTR orientation.
+  const targetRect = target.getFocusableElement().getBoundingClientRect();
+  const rtl = element.RTL;
+  lastX = rtl ? targetRect.x + targetRect.width : targetRect.x;
+  lastY = targetRect.y + targetRect.height;
+
   show(workspace);
 }
 

--- a/packages/blockly/core/tooltip.ts
+++ b/packages/blockly/core/tooltip.ts
@@ -364,6 +364,29 @@ export function hide() {
 }
 
 /**
+ * Display the tooltip for a given target.
+ */
+export function display(target: AnyDuringMigration, workspace?: WorkspaceSvg) {
+  // If the target is not the same element currently displaying a tooltip, hide
+  // the existing tooltip and set the target as our element.
+  if (element !== target) {
+    hide();
+    poisonedElement = null;
+    element = target;
+  }
+
+  if (!element || !(element as AnyDuringMigration).tooltip) {
+    // No tooltip here to show.
+    return;
+  } else if (blocked) {
+    // Someone doesn't want us to show tooltips.  We are probably handling a
+    // user gesture, such as a click or drag.
+    return;
+  }
+  show(workspace);
+}
+
+/**
  * Hide any in-progress tooltips and block showing new tooltips until the next
  * call to unblock().
  *

--- a/packages/blockly/msg/json/en.json
+++ b/packages/blockly/msg/json/en.json
@@ -451,6 +451,7 @@
 	"SHORTCUTS_PERFORM_ACTION": "Edit or confirm",
 	"SHORTCUTS_DUPLICATE": "Duplicate",
 	"SHORTCUTS_CLEANUP": "Clean up workspace",
+	"SHORTCUTS_SHOW_TOOLTIP": "Show tooltip",
 	"KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT": "Hold %1 and use arrow keys to move freely, then %2 to accept the position",
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Use the arrow keys to move, then %1 to accept the position",
 	"KEYBOARD_NAV_COPIED_HINT": "Copied. Press %1 to paste.",

--- a/packages/blockly/msg/json/qqq.json
+++ b/packages/blockly/msg/json/qqq.json
@@ -458,6 +458,7 @@
 	"SHORTCUTS_PERFORM_ACTION": "shortcut display text for the perform action shortcut, which triggers an action on the focused element.",
 	"SHORTCUTS_DUPLICATE": "shortcut display text for the duplicate shortcut, which duplicates the focused block or comment.",
 	"SHORTCUTS_CLEANUP": "shortcut display text for the cleanup shortcut, which organizes blocks on the workspace.",
+	"SHORTCUTS_SHOW_TOOLTIP": "shortcut display text for the show tooltip shortcut, which displays a short help text for the focused element.",
 	"KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks to arbitrary locations with the keyboard.",
 	"KEYBOARD_NAV_CONSTRAINED_MOVE_HINT": "Message shown to inform users how to move blocks with the keyboard.",
 	"KEYBOARD_NAV_COPIED_HINT": "Message shown when an item is copied in keyboard navigation mode.",

--- a/packages/blockly/msg/messages.js
+++ b/packages/blockly/msg/messages.js
@@ -1786,6 +1786,9 @@ Blockly.Msg.SHORTCUTS_DUPLICATE = 'Duplicate';
 /// shortcut display text for the cleanup shortcut, which organizes blocks on the workspace.
 Blockly.Msg.SHORTCUTS_CLEANUP = 'Clean up workspace';
 /** @type {string} */
+/// shortcut display text for the show tooltip shortcut, which displays a short help text for the focused element.
+Blockly.Msg.SHORTCUTS_SHOW_TOOLTIP = 'Show tooltip';
+/** @type {string} */
 /// Message shown to inform users how to move blocks to arbitrary locations
 /// with the keyboard.
 Blockly.Msg.KEYBOARD_NAV_UNCONSTRAINED_MOVE_HINT = 'Hold %1 and use arrow keys to move freely, then %2 to accept the position';

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1447,7 +1447,7 @@ suite('Keyboard Shortcut Items', function () {
       block.setTooltip('Tooltip Text');
       this.injectionDiv.dispatchEvent(event);
 
-      assert(Blockly.Tooltip.isVisible());
+      assert.isTrue(Blockly.Tooltip.isVisible());
     });
 
     test('Displays new tooltip on a block using the keyboard shortcut if tooltip for another block is already displayed', function () {
@@ -1462,16 +1462,16 @@ suite('Keyboard Shortcut Items', function () {
       this.injectionDiv.dispatchEvent(event);
 
       // We have block1 focused; we should see block1's tooltip
-      assert(Blockly.Tooltip.isVisible());
-      assert(Blockly.Tooltip.getDiv().innerText === 'block1');
+      assert.isTrue(Blockly.Tooltip.isVisible());
+      assert.isTrue(Blockly.Tooltip.getDiv().innerText === 'block1');
 
       // Set focus to block2 and show its tooltip
       Blockly.getFocusManager().focusNode(block2);
       this.injectionDiv.dispatchEvent(event);
 
       // Now we have block2 focused; we should see block2's tooltip
-      assert(Blockly.Tooltip.isVisible());
-      assert(Blockly.Tooltip.getDiv().innerText === 'block2');
+      assert.isTrue(Blockly.Tooltip.isVisible());
+      assert.isTrue(Blockly.Tooltip.getDiv().innerText === 'block2');
     });
 
     test('Do not show tooltip if drag in progress', function () {
@@ -1483,7 +1483,7 @@ suite('Keyboard Shortcut Items', function () {
       block.setTooltip('Tooltip Text');
       this.injectionDiv.dispatchEvent(event);
 
-      assert(!Blockly.Tooltip.isVisible());
+      assert.isFalse(Blockly.Tooltip.isVisible());
     });
   });
 });

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1435,4 +1435,55 @@ suite('Keyboard Shortcut Items', function () {
       assert.deepEqual(oldBounds, newBounds);
     });
   });
+
+  suite('Show tooltip (Ctrl/Cmd+J)', function () {
+    const event = createKeyDownEvent(Blockly.utils.KeyCodes.J, [
+      Blockly.utils.KeyCodes.CTRL_CMD,
+    ]);
+
+    test('Displays tooltip on a block using the keyboard shortcut', function () {
+      const block = this.workspace.newBlock('controls_if');
+      Blockly.getFocusManager().focusNode(block);
+      block.setTooltip('Tooltip Text');
+      this.injectionDiv.dispatchEvent(event);
+
+      assert(Blockly.Tooltip.isVisible());
+    });
+
+    test('Displays new tooltip on a block using the keyboard shortcut if tooltip for another block is already displayed', function () {
+      const block1 = this.workspace.newBlock('controls_if');
+      const block2 = this.workspace.newBlock('logic_compare');
+
+      block1.setTooltip('block1');
+      block2.setTooltip('block2');
+
+      // Set focus to block1 and show its tooltip
+      Blockly.getFocusManager().focusNode(block1);
+      this.injectionDiv.dispatchEvent(event);
+
+      // We have block1 focused; we should see block1's tooltip
+      assert(Blockly.Tooltip.isVisible());
+      assert(Blockly.Tooltip.getDiv().innerText === 'block1');
+
+      // Set focus to block2 and show its tooltip
+      Blockly.getFocusManager().focusNode(block2);
+      this.injectionDiv.dispatchEvent(event);
+
+      // Now we have block2 focused; we should see block2's tooltip
+      assert(Blockly.Tooltip.isVisible());
+      assert(Blockly.Tooltip.getDiv().innerText === 'block2');
+    });
+
+    test('Do not show tooltip if drag in progress', function () {
+      sinon.stub(this.workspace, 'isDragging').returns(true);
+      this.injectionDiv.dispatchEvent(event);
+
+      const block = this.workspace.newBlock('controls_if');
+      Blockly.getFocusManager().focusNode(block);
+      block.setTooltip('Tooltip Text');
+      this.injectionDiv.dispatchEvent(event);
+
+      assert(!Blockly.Tooltip.isVisible());
+    });
+  });
 });


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/447

### Proposed Changes

Adds a keyboard shortcut for displaying the tooltip.

### Reason for Changes

Adding the ability to display the tooltip from a keyboard shortcut increases accessibility for keyboard users.

### Test Coverage

Added unit tests around basic functionality, ensuring an existing tooltip does not block a new tooltip from popping up, and ensuring it does not display while dragging is happening.

### Additional Information

Screenshots:
<img width="309" height="93" alt="Screenshot 2026-04-24 at 1 48 43 PM" src="https://github.com/user-attachments/assets/e8c794f1-2459-42af-8461-6ad0e249095d" />
<img width="251" height="145" alt="Screenshot 2026-04-24 at 1 48 07 PM" src="https://github.com/user-attachments/assets/a99ba13f-c162-457c-8104-379cb31595f8" />


[ ] TODO: Update the key mapping to something that makes sense.
The key mapping in this PR is a placeholder; which actual key(s) to use is something that still needs to be decided. I picked Ctrl+J as it wasn't currently in use. I saw that VS Code uses Ctrl+K followed by Ctrl+I but I didn't see an obvious way to register this in the code and didn't want to spend extra time on it before we even know if we need to do so.