### PR TITLE
fix: Fix bug that could cause focus to be lost when deleting a block

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -918,6 +918,14 @@ export class BlockSvg
     Tooltip.dispose();
     ContextMenu.hide();
 
+    if (animate) {
+      this.unplug(healStack);
+      blockAnimations.disposeUiEffect(this);
+    }
+
+    super.dispose(!!healStack);
+    dom.removeNode(this.svgGroup);
+
     // If this block (or a descendant) was focused, focus its parent or
     // workspace instead.
     const focusManager = getFocusManager();
@@ -956,14 +964,6 @@ export class BlockSvg
         }
       }
     }
-
-    if (animate) {
-      this.unplug(healStack);
-      blockAnimations.disposeUiEffect(this);
-    }
-
-    super.dispose(!!healStack);
-    dom.removeNode(this.svgGroup);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
* Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/254, sort of - the issue was already fixed, but this was the last known deletion focus glitch.

This PR fixes a bug that could cause focus to be lost when deleting a block. Blocks attempt to focus a neighbor upon deletion, but because the neighbor was being found mid-dispose, blocks had not yet marked their children as disposing, so in some cases a child block was found as the new focus position, which caused focus to be lost. Moving this to after `super.dispose()` fixes the issue by ensuring that the block and its children are all marked as disposing.