### PR TITLE
fix: Added comma between labels for fields when composing ARIA label strings

### DIFF
--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -413,7 +413,7 @@ export class Input {
         );
       }
     }
-    return labels.join(' ');
+    return labels.join(', ');
   }
 
   /**

--- a/packages/blockly/tests/mocha/input_test.js
+++ b/packages/blockly/tests/mocha/input_test.js
@@ -369,17 +369,11 @@ suite('Inputs', function () {
       assert.equal(labelA, labelB);
     });
     test('Field labels are comma separated', function () {
-      this.block
-        .appendDummyInput('NAME')
-        .appendField(new Blockly.FieldTextInput('text'), 'NAME');
-      this.block
-        .appendDummyInput('VALUE')
-        .appendField(new Blockly.FieldNumber('number'), 'VALUE');
+      this.block.appendDummyInput().appendField('first').appendField('second');
 
       const label = this.block.getAriaLabel();
-      const inputLabels = this.block.inputList.map((input) => input.getLabel());
 
-      assert.include(label, inputLabels.join(', '));
+      assert.include(label, 'first, second');
     });
   });
 });

--- a/packages/blockly/tests/mocha/input_test.js
+++ b/packages/blockly/tests/mocha/input_test.js
@@ -368,5 +368,18 @@ suite('Inputs', function () {
       // AriaLabelProvider and without setting the provider (the default label)
       assert.equal(labelA, labelB);
     });
+    test('Field labels are comma separated', function () {
+      this.block
+        .appendDummyInput('NAME')
+        .appendField(new Blockly.FieldTextInput('text'), 'NAME');
+      this.block
+        .appendDummyInput('VALUE')
+        .appendField(new Blockly.FieldNumber('number'), 'VALUE');
+
+      const label = this.block.getAriaLabel();
+      const inputLabels = this.block.inputList.map((input) => input.getLabel());
+
+      assert.include(label, inputLabels.join(', '));
+    });
   });
 });


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9791

### Proposed Changes

Adds a comma between inputs when joining together the array of input labels.

Screenshot:

<img width="1030" height="822" alt="Screenshot 2026-05-04 at 12 11 09 PM" src="https://github.com/user-attachments/assets/800a3b95-ad54-493e-af21-3d5a09f55971" />

### Reason for Changes

This change will add a comma between labels for fields when composing the ARIA label string. This signals to the screenreader that it should pause, which gives screenreader users valuable information about the composition of the block.

### Test Coverage

N/A

