### PR TITLE
fix: Avoid locking up the test suite

### DIFF
--- a/packages/blockly/tests/mocha/index.html
+++ b/packages/blockly/tests/mocha/index.html
@@ -157,6 +157,8 @@
       import * as Blockly from '../../build/blockly.loader.mjs';
       import '../../build/blocks.loader.mjs';
       import {javascriptGenerator} from '../../build/javascript.loader.mjs';
+      import {config} from '../../node_modules/chai/index.js';
+      config.showDiff = false;
 
       // Import tests.
       import './aria_test.js';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
This PR fixes an issue that could cause the entire test suite page/tab to entirely freeze when a failed assertion was encountered. For undetermined reasons, trying to calculate/display the diff of certain objects would have this effect. Now, diffs are suppressed, so the assert will simply fail normally and allow the rest of the test suite to continue merrily on its way. Tests generally shouldn't be failing, and if they are the first thing to do is to investigate the cause, so not having diffs automatically displayed is not a large burden vs manually binary searching for failing tests when a code change causes multiple breakages that can't be identified because the whole test suite locks up.