### PR TITLE
fix: Improve display of move-related hints

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -16,7 +16,10 @@ import type {BlockMove} from '../events/events_block_move.js';
 import {EventType} from '../events/type.js';
 import * as eventUtils from '../events/utils.js';
 import {FocusManager} from '../focus_manager.js';
-import {showUnconstrainedMoveHint} from '../hints.js';
+import {
+  showConstrainedMovementHint,
+  showUnconstrainedMoveHint,
+} from '../hints.js';
 import type {IBubble} from '../interfaces/i_bubble.js';
 import type {IConnectionPreviewer} from '../interfaces/i_connection_previewer.js';
 import type {IDragStrategy} from '../interfaces/i_draggable.js';
@@ -272,6 +275,12 @@ export class BlockDragStrategy implements IDragStrategy {
         }
         this.block.moveDuringDrag(offset);
       }
+
+      if (this.allConnectionPairs.length) {
+        showConstrainedMovementHint(this.workspace);
+      } else {
+        showUnconstrainedMoveHint(this.workspace);
+      }
     } else {
       this.block.moveDuringDrag(this.startLoc);
     }
@@ -519,7 +528,7 @@ export class BlockDragStrategy implements IDragStrategy {
         this.moveMode === MoveMode.CONSTRAINED &&
         !this.allConnectionPairs.length
       ) {
-        showUnconstrainedMoveHint(this.workspace);
+        showUnconstrainedMoveHint(this.workspace, true);
         this.workspace.getAudioManager().playErrorBeep();
       }
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9799

### Proposed Changes
This PR improves the display of move mode-related hints in toasts. Specifically, it:

* Displays a prompt to use unconstrained mode every time the arrow keys are used without a modifier when the block being moved has no available destinations
* Displays a prompt to use constrained/unconstrained move mode, as appropriate, the first time a block is inserted from the flyout as does/does not have available destinations.