### PR TITLE
feat: Play delete sound when workspace comments are deleted

### DIFF
--- a/packages/blockly/core/comments/delete_comment_bar_button.ts
+++ b/packages/blockly/core/comments/delete_comment_bar_button.ts
@@ -102,5 +102,6 @@ export class DeleteCommentBarButton extends CommentBarButton {
     this.getCommentView().dispose();
     e?.stopPropagation();
     getFocusManager().focusNode(this.workspace);
+    this.workspace.getAudioManager().play('delete');
   }
 }

--- a/packages/blockly/core/contextmenu_items.ts
+++ b/packages/blockly/core/contextmenu_items.ts
@@ -591,6 +591,7 @@ export function registerCommentDelete() {
       eventUtils.setGroup(true);
       scope.comment?.dispose();
       eventUtils.setGroup(false);
+      scope.comment?.workspace.getAudioManager().play('delete');
     },
     scopeType: ContextMenuRegistry.ScopeType.COMMENT,
     id: 'commentDelete',

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -118,6 +118,7 @@ export function registerDelete() {
         eventUtils.setGroup(true);
         focused.dispose();
         eventUtils.setGroup(false);
+        workspace.getAudioManager().play('delete');
       }
       return true;
     },

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -250,10 +250,13 @@ export function registerCut() {
 
       if (focused instanceof BlockSvg) {
         focused.checkAndDelete();
+        e.preventDefault();
       } else if (isIDeletable(focused)) {
         eventUtils.setGroup(true);
         focused.dispose();
         eventUtils.setGroup(false);
+        workspace.getAudioManager().play('delete');
+        e.preventDefault();
       }
       return !!copyData;
     },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR plays the delete sound effect when workspace comments (or other non-block elements) are deleted or cut. This is consistent with blocks and a helpful auditory cue for accessibility.