### PR TITLE
feat!: Added additional keyboard shortcuts for context menu

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -558,13 +558,18 @@ export function registerMovementShortcuts() {
 }
 
 /**
- * Keyboard shortcut to show the context menu on ctrl/cmd+Enter.
+ * Keyboard shortcut to show the context menu on ctrl/cmd+Enter, shift+F10, and
+ * the menu key.
  */
 export function registerShowContextMenu() {
   const ctrlEnter = ShortcutRegistry.registry.createSerializedKey(
     KeyCodes.ENTER,
     [KeyCodes.CTRL_CMD],
   );
+
+  const shiftF10 = ShortcutRegistry.registry.createSerializedKey(KeyCodes.F10, [
+    KeyCodes.SHIFT,
+  ]);
 
   const contextMenuShortcut: KeyboardShortcut = {
     name: names.MENU,
@@ -582,7 +587,7 @@ export function registerShowContextMenu() {
       }
       return false;
     },
-    keyCodes: [ctrlEnter],
+    keyCodes: [ctrlEnter, shiftF10, KeyCodes.CONTEXT_MENU],
     displayText: () => Msg['SHORTCUTS_SHOW_CONTEXT_MENU'],
   };
   ShortcutRegistry.registry.register(contextMenuShortcut);

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -474,13 +474,12 @@ suite('Keyboard Shortcut Items', function () {
       [Blockly.utils.KeyCodes.CTRL_CMD],
     );
 
-    const shiftF10KeyEvent = createKeyDownEvent(
-      Blockly.utils.KeyCodes.F10,
-      [Blockly.utils.KeyCodes.SHIFT],
-    );
+    const shiftF10KeyEvent = createKeyDownEvent(Blockly.utils.KeyCodes.F10, [
+      Blockly.utils.KeyCodes.SHIFT,
+    ]);
 
     const menuKeyEvent = createKeyDownEvent(
-      Blockly.utils.KeyCodes.CONTEXT_MENU
+      Blockly.utils.KeyCodes.CONTEXT_MENU,
     );
 
     test('Displays context menu on a block using Ctrl/Cmd+Enter', function () {
@@ -533,7 +532,7 @@ suite('Keyboard Shortcut Items', function () {
       }
     });
 
-        test('Displays context menu on a block using Shift+F10', function () {
+    test('Displays context menu on a block using Shift+F10', function () {
       const block = setSelectedBlock(this.workspace);
       this.injectionDiv.dispatchEvent(shiftF10KeyEvent);
 
@@ -583,7 +582,7 @@ suite('Keyboard Shortcut Items', function () {
       }
     });
 
-        test('Displays context menu on a block using the menu button', function () {
+    test('Displays context menu on a block using the menu button', function () {
       const block = setSelectedBlock(this.workspace);
       this.injectionDiv.dispatchEvent(menuKeyEvent);
 

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -468,13 +468,22 @@ suite('Keyboard Shortcut Items', function () {
     );
   });
 
-  suite('Show context menu (Ctrl/Cmd+Enter)', function () {
+  suite('Show context menu', function () {
     const contextMenuKeyEvent = createKeyDownEvent(
       Blockly.utils.KeyCodes.ENTER,
       [Blockly.utils.KeyCodes.CTRL_CMD],
     );
 
-    test('Displays context menu on a block using the keyboard shortcut', function () {
+    const shiftF10KeyEvent = createKeyDownEvent(
+      Blockly.utils.KeyCodes.F10,
+      [Blockly.utils.KeyCodes.SHIFT],
+    );
+
+    const menuKeyEvent = createKeyDownEvent(
+      Blockly.utils.KeyCodes.CONTEXT_MENU
+    );
+
+    test('Displays context menu on a block using Ctrl/Cmd+Enter', function () {
       const block = setSelectedBlock(this.workspace);
       this.injectionDiv.dispatchEvent(contextMenuKeyEvent);
 
@@ -491,7 +500,7 @@ suite('Keyboard Shortcut Items', function () {
       }
     });
 
-    test('Displays context menu on the workspace using the keyboard shortcut', function () {
+    test('Displays context menu on the workspace using Ctrl/Cmd+Enter', function () {
       Blockly.getFocusManager().focusNode(this.workspace);
       this.injectionDiv.dispatchEvent(contextMenuKeyEvent);
 
@@ -507,7 +516,7 @@ suite('Keyboard Shortcut Items', function () {
       }
     });
 
-    test('Displays context menu on a workspace comment using the keyboard shortcut', function () {
+    test('Displays context menu on a workspace comment using Ctrl/Cmd+Enter', function () {
       Blockly.ContextMenuItems.registerCommentOptions();
       const comment = setSelectedComment(this.workspace);
       this.injectionDiv.dispatchEvent(contextMenuKeyEvent);
@@ -518,6 +527,106 @@ suite('Keyboard Shortcut Items', function () {
         Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
           {comment, focusedNode: comment},
           contextMenuKeyEvent,
+        );
+      for (const option of menuOptions) {
+        assert.include(menu.getElement().textContent, option.text);
+      }
+    });
+
+        test('Displays context menu on a block using Shift+F10', function () {
+      const block = setSelectedBlock(this.workspace);
+      this.injectionDiv.dispatchEvent(shiftF10KeyEvent);
+
+      const menu = Blockly.ContextMenu.getMenu();
+      assert.instanceOf(menu, Blockly.Menu, 'Context menu should be shown');
+
+      const menuOptions =
+        Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
+          {block, focusedNode: block},
+          shiftF10KeyEvent,
+        );
+      for (const option of menuOptions) {
+        assert.include(menu.getElement().textContent, option.text);
+      }
+    });
+
+    test('Displays context menu on the workspace using Shift+F10', function () {
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.injectionDiv.dispatchEvent(shiftF10KeyEvent);
+
+      const menu = Blockly.ContextMenu.getMenu();
+      assert.instanceOf(menu, Blockly.Menu, 'Context menu should be shown');
+      const menuOptions =
+        Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
+          {workspace: this.workspace, focusedNode: this.workspace},
+          shiftF10KeyEvent,
+        );
+      for (const option of menuOptions) {
+        assert.include(menu.getElement().textContent, option.text);
+      }
+    });
+
+    test('Displays context menu on a workspace comment using Shift+F10', function () {
+      Blockly.ContextMenuItems.registerCommentOptions();
+      const comment = setSelectedComment(this.workspace);
+      this.injectionDiv.dispatchEvent(shiftF10KeyEvent);
+
+      const menu = Blockly.ContextMenu.getMenu();
+      assert.instanceOf(menu, Blockly.Menu, 'Context menu should be shown');
+      const menuOptions =
+        Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
+          {comment, focusedNode: comment},
+          shiftF10KeyEvent,
+        );
+      for (const option of menuOptions) {
+        assert.include(menu.getElement().textContent, option.text);
+      }
+    });
+
+        test('Displays context menu on a block using the menu button', function () {
+      const block = setSelectedBlock(this.workspace);
+      this.injectionDiv.dispatchEvent(menuKeyEvent);
+
+      const menu = Blockly.ContextMenu.getMenu();
+      assert.instanceOf(menu, Blockly.Menu, 'Context menu should be shown');
+
+      const menuOptions =
+        Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
+          {block, focusedNode: block},
+          menuKeyEvent,
+        );
+      for (const option of menuOptions) {
+        assert.include(menu.getElement().textContent, option.text);
+      }
+    });
+
+    test('Displays context menu on the workspace using the menu button', function () {
+      Blockly.getFocusManager().focusNode(this.workspace);
+      this.injectionDiv.dispatchEvent(menuKeyEvent);
+
+      const menu = Blockly.ContextMenu.getMenu();
+      assert.instanceOf(menu, Blockly.Menu, 'Context menu should be shown');
+      const menuOptions =
+        Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
+          {workspace: this.workspace, focusedNode: this.workspace},
+          menuKeyEvent,
+        );
+      for (const option of menuOptions) {
+        assert.include(menu.getElement().textContent, option.text);
+      }
+    });
+
+    test('Displays context menu on a workspace comment using the menu button', function () {
+      Blockly.ContextMenuItems.registerCommentOptions();
+      const comment = setSelectedComment(this.workspace);
+      this.injectionDiv.dispatchEvent(menuKeyEvent);
+
+      const menu = Blockly.ContextMenu.getMenu();
+      assert.instanceOf(menu, Blockly.Menu, 'Context menu should be shown');
+      const menuOptions =
+        Blockly.ContextMenuRegistry.registry.getContextMenuOptions(
+          {comment, focusedNode: comment},
+          menuKeyEvent,
         );
       for (const option of menuOptions) {
         assert.include(menu.getElement().textContent, option.text);


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/622

### Proposed Changes

Adds context menu shortcuts for Shift+F10 and the Menu key.

### Reason for Changes

These are common shortcuts for the context menu in Windows.

### Test Coverage

Added unit tests for validating the context menu appears from a block, from a workspace comment, and from the workspace when pressing these key combinations. Tested manually (my keyboard does have a menu button).

### Breaking Changes

New keyboard shortcuts have been registered for Shift+F10 and the Menu/Context Menu key. This will cause an error if you try to register another shortcut with these same keys. If you already have one or both of these keyboard shortcuts registered for something in your code, you will need to either change which key(s) your shortcut uses or remove the new registration(s) to keep your existing shortcut(s).
