### PR TITLE
fix: Don't suppress passive focus on blocks

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -566,12 +566,6 @@ input[type=number] {
 
 /* Passive focus cases: */
 /* Blocks with passive focus except when widget/dropdown div in use. */
-.blocklyKeyboardNavigation:not(
-        :has(
-            .blocklyDropDownDiv:focus-within,
-            .blocklyWidgetDiv:focus-within
-          )
-      )
   .blocklyPassiveFocus:is(
     .blocklyPath:not(.blocklyFlyout .blocklyPath),
     .blocklyHighlightedConnectionPath


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9816

### Proposed Changes
This PR removes CSS that suppressed the display of passive focus on blocks when the widgetdiv/dropdowndiv were present. This means that the block that triggered a contextual menu will now be displayed as having passive focus when a contextual menu is opened via the mouse or the keyboard.