### PR TITLE
fix: Improve focus management on block deletion

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -923,17 +923,16 @@ export class BlockSvg
       blockAnimations.disposeUiEffect(this);
     }
 
+    const focusManager = getFocusManager();
+    const focusedElement =
+      focusManager.getFocusedNode()?.getFocusableElement() ?? null;
+
     super.dispose(!!healStack);
     dom.removeNode(this.svgGroup);
 
     // If this block (or a descendant) was focused, focus its parent or
     // workspace instead.
-    const focusManager = getFocusManager();
-    if (
-      this.getSvgRoot().contains(
-        focusManager.getFocusedNode()?.getFocusableElement() ?? null,
-      )
-    ) {
+    if (this.getSvgRoot().contains(focusedElement)) {
       let parent: BlockSvg | undefined | null = this.getParent();
       if (!parent) {
         // In some cases, blocks are disconnected from their parents before
@@ -950,19 +949,20 @@ export class BlockSvg
           parent = targetConnection?.getSourceBlock();
         }
       }
-      if (parent) {
-        focusManager.focusNode(parent);
-      } else {
-        const nearestNeighbour = this.getNearestNeighbour();
-        if (nearestNeighbour) {
-          focusManager.focusNode(nearestNeighbour);
+      setTimeout(() => {
+        if (!this.workspace.rendered) return;
+        if (parent) {
+          focusManager.focusNode(parent);
         } else {
-          setTimeout(() => {
-            if (!this.workspace.rendered) return;
+          const nearestNeighbour = this.getNearestNeighbour();
+
+          if (nearestNeighbour) {
+            focusManager.focusNode(nearestNeighbour);
+          } else {
             focusManager.focusTree(this.workspace);
-          }, 0);
+          }
         }
-      }
+      }, 0);
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9823

### Proposed Changes
This PR fixes the focus management on block deletion in Chrome. I verified that this works in Chrome, Safari and Firefox when deleting a block (a) with a parent (b) with a near neighbor and (c) the last block on the workspace. 