### PR TITLE
fix: Remove unneeded scrollbars on contextual menus

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -380,6 +380,7 @@ input[type=number] {
 .blocklyContextMenu {
   border-radius: 4px;
   max-height: 100%;
+  box-sizing: content-box;
 }
 
 .blocklyDropdownMenu {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9754

### Proposed Changes
This PR fixes the display of scrollbars in non-scrollable menus. Seems like this was a side effect of changing to `box-sizing: border-box`, so I just reverted that for the menu specifically.