### PR TITLE
fix: Update workspace ARIA label on focus

### DIFF
--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -720,7 +720,7 @@ export class WorkspaceSvg
       );
     } else {
       // Main workspaces get labelled with how many stacks of blocks they contain
-      // This will be updated in a change listener, but set it here in case there are blocks in the initial state of the workspace
+      // This will be updated on focus, but set it here in case there are blocks in the initial state of the workspace
       this.updateAriaLabel();
     }
   }
@@ -797,14 +797,6 @@ export class WorkspaceSvg
     this.svgBubbleCanvas_ = this.layerManager.getBubbleLayer();
 
     this.setInitialAriaContext();
-
-    if (!this.isFlyout && !this.isMutator) {
-      // Set up a change listener to update the aria label on main workspace
-      this.addChangeListener((e) => {
-        if (e.isUiEvent) return;
-        this.updateAriaLabel();
-      });
-    }
 
     if (!this.isFlyout) {
       browserEvents.conditionalBind(
@@ -2696,7 +2688,11 @@ export class WorkspaceSvg
   }
 
   /** See IFocusableNode.onNodeFocus. */
-  onNodeFocus(): void {}
+  onNodeFocus(): void {
+    if (!this.isFlyout && !this.isMutator) {
+      this.updateAriaLabel();
+    }
+  }
 
   /** See IFocusableNode.onNodeBlur. */
   onNodeBlur(): void {}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9835

### Proposed Changes
This PR updates the workspace's ARIA label when it gains focus, instead of a change listener. This avoids unneeded updates and improves performance. Mutator and flyout workspaces are excluded, as their labels are set elsewhere. 