### PR TITLE
fix: Adjust keyboard navigation of external inputs

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1978,9 +1978,9 @@ export class BlockSvg
 
   /**
    * Returns an ID for the visual "row" this block is part of. A "row" is
-   * bounded by a previous/next connection or a block stack boundary; all
-   * blocks/inputs nested inside of a block that is a root block or has a next/
-   * previous connection are conceptually part of its same row.
+   * bounded by a previous/next connection, a statement input, or a block stack
+   * boundary; all blocks/inputs nested inside of one of those are conceptually
+   * part of its same row.
    *
    * @internal
    */

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1977,7 +1977,7 @@ export class BlockSvg
   }
 
   /**
-   * Returns an ID for the visual "row" this block is part of. A "row" is
+   * Returns an ID for the logical "row" this block is part of. A "row" is
    * bounded by a previous/next connection, a statement input, or a block stack
    * boundary; all blocks/inputs nested inside of one of those are conceptually
    * part of its same row.

--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1977,7 +1977,10 @@ export class BlockSvg
   }
 
   /**
-   * Returns an ID for the visual "row" this block is part of.
+   * Returns an ID for the visual "row" this block is part of. A "row" is
+   * bounded by a previous/next connection or a block stack boundary; all
+   * blocks/inputs nested inside of a block that is a root block or has a next/
+   * previous connection are conceptually part of its same row.
    *
    * @internal
    */

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -361,7 +361,10 @@ export class Input {
   }
 
   /**
-   * Returns an ID for the visual "row" this input is part of.
+   * Returns an ID for the visual "row" this input is part of. A "row" is
+   * bounded by a previous/next connection or a block stack boundary; all
+   * blocks/inputs nested inside of a block that is a root block or has a next/
+   * previous connection are conceptually part of its same row.
    *
    * @internal
    */
@@ -377,19 +380,17 @@ export class Input {
     const precedingStatementInput =
       inputs[inputIndex - 1].connection?.type === ConnectionType.NEXT_STATEMENT;
 
-    // Each subsequent (a) external input (b) statement input or (c) inline
-    // input following a statement input is on its own row and has its own row
-    // ID.
+    // Each subsequent statement input or value input following a statement
+    // input is on its own row and has its own row ID.
     if (
-      !this.getSourceBlock().getInputsInline() ||
       this.connection?.type === ConnectionType.NEXT_STATEMENT ||
       precedingStatementInput
     ) {
       return `${this.getSourceBlock().id}-input${inputIndex}`;
     }
 
-    // Value inputs on a inline input block have the same row ID as their
-    // preceding input, since they're all on one row.
+    // Value inputs have the same row ID as their preceding input, since
+    // they're all on one row.
     return inputs[inputIndex - 1].getRowId();
   }
 

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -362,9 +362,9 @@ export class Input {
 
   /**
    * Returns an ID for the visual "row" this input is part of. A "row" is
-   * bounded by a previous/next connection or a block stack boundary; all
-   * blocks/inputs nested inside of a block that is a root block or has a next/
-   * previous connection are conceptually part of its same row.
+   * bounded by a previous/next connection, a statement input, or a block stack
+   * boundary; all blocks/inputs nested inside of one of those are conceptually
+   * part of its same row.
    *
    * @internal
    */

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -361,7 +361,7 @@ export class Input {
   }
 
   /**
-   * Returns an ID for the visual "row" this input is part of. A "row" is
+   * Returns an ID for the logical "row" this input is part of. A "row" is
    * bounded by a previous/next connection, a statement input, or a block stack
    * boundary; all blocks/inputs nested inside of one of those are conceptually
    * part of its same row.

--- a/packages/blockly/core/keyboard_nav/navigators/navigator.ts
+++ b/packages/blockly/core/keyboard_nav/navigators/navigator.ts
@@ -5,7 +5,6 @@
  */
 
 import {BlockSvg} from '../../block_svg.js';
-import {ConnectionType} from '../../connection_type.js';
 import {Field} from '../../field.js';
 import {getFocusManager} from '../../focus_manager.js';
 import {Icon} from '../../icons/icon.js';
@@ -182,24 +181,6 @@ export class Navigator {
    *     "row" as the given node, or null if there is none.
    */
   getOutNode(node = getFocusManager().getFocusedNode()): IFocusableNode | null {
-    // Special case: blocks and input value connections on blocks with external
-    // inputs should always navigate to the parent block, even though they're
-    // not necessarily on the same visual row.
-    const connection =
-      node instanceof BlockSvg
-        ? node.outputConnection?.targetConnection
-        : node instanceof RenderedConnection &&
-            node.type === ConnectionType.INPUT_VALUE
-          ? node
-          : null;
-    if (
-      connection &&
-      !connection.getSourceBlock().getInputsInline() &&
-      connection !== connection.getSourceBlock().inputList[0].connection
-    ) {
-      return connection.getSourceBlock();
-    }
-
     return this.getPreviousNodeImpl(node, node, NavigationDirection.OUT);
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR adjusts the behavior of keyboard navigation on blocks, particularly those with external inputs. Previously, every empty external input or block connected to an external input was treated as being on its own row, so that pressing the up/down arrows would move focus to the next "row". For example, in this screenshot, pressing up would focus the empty "if true" input,  then the "if false" input on the most-deeply-nested ternary block, and so forth.
<img width="321" height="293" alt="Screenshot 2026-05-06 at 9 19 13 AM" src="https://github.com/user-attachments/assets/e2d23e41-e709-4edf-bbb8-eb9d51e38767" />

Now, rows are demarcated solely by (a) next/previous connections (b) separate block stacks, and (c) statement inputs. All nested blocks/inputs/fields inside a block that has a next/previous connection, is a root block, or is part of a clause of a block that has statement inputs are treated as being on its same row. Thus, up arrow in the screenshot above would take you to the previous block stack. Nested inputs/blocks may be visited via the left and right arrows.