### PR TITLE
fix: Block-level ARIA labels no longer include clickable image descri…

### DIFF
--- a/packages/blockly/core/field.ts
+++ b/packages/blockly/core/field.ts
@@ -366,9 +366,11 @@ export abstract class Field<T = any>
    * checkboxes represent their checked/non-checked status (i.e. value) through
    * a separate ARIA property.
    *
-   * It's not expected that this method, under normal operations, returns an empty
-   * string. If the field's value is empty then it will return a localized
-   * placeholder indicating that its value is empty.
+   * If the field's value is empty then it will return a localized placeholder
+   * indicating that its value is empty. If this method returns an empty string,
+   * the output will be ignored when composing the block-level ARIA label. Make
+   * sure you want your label hidden from screenreaders before returning an
+   * empty string.
    *
    * @param includeTypeInfo Whether to include the field's type information in
    *     the returned label, if available.

--- a/packages/blockly/core/field_image.ts
+++ b/packages/blockly/core/field_image.ts
@@ -315,11 +315,34 @@ export class FieldImage extends Field<string> {
     return this.altText || null;
   }
 
+  /**
+   * Computes a descriptive ARIA label to represent this field with configurable
+   * verbosity.
+   *
+   * A 'verbose' label includes type information, if available, whereas a
+   * non-verbose label only contains the field's value.
+   *
+   * Note that this will always return the latest representation of the field's
+   * label which may differ from any previously set ARIA label for the field
+   * itself. Implementations are largely responsible for ensuring that the
+   * field's ARIA label is set correctly at relevant moments in the field's
+   * lifecycle (such as when its value changes).
+   *
+   * Finally, it is never guaranteed that implementations use the label returned
+   * by this method for their actual ARIA label. Some implementations may rely
+   * on other contexts to convey information like the field's value. Example:
+   * checkboxes represent their checked/non-checked status (i.e. value) through
+   * a separate ARIA property.
+   *
+   * Returns an empty string on clickable images (buttons), as we do not want to
+   * include image buttons on the block-level ARIA label. When the button is
+   * focused the label is set in recomputeAriaContext below.
+   *
+   * @param includeTypeInfo Whether to include the field's type information in
+   *     the returned label, if available.
+   */
   override computeAriaLabel(includeTypeInfo: boolean): string {
-    if (this.isClickable()) {
-      return '';
-    }
-    return super.computeAriaLabel(includeTypeInfo);
+    return this.isClickable() ? '' : super.computeAriaLabel(includeTypeInfo);
   }
 
   /**
@@ -340,6 +363,11 @@ export class FieldImage extends Field<string> {
       aria.clearState(focusableElement, aria.State.LABEL);
       return false;
     }
+    // For clickable images we need to set the label to the alt text here as
+    // we have overridden the computeAriaLabel to return an empty string. This
+    // will set it at the element level.
+    const label = this.getAriaValue() || '';
+    aria.setState(focusableElement, aria.State.LABEL, label);
     return true;
   }
 }

--- a/packages/blockly/core/field_image.ts
+++ b/packages/blockly/core/field_image.ts
@@ -315,6 +315,13 @@ export class FieldImage extends Field<string> {
     return this.altText || null;
   }
 
+  override computeAriaLabel(includeTypeInfo: boolean): string {
+    if (this.isClickable()) {
+      return '';
+    }
+    return super.computeAriaLabel(includeTypeInfo);
+  }
+
   /**
    * Recomputes the ARIA role and label for this field.
    */
@@ -338,7 +345,7 @@ export class FieldImage extends Field<string> {
       this.isClickable() ? aria.Role.BUTTON : aria.Role.PRESENTATION,
     );
 
-    const label = this.computeAriaLabel(true);
+    const label = this.isClickable() ? this.getAriaValue() || '' : super.computeAriaLabel(true);
     aria.setState(focusableElement, aria.State.LABEL, label);
   }
 }

--- a/packages/blockly/tests/mocha/field_image_test.js
+++ b/packages/blockly/tests/mocha/field_image_test.js
@@ -379,7 +379,7 @@ suite('Image Fields', function () {
       });
     });
     suite('Image with click handler', function () {
-      test('Field has field type name in ARIA label', function () {
+      test('Field has alt text ARIA label', function () {
         const block = this.workspace.newBlock('test_images_clickhandler');
         const field = block.getField('IMAGE');
         block.initSvg();
@@ -387,9 +387,9 @@ suite('Image Fields', function () {
 
         const focusableElement = field.getFocusableElement();
         const fieldLabel = focusableElement.getAttribute('aria-label');
-        assert.include(fieldLabel, 'image:');
+        assert.include(fieldLabel, 'image with click handler');
       });
-      test('Focusable element has  role of button', function () {
+      test('Focusable element has role of button', function () {
         const block = this.workspace.newBlock('test_images_clickhandler');
         const field = block.getField('IMAGE');
         block.initSvg();
@@ -398,6 +398,17 @@ suite('Image Fields', function () {
         const focusableElement = field.getFocusableElement();
         const role = focusableElement.getAttribute('role');
         assert.equal(role, 'button');
+      });
+      test('Block omits image button from ARIA label', function () {
+        const block = this.workspace.newBlock('test_images_clickhandler');
+        const field = block.getField('IMAGE');
+        block.initSvg();
+        block.render();
+
+        const blockFocusableElement = block.getFocusableElement();
+        const blockLabel = blockFocusableElement.getAttribute('aria-label');
+        assert.notInclude(blockLabel, 'Image:');
+        assert.notInclude(blockLabel, 'image with click handler');
       });
     });
   });


### PR DESCRIPTION
## The basics

- [x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9797

### Proposed Changes

Updates how we handle ARIA labels for clickable images (image buttons) as folows:
 - At the block level, we ignore these images
 - At the focusable element level, we set the ARIA label to the alt text

#### Before changes
Block level:
<img width="638" height="260" alt="Screenshot 2026-05-12 at 1 17 39 PM (2)" src="https://github.com/user-attachments/assets/06b04655-576a-4b50-adfa-4c06a7deaf0b" />
Clickable image level:
<img width="632" height="246" alt="Screenshot 2026-05-12 at 1 17 49 PM (2)" src="https://github.com/user-attachments/assets/2dcf141d-6e6d-4a36-9ac6-e236f9adddab" />

#### After changes
Block level:
<img width="647" height="267" alt="Screenshot 2026-05-12 at 1 18 33 PM (2)" src="https://github.com/user-attachments/assets/ed2d87d1-1dc3-4152-a7c5-ab97f9a883a0" />
Clickable image level:
<img width="629" height="256" alt="Screenshot 2026-05-12 at 1 18 42 PM (2)" src="https://github.com/user-attachments/assets/4b709329-5c5e-488d-9b4d-b71739b07c33" />

### Reason for Changes

The way we were handling image buttons was confusing to users and made it difficult to navigate custom blocks with image buttons.

### Test Coverage

Updated an existing test and added a new test.
