### PR TITLE
fix: Fix bug that caused focus rings to be inverted in RTL Zelos

### DIFF
--- a/packages/blockly/core/renderers/zelos/path_object.ts
+++ b/packages/blockly/core/renderers/zelos/path_object.ts
@@ -97,6 +97,7 @@ export class PathObject extends BasePathObject {
             'stroke': this.svgPath.getAttribute('stroke') || '',
             'fill': this.svgPath.getAttribute('fill') || '',
             'd': this.svgPath.getAttribute('d') || '',
+            'transform': this.svgPath.getAttribute('transform') || '',
             'role': Role.PRESENTATION,
           },
           this.svgRoot,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes a bug that caused focus indicators to be flipped when using Zelos in an RTL workspace:

<img width="704" height="347" alt="Screenshot 2026-04-24 at 2 15 33 PM" src="https://github.com/user-attachments/assets/3a26e596-c604-448c-b163-b583bc87dd49" />
