### PR TITLE
fix: Fix bug that could cause focus to be lost in Chrome when dismissing a dropdown

### DIFF
--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -712,7 +712,6 @@ export function hideWithoutAnimation() {
     onHide();
     onHide = null;
   }
-  clearContent();
   owner = null;
 
   (common.getMainWorkspace() as WorkspaceSvg).markFocused();
@@ -721,6 +720,8 @@ export function hideWithoutAnimation() {
     returnEphemeralFocus();
     returnEphemeralFocus = null;
   }
+
+  clearContent();
 }
 
 /**


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9759 

### Proposed Changes
This PR fixes a bug that caused focus to be lost/become passive on the element that spawned a dropdown when selecting an item in the dropdown or dismissing it on Chrome. This was because removal of elements from the DOM triggers `focusout` on Chrome, but not on Firefox and Safari, due to an ambiguity in the spec. That has since been resolved, but Chrome has not (yet?) updated its behavior. I inverted the order of returning ephemeral focus and removing the dropdowndiv from the dom, so that focus will have already been returned before the div is removed, and thus even though that still fires a `focusout` event the `returnEphemeralFocus` handler will have already been invoked and cleared by that point.