### PR TITLE
feat: Insert blocks at focus point

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -15,6 +15,7 @@ import {ConnectionType} from '../connection_type.js';
 import type {BlockMove} from '../events/events_block_move.js';
 import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
+import {FocusManager} from '../focus_manager.js';
 import {showUnconstrainedMoveHint} from '../hints.js';
 import type {IBubble} from '../interfaces/i_bubble.js';
 import type {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
@@ -26,7 +27,7 @@ import * as layers from '../layers.js';
 import {Msg} from '../msg.js';
 import * as registry from '../registry.js';
 import {finishQueuedRenders} from '../render_management.js';
-import type {RenderedConnection} from '../rendered_connection.js';
+import {RenderedConnection} from '../rendered_connection.js';
 import * as blocks from '../serialization/blocks.js';
 import {Coordinate} from '../utils.js';
 import * as aria from '../utils/aria.js';
@@ -243,10 +244,6 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     this.block.setDragging(true);
-    this.workspace.getLayerManager()?.moveToDragLayer(this.block);
-    this.getVisibleBubbles(this.block).forEach((bubble) => {
-      this.workspace.getLayerManager()?.moveToDragLayer(bubble, false);
-    });
 
     // For keyboard-driven moves, cache a list of valid connection points for
     // use in constrained moved mode.
@@ -254,7 +251,6 @@ export class BlockDragStrategy implements IDragStrategy {
       this.cacheAllConnectionPairs();
 
       // Scooch the block to be offset from the connection preview indicator.
-      this.block.moveDuringDrag(this.startLoc);
       const neighbour = this.updateConnectionPreview(
         this.block,
         new Coordinate(0, 0),
@@ -262,10 +258,11 @@ export class BlockDragStrategy implements IDragStrategy {
       if (neighbour) {
         let offset: Coordinate;
         if (neighbour.type === ConnectionType.PREVIOUS_STATEMENT) {
-          const origin = this.block.getRelativeToSurfaceXY();
           offset = new Coordinate(
-            origin.x + this.BLOCK_CONNECTION_OFFSET,
-            origin.y - this.BLOCK_CONNECTION_OFFSET,
+            neighbour.x,
+            neighbour.y -
+              this.block.getHeightWidth().height -
+              this.BLOCK_CONNECTION_OFFSET,
           );
         } else {
           offset = new Coordinate(
@@ -275,7 +272,14 @@ export class BlockDragStrategy implements IDragStrategy {
         }
         this.block.moveDuringDrag(offset);
       }
+    } else {
+      this.block.moveDuringDrag(this.startLoc);
     }
+
+    this.workspace.getLayerManager()?.moveToDragLayer(this.block);
+    this.getVisibleBubbles(this.block).forEach((bubble) => {
+      this.workspace.getLayerManager()?.moveToDragLayer(bubble, false);
+    });
 
     this.announceMove(true);
     return this.block;
@@ -388,7 +392,7 @@ export class BlockDragStrategy implements IDragStrategy {
    * the initial connection pair is also used as the first connection candidate.
    */
   private storeInitialConnections(healStack: boolean) {
-    // Prioritze the block's parent connection (output or previous) if one exists.
+    // Prioritize the block's parent connection (output or previous) if one exists.
     let localParentConn: RenderedConnection | null = null;
     let parentTargetConn: RenderedConnection | null = null;
 
@@ -536,7 +540,8 @@ export class BlockDragStrategy implements IDragStrategy {
     delta: Coordinate,
   ): RenderedConnection | undefined {
     const currCandidate = this.connectionCandidate;
-    const newCandidate = this.getConnectionCandidate(delta);
+    const newCandidate =
+      this.getInitialCandidate() ?? this.getConnectionCandidate(delta);
 
     if (!newCandidate) {
       // Position above or below the first/last block.
@@ -584,6 +589,8 @@ export class BlockDragStrategy implements IDragStrategy {
         ? currCandidate
         : newCandidate;
     this.connectionCandidate = candidate;
+    console.log('updated');
+    console.log(this.connectionCandidate);
 
     const {local, neighbour} = candidate;
     const localIsOutputOrPrevious =
@@ -1048,5 +1055,75 @@ export class BlockDragStrategy implements IDragStrategy {
     }
 
     return connections as RenderedConnection[];
+  }
+
+  /**
+   * Returns a connection candidate to move the dragged block to at the start of
+   * a drag. If the passively focused node is a connection and the dragged block
+   * can connect to it, the connection will be returned. Otherwise, the first
+   * compatible connection on the passively focused node's block, if any, will
+   * be returned. Returns null if the workspace does not have passive focus.
+   */
+  private getInitialCandidate(): ConnectionCandidate | null {
+    const passiveElement = this.workspace
+      .getSvgGroup()
+      .querySelector(`.${FocusManager.PASSIVE_FOCUS_NODE_CSS_CLASS_NAME}`);
+    if (
+      !passiveElement ||
+      !passiveElement.id ||
+      passiveElement === this.block.getFocusableElement()
+    ) {
+      return null;
+    }
+    const passiveNode = this.workspace.lookUpFocusableNode(passiveElement.id);
+    if (!passiveNode) return null;
+
+    const passiveBlock = this.workspace
+      .getNavigator()
+      .getSourceBlockFromNode(passiveNode);
+    if (!passiveBlock) return null;
+
+    const passiveBlockConnections = passiveBlock.getConnections_(false);
+    let passiveConnection: RenderedConnection | null = null;
+
+    // If the passively focused node is a connection, return it if it is
+    // compatible with the dragged block.
+    if (passiveBlockConnections.includes(passiveNode as any)) {
+      passiveConnection = passiveNode as RenderedConnection;
+      const connectionChecker = this.block.workspace.connectionChecker;
+      const local = this.block.getConnections_(false).find((connection) => {
+        return connectionChecker.canConnect(
+          connection,
+          passiveConnection,
+          true,
+          Infinity,
+        );
+      });
+
+      if (local) {
+        return {local, neighbour: passiveConnection, distance: 0};
+      }
+    }
+
+    // Fall back to returning the first compatible connection on the passively
+    // focused block, if any.
+    const pair = this.allConnectionPairs.find(
+      (pair) => pair.neighbour.getSourceBlock() === passiveBlock,
+    );
+    if (pair) {
+      return this.pairToCandidate(pair);
+    }
+
+    // Fall back further to the parent connection of the passively focused
+    // block, if any.
+    const outputTarget = passiveBlock.outputConnection?.targetConnection;
+    const parentPair = this.allConnectionPairs.find(
+      (pair) => pair.neighbour === outputTarget,
+    );
+    if (parentPair) {
+      return this.pairToCandidate(parentPair);
+    }
+
+    return null;
   }
 }

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -27,7 +27,7 @@ import * as layers from '../layers.js';
 import {Msg} from '../msg.js';
 import * as registry from '../registry.js';
 import {finishQueuedRenders} from '../render_management.js';
-import {RenderedConnection} from '../rendered_connection.js';
+import type {RenderedConnection} from '../rendered_connection.js';
 import * as blocks from '../serialization/blocks.js';
 import {Coordinate} from '../utils.js';
 import * as aria from '../utils/aria.js';

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -589,8 +589,6 @@ export class BlockDragStrategy implements IDragStrategy {
         ? currCandidate
         : newCandidate;
     this.connectionCandidate = candidate;
-    console.log('updated');
-    console.log(this.connectionCandidate);
 
     const {local, neighbour} = candidate;
     const localIsOutputOrPrevious =

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -18,7 +18,7 @@ import {
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
-suite.only('Keyboard-driven movement', function () {
+suite('Keyboard-driven movement', function () {
   setup(function () {
     sharedTestSetup.call(this);
     const toolbox = {

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -18,10 +18,29 @@ import {
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
-suite('Keyboard-driven movement', function () {
+suite.only('Keyboard-driven movement', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    const toolbox = document.getElementById('toolbox-simple');
+    const toolbox = {
+      // There are two kinds of toolboxes. The simpler one is a flyout toolbox.
+      kind: 'flyoutToolbox',
+      // The contents is the blocks and other items that exist in your toolbox.
+      contents: [
+        {
+          kind: 'block',
+          type: 'text_print',
+        },
+        {
+          kind: 'block',
+          type: 'logic_negate',
+        },
+        {
+          kind: 'block',
+          type: 'math_number',
+        },
+      ],
+    };
+
     this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
     Blockly.common.defineBlocks(p5blocks);
     Blockly.KeyboardMover.mover.setMoveDistance(20);
@@ -552,6 +571,124 @@ suite('Keyboard-driven movement', function () {
         sinon.assert.calledOnce(beepSpy);
         beepSpy.restore();
         toastSpy.restore();
+      });
+
+      test('initially moves the block to the previously-focused statement connection', function () {
+        const ifBlock = this.workspace.newBlock('controls_if');
+        ifBlock.initSvg();
+        ifBlock.render();
+
+        const statementConnection = ifBlock.getInput('DO0').connection;
+        Blockly.getFocusManager().focusNode(statementConnection);
+        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
+        this.workspace.getInjectionDiv().dispatchEvent(t);
+        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
+        this.workspace.getInjectionDiv().dispatchEvent(enter);
+
+        const movingBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, movingBlock.previousConnection);
+        assert.equal(candidate.neighbour, statementConnection);
+
+        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
+        this.workspace.getInjectionDiv().dispatchEvent(esc);
+      });
+
+      test("initially moves the block to the previously-focused block's previous connection", function () {
+        const ifBlock = this.workspace.newBlock('controls_if');
+        ifBlock.initSvg();
+        ifBlock.render();
+
+        Blockly.getFocusManager().focusNode(ifBlock);
+        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
+        this.workspace.getInjectionDiv().dispatchEvent(t);
+        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
+        this.workspace.getInjectionDiv().dispatchEvent(enter);
+
+        const movingBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, movingBlock.nextConnection);
+        assert.equal(candidate.neighbour, ifBlock.previousConnection);
+
+        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
+        this.workspace.getInjectionDiv().dispatchEvent(esc);
+      });
+
+      test('initially moves the block to the previously-focused input connection', function () {
+        const ifBlock = this.workspace.newBlock('controls_if');
+        ifBlock.initSvg();
+        ifBlock.render();
+
+        const inputConnection = ifBlock.getInput('IF0').connection;
+        Blockly.getFocusManager().focusNode(inputConnection);
+        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
+        this.workspace.getInjectionDiv().dispatchEvent(t);
+        const down = createKeyDownEvent(Blockly.utils.KeyCodes.DOWN);
+        this.workspace.getInjectionDiv().dispatchEvent(down);
+        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
+        this.workspace.getInjectionDiv().dispatchEvent(enter);
+
+        const movingBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, movingBlock.outputConnection);
+        assert.equal(candidate.neighbour, inputConnection);
+
+        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
+        this.workspace.getInjectionDiv().dispatchEvent(esc);
+      });
+
+      test("initially moves the block to the previously-focused block's input connection", function () {
+        const ifBlock = this.workspace.newBlock('controls_if');
+        ifBlock.initSvg();
+        ifBlock.render();
+
+        Blockly.getFocusManager().focusNode(ifBlock);
+        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
+        this.workspace.getInjectionDiv().dispatchEvent(t);
+        const down = createKeyDownEvent(Blockly.utils.KeyCodes.DOWN);
+        this.workspace.getInjectionDiv().dispatchEvent(down);
+        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
+        this.workspace.getInjectionDiv().dispatchEvent(enter);
+
+        const movingBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, movingBlock.outputConnection);
+        assert.equal(candidate.neighbour, ifBlock.getInput('IF0').connection);
+
+        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
+        this.workspace.getInjectionDiv().dispatchEvent(esc);
+      });
+
+      test("initially moves the block to the previously-focused block's parent input connection", function () {
+        const compare = this.workspace.newBlock('logic_compare');
+        compare.initSvg();
+        compare.render();
+
+        const boolean = this.workspace.newBlock('logic_boolean');
+        boolean.initSvg();
+        boolean.render();
+        boolean.outputConnection.connect(compare.getInput('A').connection);
+
+        Blockly.getFocusManager().focusNode(boolean);
+        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
+        this.workspace.getInjectionDiv().dispatchEvent(t);
+        const down = createKeyDownEvent(Blockly.utils.KeyCodes.DOWN);
+        this.workspace.getInjectionDiv().dispatchEvent(down);
+        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
+        this.workspace.getInjectionDiv().dispatchEvent(enter);
+
+        const movingBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, movingBlock.outputConnection);
+        assert.equal(candidate.neighbour, compare.getInput('A').connection);
+
+        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
+        this.workspace.getInjectionDiv().dispatchEvent(esc);
       });
 
       suite('Statement move tests', function () {

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -556,7 +556,7 @@ suite('Keyboard-driven movement', function () {
       testExemptedShortcutsAllowed();
     });
 
-    suite.only('in constrained mode', function () {
+    suite('in constrained mode', function () {
       test('prompts to use unconstrained mode when no destinations are available', function () {
         const toastSpy = sinon.spy(Blockly.Toast, 'show');
         const beepSpy = sinon.spy(this.workspace.getAudioManager(), 'beep');
@@ -604,7 +604,7 @@ suite('Keyboard-driven movement', function () {
 
         Blockly.getFocusManager().focusNode(ifBlock);
         focusToolbox(this.workspace);
-        startMove(this.workspace)
+        startMove(this.workspace);
 
         const printBlock = Blockly.getFocusManager().getFocusedNode();
         const candidate = printBlock.getDragStrategy().connectionCandidate;
@@ -635,6 +635,25 @@ suite('Keyboard-driven movement', function () {
         cancelMove(this.workspace);
       });
 
+      test('initially moves the block to the previously-focused not-first statement connection', function () {
+        const ifBlock = this.workspace.newBlock('controls_ifelse');
+        ifBlock.initSvg();
+        ifBlock.render();
+
+        const statementConnection = ifBlock.getInput('ELSE').connection;
+        Blockly.getFocusManager().focusNode(statementConnection);
+        focusToolbox(this.workspace);
+        startMove(this.workspace);
+
+        const printBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = printBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, printBlock.previousConnection);
+        assert.equal(candidate.neighbour, statementConnection);
+
+        cancelMove(this.workspace);
+      });
+
       test("initially moves the block to the previously-focused block's input connection", function () {
         const ifBlock = this.workspace.newBlock('controls_if');
         ifBlock.initSvg();
@@ -650,6 +669,25 @@ suite('Keyboard-driven movement', function () {
 
         assert.equal(candidate.local, notBlock.outputConnection);
         assert.equal(candidate.neighbour, ifBlock.getInput('IF0').connection);
+
+        cancelMove(this.workspace);
+      });
+
+      test('initially moves the block to the previously-focused not-first input connection', function () {
+        const compare = this.workspace.newBlock('logic_compare');
+        compare.initSvg();
+        compare.render();
+
+        Blockly.getFocusManager().focusNode(compare.getInput('B').connection);
+        focusToolbox(this.workspace);
+        moveDown(this.workspace);
+        startMove(this.workspace);
+
+        const notBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = notBlock.getDragStrategy().connectionCandidate;
+
+        assert.equal(candidate.local, notBlock.outputConnection);
+        assert.equal(candidate.neighbour, compare.getInput('B').connection);
 
         cancelMove(this.workspace);
       });
@@ -674,6 +712,24 @@ suite('Keyboard-driven movement', function () {
 
         assert.equal(candidate.local, notBlock.outputConnection);
         assert.equal(candidate.neighbour, compare.getInput('A').connection);
+
+        cancelMove(this.workspace);
+      });
+
+      test('initially moves the block to the workspace when the previously-focused block has no compatible connections', function () {
+        const repeat = this.workspace.newBlock('controls_repeat');
+        repeat.initSvg();
+        repeat.render();
+
+        Blockly.getFocusManager().focusNode(repeat);
+        focusToolbox(this.workspace);
+        moveDown(this.workspace);
+        startMove(this.workspace);
+
+        const notBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = notBlock.getDragStrategy().connectionCandidate;
+
+        assert.isNull(candidate);
 
         cancelMove(this.workspace);
       });

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -92,6 +92,11 @@ suite('Keyboard-driven movement', function () {
     workspace.getInjectionDiv().dispatchEvent(event);
   }
 
+  function focusToolbox(workspace) {
+    const event = createKeyDownEvent(Blockly.utils.KeyCodes.T);
+    workspace.getInjectionDiv().dispatchEvent(event);
+  }
+
   /**
    * Create a new block from serialised state (parsed JSON) and
    * optionally attach it to an existing block on the workspace.
@@ -551,7 +556,7 @@ suite('Keyboard-driven movement', function () {
       testExemptedShortcutsAllowed();
     });
 
-    suite('in constrained mode', function () {
+    suite.only('in constrained mode', function () {
       test('prompts to use unconstrained mode when no destinations are available', function () {
         const toastSpy = sinon.spy(Blockly.Toast, 'show');
         const beepSpy = sinon.spy(this.workspace.getAudioManager(), 'beep');
@@ -580,19 +585,16 @@ suite('Keyboard-driven movement', function () {
 
         const statementConnection = ifBlock.getInput('DO0').connection;
         Blockly.getFocusManager().focusNode(statementConnection);
-        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
-        this.workspace.getInjectionDiv().dispatchEvent(t);
-        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
-        this.workspace.getInjectionDiv().dispatchEvent(enter);
+        focusToolbox(this.workspace);
+        startMove(this.workspace);
 
-        const movingBlock = Blockly.getFocusManager().getFocusedNode();
-        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+        const printBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = printBlock.getDragStrategy().connectionCandidate;
 
-        assert.equal(candidate.local, movingBlock.previousConnection);
+        assert.equal(candidate.local, printBlock.previousConnection);
         assert.equal(candidate.neighbour, statementConnection);
 
-        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
-        this.workspace.getInjectionDiv().dispatchEvent(esc);
+        cancelMove(this.workspace);
       });
 
       test("initially moves the block to the previously-focused block's previous connection", function () {
@@ -601,19 +603,16 @@ suite('Keyboard-driven movement', function () {
         ifBlock.render();
 
         Blockly.getFocusManager().focusNode(ifBlock);
-        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
-        this.workspace.getInjectionDiv().dispatchEvent(t);
-        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
-        this.workspace.getInjectionDiv().dispatchEvent(enter);
+        focusToolbox(this.workspace);
+        startMove(this.workspace)
 
-        const movingBlock = Blockly.getFocusManager().getFocusedNode();
-        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+        const printBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = printBlock.getDragStrategy().connectionCandidate;
 
-        assert.equal(candidate.local, movingBlock.nextConnection);
+        assert.equal(candidate.local, printBlock.nextConnection);
         assert.equal(candidate.neighbour, ifBlock.previousConnection);
 
-        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
-        this.workspace.getInjectionDiv().dispatchEvent(esc);
+        cancelMove(this.workspace);
       });
 
       test('initially moves the block to the previously-focused input connection', function () {
@@ -623,21 +622,17 @@ suite('Keyboard-driven movement', function () {
 
         const inputConnection = ifBlock.getInput('IF0').connection;
         Blockly.getFocusManager().focusNode(inputConnection);
-        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
-        this.workspace.getInjectionDiv().dispatchEvent(t);
-        const down = createKeyDownEvent(Blockly.utils.KeyCodes.DOWN);
-        this.workspace.getInjectionDiv().dispatchEvent(down);
-        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
-        this.workspace.getInjectionDiv().dispatchEvent(enter);
+        focusToolbox(this.workspace);
+        moveDown(this.workspace);
+        startMove(this.workspace);
 
-        const movingBlock = Blockly.getFocusManager().getFocusedNode();
-        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+        const notBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = notBlock.getDragStrategy().connectionCandidate;
 
-        assert.equal(candidate.local, movingBlock.outputConnection);
+        assert.equal(candidate.local, notBlock.outputConnection);
         assert.equal(candidate.neighbour, inputConnection);
 
-        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
-        this.workspace.getInjectionDiv().dispatchEvent(esc);
+        cancelMove(this.workspace);
       });
 
       test("initially moves the block to the previously-focused block's input connection", function () {
@@ -646,21 +641,17 @@ suite('Keyboard-driven movement', function () {
         ifBlock.render();
 
         Blockly.getFocusManager().focusNode(ifBlock);
-        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
-        this.workspace.getInjectionDiv().dispatchEvent(t);
-        const down = createKeyDownEvent(Blockly.utils.KeyCodes.DOWN);
-        this.workspace.getInjectionDiv().dispatchEvent(down);
-        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
-        this.workspace.getInjectionDiv().dispatchEvent(enter);
+        focusToolbox(this.workspace);
+        moveDown(this.workspace);
+        startMove(this.workspace);
 
-        const movingBlock = Blockly.getFocusManager().getFocusedNode();
-        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+        const notBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = notBlock.getDragStrategy().connectionCandidate;
 
-        assert.equal(candidate.local, movingBlock.outputConnection);
+        assert.equal(candidate.local, notBlock.outputConnection);
         assert.equal(candidate.neighbour, ifBlock.getInput('IF0').connection);
 
-        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
-        this.workspace.getInjectionDiv().dispatchEvent(esc);
+        cancelMove(this.workspace);
       });
 
       test("initially moves the block to the previously-focused block's parent input connection", function () {
@@ -674,21 +665,17 @@ suite('Keyboard-driven movement', function () {
         boolean.outputConnection.connect(compare.getInput('A').connection);
 
         Blockly.getFocusManager().focusNode(boolean);
-        const t = createKeyDownEvent(Blockly.utils.KeyCodes.T);
-        this.workspace.getInjectionDiv().dispatchEvent(t);
-        const down = createKeyDownEvent(Blockly.utils.KeyCodes.DOWN);
-        this.workspace.getInjectionDiv().dispatchEvent(down);
-        const enter = createKeyDownEvent(Blockly.utils.KeyCodes.ENTER);
-        this.workspace.getInjectionDiv().dispatchEvent(enter);
+        focusToolbox(this.workspace);
+        moveDown(this.workspace);
+        startMove(this.workspace);
 
-        const movingBlock = Blockly.getFocusManager().getFocusedNode();
-        const candidate = movingBlock.getDragStrategy().connectionCandidate;
+        const notBlock = Blockly.getFocusManager().getFocusedNode();
+        const candidate = notBlock.getDragStrategy().connectionCandidate;
 
-        assert.equal(candidate.local, movingBlock.outputConnection);
+        assert.equal(candidate.local, notBlock.outputConnection);
         assert.equal(candidate.neighbour, compare.getInput('A').connection);
 
-        const esc = createKeyDownEvent(Blockly.utils.KeyCodes.ESC);
-        this.workspace.getInjectionDiv().dispatchEvent(esc);
+        cancelMove(this.workspace);
       });
 
       suite('Statement move tests', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9758

### Proposed Changes
This PR reintroduces support for inserting blocks from the flyout at or near the currently focused node in the workspace. If a connection is focused, and the chosen block can connect to it, it will be initially moved to/proposed for connection at that point; otherwise, the focused node's parent block will be identified, and, assuming there is one, the inserted block will be proposed for connection to the first compatible connection on that block. A final attempt will be made to connect the inserted block to the focused block's parent block's input connection, after which the inserted block will just be initially proposed as a top-level block.