### PR TITLE
fix: Disable some shortcuts in the flyout

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -934,6 +934,7 @@ export function registerDuplicate() {
       return (
         !workspace.isDragging() &&
         !workspace.isReadOnly() &&
+        !workspace.isFlyout &&
         (focusedNode instanceof BlockSvg ? focusedNode.isDuplicatable() : true)
       );
     },
@@ -959,7 +960,7 @@ export function registerCleanup() {
   const cleanupShortcut: KeyboardShortcut = {
     name: names.CLEANUP,
     preconditionFn: (workspace) =>
-      !workspace.isDragging() && !workspace.isReadOnly(),
+      !workspace.isDragging() && !workspace.isReadOnly() && !workspace.isFlyout,
     callback: (workspace) => {
       keyboardNavigationController.setIsActive(true);
       workspace.cleanUp();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9760

### Proposed Changes
This PR disables the cleanup shortcut in the flyout, because that was silly. It also disables the Duplicate shortcut, which worked (it put the duplicated block on the main workspace) but...duplicated the functionality of Enter and M, which also insert a block, except in move mode, which seemed preferable, and moreover it was unnecessary to have a third, more esoteric way to do.