### PR TITLE
fix: Fix bug that could cause unintend block movements

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1893,7 +1893,8 @@ export class BlockSvg
   onNodeFocus(): void {
     this.recomputeAriaAttributes();
     this.select();
-    if (getFocusManager().getFocusedNode() !== this) {
+    const focusedNode = getFocusManager().getFocusedNode();
+    if (focusedNode && focusedNode !== this) {
       renderManagement.finishQueuedRenders().then(() => {
         this.workspace.scrollBoundsIntoView(
           this.getBoundingRectangleWithoutChildren(),


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9708

### Proposed Changes
This PR fixes a bug that caused unintended block movements in Chrome. When blocks are focused, they scroll themselves into view, so that keyboard navigation doesn't focus an offscreen block. Now, blocks only do so if there was already a focused node - this still works in the keyboard nav case (if the block gains focus via a click, it must have been on screen, and if it gains focus via the keyboard, something else e.g. the workspace or another block had to have focus first), but avoids a situation where blocks would try to refocus themselves or focus during intermediate transition states between the drag layer and main workspace layer where focus could be lost as elements were added and removed from the DOM.