### PR TITLE
fix: skip empty label fields and dummy/end row inputs for move announcements

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -209,7 +209,7 @@ export function getInputLabels(
 ): string[] {
   return block.inputList
     .filter((input) => input.isVisible())
-    .map((input) => input.getLabel(verbosity, input.getAriaLabelText()));
+    .map((input) => input.getAriaLabelText() ?? input.getLabel(verbosity));
 }
 
 /**
@@ -246,7 +246,7 @@ function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
     .filter((input) => input.isVisible())
     .map(
       (input) =>
-        input.getLabel(Verbosity.TERSE, input.getAriaLabelText()) ||
+        input.getLabel(Verbosity.TERSE) ||
         Msg['INPUT_LABEL_INDEX'].replace(
           '%1',
           (input.getIndex() + 1).toString(),
@@ -374,10 +374,16 @@ function computeMoveConnectionLabel(
   const input = conn.getParentInput();
   if (!input) return baseLabel;
 
-  const labels = getInputLabelsSubset(conn.getSourceBlock(), input);
-  if (!labels.length) return baseLabel;
+  let inputLabel = input.getAriaLabelText();
 
-  const inputLabel = labels.join(', ');
+  // If the input doesn't have a custom ARIA label, compute one using the labels from
+  // nearby fields.
+  if (!inputLabel) {
+    const labels = getInputLabelsSubset(conn.getSourceBlock(), input);
+    if (!labels.length) return baseLabel;
+
+    inputLabel = labels.join(', ');
+  }
 
   return baseLabel
     ? Msg['ANNOUNCE_MOVE_OF'].replace('%1', inputLabel).replace('%2', baseLabel)

--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -205,7 +205,7 @@ export function getInputLabels(
 ): string[] {
   return block.inputList
     .filter((input) => input.isVisible())
-    .map((input) => input.getAriaLabelText() ?? input.getLabel(verbosity));
+    .map((input) => input.getLabel(verbosity, input.getAriaLabelText()));
 }
 
 /**
@@ -224,11 +224,7 @@ export function getInputLabels(
  * @param input The input that defines the end of the subset.
  * @returns A list of field/input labels for the given block.
  */
-export function getInputLabelsSubset(
-  block: BlockSvg,
-  input: Input,
-  verbosity = Verbosity.STANDARD,
-): string[] {
+function getInputLabelsSubset(block: BlockSvg, input: Input): string[] {
   const inputIndex = block.inputList.indexOf(input);
   if (inputIndex === -1) {
     throw new Error(
@@ -246,7 +242,7 @@ export function getInputLabelsSubset(
     .filter((input) => input.isVisible())
     .map(
       (input) =>
-        input.getLabel(verbosity) ||
+        input.getLabel(Verbosity.TERSE, input.getAriaLabelText()) ||
         Msg['INPUT_LABEL_INDEX'].replace(
           '%1',
           (input.getIndex() + 1).toString(),
@@ -374,20 +370,10 @@ function computeMoveConnectionLabel(
   const input = conn.getParentInput();
   if (!input) return baseLabel;
 
-  let inputLabel = input.getAriaLabelText();
+  const labels = getInputLabelsSubset(conn.getSourceBlock(), input);
+  if (!labels.length) return baseLabel;
 
-  // If the input doesn't have a custom ARIA label, compute one using the labels from
-  // nearby fields.
-  if (!inputLabel) {
-    const labels = getInputLabelsSubset(
-      conn.getSourceBlock(),
-      input,
-      Verbosity.TERSE,
-    );
-    if (!labels.length) return baseLabel;
-
-    inputLabel = labels.join(', ');
-  }
+  const inputLabel = labels.join(', ');
 
   return baseLabel
     ? Msg['ANNOUNCE_MOVE_OF'].replace('%1', inputLabel).replace('%2', baseLabel)

--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -112,6 +112,10 @@ export function configureAriaRole(block: BlockSvg) {
  * `lookback` attribute is specified, all of the fields on the row immediately
  * above the Input will be used instead.
  *
+ * Empty field labels are excluded because they don't provide useful context.
+ * Fields should generally have a helpful label, but there are exceptions, such
+ * as when empty label fields are used to control the layout of a block.
+ *
  * @internal
  * @param input The Input to compute a description/context label for.
  * @param lookback If true, will use labels for fields on the previous row if
@@ -135,7 +139,7 @@ export function computeFieldRowLabel(
       return computeFieldRowLabel(inputs[index - 1], lookback, verbosity);
     }
   }
-  return fieldRowLabel;
+  return fieldRowLabel.filter((label) => !!label);
 }
 
 /**

--- a/packages/blockly/core/field_label.ts
+++ b/packages/blockly/core/field_label.ts
@@ -82,6 +82,42 @@ export class FieldLabel extends Field<string> {
   }
 
   /**
+   * Computes a descriptive ARIA label to represent this field with configurable
+   * verbosity.
+   *
+   * A 'verbose' label includes type information, if available, whereas a
+   * non-verbose label only contains the field's value.
+   *
+   * Note that this will always return the latest representation of the field's
+   * label which may differ from any previously set ARIA label for the field
+   * itself. Implementations are largely responsible for ensuring that the
+   * field's ARIA label is set correctly at relevant moments in the field's
+   * lifecycle (such as when its value changes).
+   *
+   * Finally, it is never guaranteed that implementations use the label returned
+   * by this method for their actual ARIA label. Some implementations may rely
+   * on other contexts to convey information like the field's value. Example:
+   * checkboxes represent their checked/non-checked status (i.e. value) through
+   * a separate ARIA property.
+   *
+   * Unlike other built-in fields, FieldLabel does return an empty string when its
+   * value is empty. This is because empty labels are sometimes used for layout
+   * purposes.
+   *
+   * @param includeTypeInfo Whether to include the field's type information in
+   *     the returned label, if available.
+   */
+  computeAriaLabel(includeTypeInfo: boolean = true): string {
+    const ariaTypeName = includeTypeInfo ? this.getAriaTypeName() : null;
+    const ariaValue = this.getAriaValue() ?? '';
+
+    if (ariaTypeName) {
+      return `${ariaTypeName}: ${ariaValue}`;
+    }
+    return ariaValue;
+  }
+
+  /**
    * Ensure that the input value casts to a valid string.
    *
    * @param newValue The input value.

--- a/packages/blockly/core/field_label.ts
+++ b/packages/blockly/core/field_label.ts
@@ -107,7 +107,7 @@ export class FieldLabel extends Field<string> {
    * @param includeTypeInfo Whether to include the field's type information in
    *     the returned label, if available.
    */
-  computeAriaLabel(includeTypeInfo: boolean = true): string {
+  override computeAriaLabel(includeTypeInfo: boolean = true): string {
     const ariaTypeName = includeTypeInfo ? this.getAriaTypeName() : null;
     const ariaValue = this.getAriaValue() ?? '';
 

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -401,21 +401,10 @@ export class Input {
    *
    * @internal
    */
-  getLabel(
-    verbosity = Verbosity.STANDARD,
-    ariaLabelText: string | null,
-  ): string {
+  getLabel(verbosity = Verbosity.STANDARD): string {
     if (!this.isVisible()) return '';
 
     const labels = computeFieldRowLabel(this, false, verbosity);
-
-    // A block's custom ARIA label for this input is inserted between the field
-    // row label and the connected block labels, since it's meant to describe the
-    // connection itself, which is conceptually between the field row and any
-    // connected blocks.
-    if (ariaLabelText) {
-      labels.push(ariaLabelText);
-    }
 
     if (this.connection?.type === ConnectionType.INPUT_VALUE) {
       const childBlock = this.connection.targetBlock();

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -401,10 +401,21 @@ export class Input {
    *
    * @internal
    */
-  getLabel(verbosity = Verbosity.STANDARD): string {
+  getLabel(
+    verbosity = Verbosity.STANDARD,
+    ariaLabelText: string | null,
+  ): string {
     if (!this.isVisible()) return '';
 
     const labels = computeFieldRowLabel(this, false, verbosity);
+
+    // A block's custom ARIA label for this input is inserted between the field
+    // row label and the connected block labels, since it's meant to describe the
+    // connection itself, which is conceptually between the field row and any
+    // connected blocks.
+    if (ariaLabelText) {
+      labels.push(ariaLabelText);
+    }
 
     if (this.connection?.type === ConnectionType.INPUT_VALUE) {
       const childBlock = this.connection.targetBlock();
@@ -418,12 +429,17 @@ export class Input {
   }
 
   /**
-   * Returns the index of this input on its source block.
+   * Returns the index of this input, excluding inputs without connections, on its
+   * source block.
    *
    * @internal
    */
   getIndex(): number {
-    const inputs = this.getSourceBlock().inputList;
-    return inputs.indexOf(this);
+    const noConnectionInputTypes = [inputTypes.DUMMY, inputTypes.END_ROW];
+    const allInputs = this.getSourceBlock().inputList;
+    const allConnectionInputs = allInputs.filter(
+      (input) => !noConnectionInputTypes.includes(input.type),
+    );
+    return allConnectionInputs.indexOf(this);
   }
 }

--- a/packages/blockly/tests/mocha/input_test.js
+++ b/packages/blockly/tests/mocha/input_test.js
@@ -315,13 +315,13 @@ suite('Inputs', function () {
       // Using a text input as it will return a default ARIA label
       this.block
         .appendValueInput('NAME')
-        .appendField(new Blockly.FieldTextInput('text'), 'NAME')
+        .appendField(new Blockly.FieldTextInput('test'), 'NAME')
         .setAriaLabelProvider((input) => customLabel);
 
       const label = this.block.getAriaLabel();
 
-      assert.include(label, customLabel);
-      assert.notInclude(label, 'text');
+      assert.include(label, 'text: test'); // Computed label from fields
+      assert.include(label, customLabel); // Custom ARIA label from provider
     });
     test('Set input ARIA Label Provider from JSON', function () {
       const customLabel = 'custom ARIA label';

--- a/packages/blockly/tests/mocha/input_test.js
+++ b/packages/blockly/tests/mocha/input_test.js
@@ -315,13 +315,13 @@ suite('Inputs', function () {
       // Using a text input as it will return a default ARIA label
       this.block
         .appendValueInput('NAME')
-        .appendField(new Blockly.FieldTextInput('test'), 'NAME')
+        .appendField(new Blockly.FieldTextInput('text'), 'NAME')
         .setAriaLabelProvider((input) => customLabel);
 
       const label = this.block.getAriaLabel();
 
-      assert.include(label, 'text: test'); // Computed label from fields
-      assert.include(label, customLabel); // Custom ARIA label from provider
+      assert.include(label, customLabel);
+      assert.notInclude(label, 'text');
     });
     test('Set input ARIA Label Provider from JSON', function () {
       const customLabel = 'custom ARIA label';

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1306,7 +1306,7 @@ suite('Keyboard-driven movement', function () {
         this.clock.tick(10);
         this.moveAndAssert(
           moveRight,
-          ['Moving', 'custom branch label', 'around', 'draw', '❤️'],
+          ['Moving', 'custom else if branch', 'around', 'draw', '❤️'],
           ['else if, do'],
         );
         cancelMove(this.workspace);

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1280,7 +1280,7 @@ suite('Keyboard-driven movement', function () {
         ifBlock.elseCount_ = 1;
         ifBlock.updateShape_();
         ifBlock.render();
-        ifBlock.getInput('DO1').setAriaLabelProvider('custom else if branch');
+        ifBlock.getInput('DO1').setAriaLabelProvider('custom branch label');
         this.workspace.cleanUp();
 
         Blockly.getFocusManager().focusNode(ifBlock);
@@ -1289,16 +1289,23 @@ suite('Keyboard-driven movement', function () {
         this.clock.tick(10);
         this.moveAndAssert(
           moveRight,
-          ['Moving', 'custom else if branch', 'around', 'draw', '❤️'],
-          ['else if, do'],
+          [
+            'Moving',
+            'else if, do',
+            'custom branch label',
+            'around',
+            'draw',
+            '❤️',
+          ],
+          [],
         );
         cancelMove(this.workspace);
         Blockly.getFocusManager().focusNode(this.block1);
         this.clock.tick(10);
         this.moveAndAssert(
           startMove,
-          ['Moving', 'inside', 'custom else if branch'],
-          ['else if, do'],
+          ['Moving', 'inside', 'else if, do', 'custom branch label'],
+          [],
         );
         cancelMove(this.workspace);
       });
@@ -1351,6 +1358,50 @@ suite('Keyboard-driven movement', function () {
           [this.getBlockLabel(text)],
         );
 
+        cancelMove(this.workspace);
+      });
+      test('ignores dummy inputs when disambiguating', function () {
+        const subListBlock = this.workspace.newBlock('lists_getSublist');
+        subListBlock.initSvg();
+        subListBlock.render();
+        const mathBlock = this.workspace.newBlock('math_number');
+        mathBlock.initSvg();
+        mathBlock.render();
+
+        Blockly.getFocusManager().focusNode(mathBlock);
+        startMove(this.workspace);
+        this.clock.tick(10);
+        this.moveAndAssert(
+          moveRight,
+          ['Moving', 'to', 'list, get sub-list from', 'input 2'],
+          ['input 3'],
+        );
+        this.moveAndAssert(
+          moveRight,
+          ['Moving', 'to', 'list, get sub-list from', 'input 3'],
+          ['input 4'],
+        );
+
+        cancelMove(this.workspace);
+      });
+      test('ignores end row inputs when disambiguating', function () {
+        const compare = this.workspace.newBlock('logic_compare');
+        compare.appendDummyInput('END_ROW');
+        compare.moveInputBefore('END_ROW', 'A');
+        compare.initSvg();
+        compare.render();
+        const boolean = this.workspace.newBlock('logic_boolean');
+        boolean.initSvg();
+        boolean.render();
+
+        Blockly.getFocusManager().focusNode(boolean);
+        startMove(this.workspace);
+        this.clock.tick(10);
+        this.moveAndAssert(
+          moveRight,
+          ['Moving', 'to', 'input 1', '='],
+          [this.getBlockLabel(boolean)],
+        );
         cancelMove(this.workspace);
       });
     });

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1289,23 +1289,16 @@ suite('Keyboard-driven movement', function () {
         this.clock.tick(10);
         this.moveAndAssert(
           moveRight,
-          [
-            'Moving',
-            'else if, do',
-            'custom branch label',
-            'around',
-            'draw',
-            '❤️',
-          ],
-          [],
+          ['Moving', 'custom branch label', 'around', 'draw', '❤️'],
+          ['else if, do'],
         );
         cancelMove(this.workspace);
         Blockly.getFocusManager().focusNode(this.block1);
         this.clock.tick(10);
         this.moveAndAssert(
           startMove,
-          ['Moving', 'inside', 'else if, do', 'custom branch label'],
-          [],
+          ['Moving', 'inside', 'custom branch label'],
+          ['else if, do'],
         );
         cancelMove(this.workspace);
       });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

This updates the way unlabeled inputs are counted, in order to skip dummy and end row inputs.
It also updates `FieldLabel` to allow for empty string ARIA labels (which are then ignored for input/block).
The **before** screenshot below shows incorrect input counting due to the presence of a dummy input. It also shows an `'empty'` label due to a blank field that is used to assist in laying out the block.
<img width="669" height="322" alt="image" src="https://github.com/user-attachments/assets/91b35e7a-fc3a-448d-8b89-67ecde4610b8" />

After these changes, the input index is reported in a more intuitive way and the 'empty' label field is skipped entirely:
<img width="641" height="260" alt="image" src="https://github.com/user-attachments/assets/881ce9ce-3d76-4af5-9d5d-37ceab77a04e" />

### Reason for Changes

These changes are important in order to make sure that inputs are described more helpfully, and that superfluous block layout information is not conveyed to assistive technologies.

### Test Coverage

New tests were added to ensure we do not count dummy and end row inputs when announcing moves involving unlabeled inputs.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
