### PR TITLE
fix: Prevent errors when mixing keyboard/mouse input in the toolbox/flyout

### DIFF
--- a/packages/blockly/core/interfaces/i_collapsible_toolbox_item.ts
+++ b/packages/blockly/core/interfaces/i_collapsible_toolbox_item.ts
@@ -42,6 +42,7 @@ export function isCollapsibleToolboxItem(
   obj: any,
 ): obj is ICollapsibleToolboxItem {
   return (
+    obj &&
     typeof obj.getChildToolboxItems === 'function' &&
     typeof obj.isExpanded === 'function' &&
     typeof obj.toggleExpanded === 'function' &&

--- a/packages/blockly/core/keyboard_nav/navigators/toolbox_navigator.ts
+++ b/packages/blockly/core/keyboard_nav/navigators/toolbox_navigator.ts
@@ -45,7 +45,10 @@ export class ToolboxNavigator extends Navigator {
       }
     }
 
-    if (isSelectableToolboxItem(node) && !node.getContents().length) {
+    if (
+      !isSelectableToolboxItem(node) ||
+      (isSelectableToolboxItem(node) && !node.getContents().length)
+    ) {
       return null;
     }
 

--- a/packages/blockly/core/toolbox/toolbox.ts
+++ b/packages/blockly/core/toolbox/toolbox.ts
@@ -277,22 +277,33 @@ export class Toolbox
    * @param e Click event to handle.
    */
   protected onClick_(e: PointerEvent) {
+    const close = () => {
+      getFocusManager().focusNode(this);
+      this.clearSelection();
+      (common.getMainWorkspace() as WorkspaceSvg).hideChaff(false);
+      e.preventDefault();
+    };
+
     this.mouseDown = true;
     if (browserEvents.isRightButton(e) || e.target === this.HtmlDiv) {
       // Close flyout.
-      (common.getMainWorkspace() as WorkspaceSvg).hideChaff(false);
+      close();
     } else {
       const targetElement = e.target;
       const itemId = (targetElement as Element).getAttribute('id');
       if (itemId) {
         const item = this.getToolboxItemById(itemId);
         if (item?.isSelectable()) {
-          this.setSelectedItem(item);
           (item as ISelectableToolboxItem).onClick(e);
+          if (item === this.getSelectedItem()) {
+            close();
+          } else {
+            this.setSelectedItem(item);
+            // Just close popups.
+            (common.getMainWorkspace() as WorkspaceSvg).hideChaff(true);
+          }
         }
       }
-      // Just close popups.
-      (common.getMainWorkspace() as WorkspaceSvg).hideChaff(true);
     }
     Touch.clearTouchIdentifier();
   }

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -234,6 +234,7 @@ suite('Toolbox', function () {
       )[0];
       const evt = {
         'target': categoryXml,
+        'stopPropagation': () => {},
       };
       const item = this.toolbox.contents.get(categoryXml.getAttribute('id'));
       const setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9756 

### Proposed Changes
This PR fixes an exception/loss of focus that occurred when clicking a keyboard-selected toolbox category, or clicking below the list of toolbox categories while the flyout was open via keyboard nav. Now, the toolbox and flyout can be interacted with via keyboard or mouse simultaneously and safely.