### PR TITLE
fix: Improve ARIA fallback generation for HTML-based menu items

### DIFF
--- a/packages/blockly/core/menuitem.ts
+++ b/packages/blockly/core/menuitem.ts
@@ -114,7 +114,12 @@ export class MenuItem {
   getAriaLabel(): string {
     // This fallback should only be hit by Context Menu items as all
     // FieldDropdown options should have an ARIA label.
-    return this.ariaLabel || String(this.content);
+    return (
+      this.ariaLabel ||
+      (typeof this.content === 'string'
+        ? String(this.content)
+        : this.content.textContent)
+    );
   }
 
   /** Dispose of this menu item. */

--- a/packages/blockly/core/menuitem.ts
+++ b/packages/blockly/core/menuitem.ts
@@ -117,7 +117,7 @@ export class MenuItem {
     return (
       this.ariaLabel ||
       (typeof this.content === 'string'
-        ? String(this.content)
+        ? this.content
         : this.content.textContent)
     );
   }

--- a/packages/blockly/tests/mocha/menu_item_test.js
+++ b/packages/blockly/tests/mocha/menu_item_test.js
@@ -173,4 +173,14 @@ suite('Menu items', function () {
     this.menuItem.performAction(new Event('click'));
     assert.isTrue(called);
   });
+
+  test('return accurate ARIA labels for HTML elements', function () {
+    const div = document.createElement('div');
+    const nestedDiv = document.createElement('div');
+    nestedDiv.textContent = 'nested';
+    div.textContent = 'test';
+    div.appendChild(nestedDiv);
+    const testMenuItem = new Blockly.MenuItem(div);
+    assert.equal(testMenuItem.getAriaLabel(), 'testnested');
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes @microbit-robert's comment in #9785 

### Proposed Changes
This PR improves the fallback ARIA label generation of HTML-based contextual menu items. Previously, menu items that didn't have an explicit ARIA label set were wrapped in `String()`, which produced `[object HTMLDivElement]` or the like. Now, when the menu item is HTML-based, its `textContent` field is used.