### PR TITLE
fix: Improve display of workspace focus rings

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -632,11 +632,11 @@ input[type=number] {
   .blocklyWorkspace.blocklyActiveFocus
   .blocklyWorkspaceFocusRing,
 /* Focus in widget/dropdown div considered to be in workspace. */
-.blocklyKeyboardNavigation:has(
-  .blocklyWidgetDiv:focus-within,
-  .blocklyDropDownDiv:focus-within
-)
-  .blocklyWorkspace
+  .blocklyKeyboardNavigation
+  .blocklyWorkspace.blocklyShowingDropDownDiv
+  .blocklyWorkspaceFocusRing,
+.blocklyKeyboardNavigation
+  .blocklyWorkspace.blocklyShowingWidgetDiv
   .blocklyWorkspaceFocusRing {
   stroke: var(--blockly-active-tree-color);
   stroke-width: calc(var(--blockly-selection-width) * 2);

--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -349,7 +349,6 @@ function showPositionedByRect(
     workspace = workspace.options.parentWorkspace;
   }
   setBoundsElement(workspace.getParentSvg().parentNode as Element | null);
-  workspace.getFocusableElement().classList.add(SHOWING_DROPDOWNDIV_SELECTOR);
   return show(
     field,
     sourceBlock.RTL,
@@ -418,6 +417,9 @@ export function show<T>(
     aria.State.OWNS,
     existingOwnership ? [existingOwnership, div.id] : div.id,
   );
+  mainWorkspace
+    .getFocusableElement()
+    .classList.add(SHOWING_DROPDOWNDIV_SELECTOR);
 
   // When we change `translate` multiple times in close succession,
   // Chrome may choose to wait and apply them all at once.

--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -51,6 +51,12 @@ export const PADDING_Y = 16;
 export const ANIMATION_TIME = 0.25;
 
 /**
+ * Class applied to the element that is displaying the DropDownDiv, used to
+ * apply focus styles.
+ */
+const SHOWING_DROPDOWNDIV_SELECTOR = 'blocklyShowingDropDownDiv';
+
+/**
  * Timer for animation out, to be cleared if we need to immediately hide
  * without disrupting new shows.
  */
@@ -343,6 +349,7 @@ function showPositionedByRect(
     workspace = workspace.options.parentWorkspace;
   }
   setBoundsElement(workspace.getParentSvg().parentNode as Element | null);
+  workspace.getFocusableElement().classList.add(SHOWING_DROPDOWNDIV_SELECTOR);
   return show(
     field,
     sourceBlock.RTL,
@@ -735,6 +742,9 @@ export function hideWithoutAnimation() {
     aria.State.OWNS,
     existingOwnership.replace(div.id, ''),
   );
+  workspace
+    .getFocusableElement()
+    .classList.remove(SHOWING_DROPDOWNDIV_SELECTOR);
 
   workspace.markFocused();
 

--- a/packages/blockly/core/inject.ts
+++ b/packages/blockly/core/inject.ts
@@ -13,6 +13,7 @@ import * as common from './common.js';
 import * as Css from './css.js';
 import * as dropDownDiv from './dropdowndiv.js';
 import {Grid} from './grid.js';
+import {keyboardNavigationController} from './keyboard_navigation_controller.js';
 import {Options} from './options.js';
 import {ScrollbarPair} from './scrollbar_pair.js';
 import * as Tooltip from './tooltip.js';
@@ -72,6 +73,14 @@ export function inject(
   subContainer.addEventListener('focusin', function () {
     common.setMainWorkspace(workspace);
   });
+
+  containerElement?.getRootNode().addEventListener('keydown', ((
+    e: KeyboardEvent,
+  ) => {
+    if (e.key === 'Tab') {
+      keyboardNavigationController.setIsActive(true);
+    }
+  }) as EventListener);
 
   browserEvents.conditionalBind(
     subContainer,

--- a/packages/blockly/core/inject.ts
+++ b/packages/blockly/core/inject.ts
@@ -74,14 +74,6 @@ export function inject(
     common.setMainWorkspace(workspace);
   });
 
-  containerElement?.getRootNode().addEventListener('keydown', ((
-    e: KeyboardEvent,
-  ) => {
-    if (e.key === 'Tab') {
-      keyboardNavigationController.setIsActive(true);
-    }
-  }) as EventListener);
-
   browserEvents.conditionalBind(
     subContainer,
     'keydown',
@@ -327,6 +319,11 @@ function bindDocumentEvents() {
     // should run regardless of what other touch event handlers have run.
     browserEvents.bind(document, 'touchend', null, Touch.longStop);
     browserEvents.bind(document, 'touchcancel', null, Touch.longStop);
+    browserEvents.bind(document, 'keydown', null, function (e: KeyboardEvent) {
+      if (e.key === 'Tab') {
+        keyboardNavigationController.setIsActive(true);
+      }
+    });
   }
   documentEventsBound = true;
 }

--- a/packages/blockly/core/widgetdiv.ts
+++ b/packages/blockly/core/widgetdiv.ts
@@ -42,6 +42,12 @@ let containerDiv: HTMLDivElement | null;
 let returnEphemeralFocus: ReturnEphemeralFocus | null = null;
 
 /**
+ * Class applied to the element that is displaying the WidgetDiv, used to apply
+ * focus styles.
+ */
+const SHOWING_WIDGETDIV_SELECTOR = 'blocklyShowingWidgetDiv';
+
+/**
  * Returns the HTML container for editor widgets.
  *
  * @returns The editor widget container.
@@ -139,6 +145,9 @@ export function show(
     aria.State.OWNS,
     existingOwnership ? [existingOwnership, div.id] : div.id,
   );
+  ownerWorkspace
+    .getFocusableElement()
+    .classList.add(SHOWING_WIDGETDIV_SELECTOR);
 
   const parentDiv = common.getParentContainer();
   parentDiv?.appendChild(div);
@@ -209,6 +218,9 @@ export function hide() {
     aria.State.OWNS,
     existingOwnership.replace(containerDiv.id, ''),
   );
+  ownerWorkspace
+    .getFocusableElement()
+    .classList.remove(SHOWING_WIDGETDIV_SELECTOR);
 }
 
 /**

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -334,6 +334,16 @@ export class WorkspaceSvg
   zoomControls_: ZoomControls | null = null;
 
   /**
+   * Focus ring in the workspace.
+   */
+  private workspaceFocusRing: Element | null = null;
+
+  /**
+   * Selection ring inside the workspace.
+   */
+  private workspaceSelectionRing: Element | null = null;
+
+  /**
    * Navigator that handles moving focus between items in this workspace in
    * response to keyboard navigation commands.
    */
@@ -848,6 +858,17 @@ export class WorkspaceSvg
     // Only the top-level and flyout workspaces should be tabbable.
     getFocusManager().registerTree(this, !!this.injectionDiv || this.isFlyout);
 
+    this.workspaceSelectionRing = dom.createSvgElement('rect', {
+      fill: 'none',
+      class: 'blocklyWorkspaceSelectionRing',
+    });
+    this.getSvgGroup().appendChild(this.workspaceSelectionRing);
+    this.workspaceFocusRing = dom.createSvgElement('rect', {
+      fill: 'none',
+      class: 'blocklyWorkspaceFocusRing',
+    });
+    this.getSvgGroup().appendChild(this.workspaceFocusRing);
+
     return this.svgGroup_;
   }
 
@@ -928,6 +949,9 @@ export class WorkspaceSvg
       document.body.removeEventListener('wheel', this.dummyWheelListener);
       this.dummyWheelListener = null;
     }
+
+    this.workspaceFocusRing?.remove();
+    this.workspaceSelectionRing?.remove();
 
     if (getFocusManager().isRegistered(this)) {
       getFocusManager().unregisterTree(this);
@@ -1108,6 +1132,28 @@ export class WorkspaceSvg
       this.scrollbar.resize();
     }
     this.updateScreenCalculations();
+
+    if (!this.workspaceFocusRing || !this.workspaceSelectionRing) return;
+    this.resizeWorkspaceRing(this.workspaceSelectionRing, 5);
+    this.resizeWorkspaceRing(this.workspaceFocusRing, 0);
+  }
+
+  /**
+   * Sizes the given focus/selection ring inside the bounds of the workspace.
+   *
+   * @param ring The interior workspace ring indicator to resize.
+   * @param inset How many pixels in from the bounds of the workspace the ring
+   *     should be positioned.
+   */
+  private resizeWorkspaceRing(ring: Element, inset: number) {
+    const metrics = this.getMetrics();
+    ring.setAttribute('x', `${metrics.absoluteLeft + inset}`);
+    ring.setAttribute('y', `${metrics.absoluteTop + inset}`);
+    ring.setAttribute('width', `${Math.max(0, metrics.viewWidth - inset * 2)}`);
+    ring.setAttribute(
+      'height',
+      `${Math.max(0, metrics.svgHeight - inset * 2)}`,
+    );
   }
 
   /**

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -801,6 +801,23 @@ export class WorkspaceSvg
       }
     }
 
+    this.workspaceSelectionRing = dom.createSvgElement(
+      Svg.RECT,
+      {
+        fill: 'none',
+        class: 'blocklyWorkspaceSelectionRing',
+      },
+      this.svgGroup_,
+    );
+    this.workspaceFocusRing = dom.createSvgElement(
+      Svg.RECT,
+      {
+        fill: 'none',
+        class: 'blocklyWorkspaceFocusRing',
+      },
+      this.svgGroup_,
+    );
+
     this.layerManager = new LayerManager(this);
     // Assign the canvases for backwards compatibility.
     this.svgBlockCanvas_ = this.layerManager.getBlockLayer();
@@ -857,17 +874,6 @@ export class WorkspaceSvg
 
     // Only the top-level and flyout workspaces should be tabbable.
     getFocusManager().registerTree(this, !!this.injectionDiv || this.isFlyout);
-
-    this.workspaceSelectionRing = dom.createSvgElement('rect', {
-      fill: 'none',
-      class: 'blocklyWorkspaceSelectionRing',
-    });
-    this.getSvgGroup().appendChild(this.workspaceSelectionRing);
-    this.workspaceFocusRing = dom.createSvgElement('rect', {
-      fill: 'none',
-      class: 'blocklyWorkspaceFocusRing',
-    });
-    this.getSvgGroup().appendChild(this.workspaceFocusRing);
 
     return this.svgGroup_;
   }

--- a/packages/blockly/tests/mocha/dropdowndiv_test.js
+++ b/packages/blockly/tests/mocha/dropdowndiv_test.js
@@ -207,6 +207,11 @@ suite('DropDownDiv', function () {
         ),
         Blockly.DropDownDiv.getContentDiv().parentElement.id,
       );
+      assert.isTrue(
+        Blockly.getMainWorkspace()
+          .getFocusableElement()
+          .classList.contains('blocklyShowingDropDownDiv'),
+      );
     });
   });
 
@@ -415,6 +420,11 @@ suite('DropDownDiv', function () {
             Blockly.getMainWorkspace().getFocusableElement(),
             Blockly.utils.aria.State.OWNS,
           ),
+        );
+        assert.isFalse(
+          Blockly.getMainWorkspace()
+            .getFocusableElement()
+            .classList.contains('blocklyShowingDropDownDiv'),
         );
       });
     });

--- a/packages/blockly/tests/mocha/widget_div_test.js
+++ b/packages/blockly/tests/mocha/widget_div_test.js
@@ -376,6 +376,11 @@ suite('WidgetDiv', function () {
         ),
         Blockly.WidgetDiv.getDiv().id,
       );
+      assert.isTrue(
+        Blockly.getMainWorkspace()
+          .getFocusableElement()
+          .classList.contains('blocklyShowingWidgetDiv'),
+      );
     });
   });
 
@@ -453,6 +458,11 @@ suite('WidgetDiv', function () {
           Blockly.getMainWorkspace().getFocusableElement(),
           Blockly.utils.aria.State.OWNS,
         ),
+      );
+      assert.isFalse(
+        Blockly.getMainWorkspace()
+          .getFocusableElement()
+          .classList.contains('blocklyShowingWidgetDiv'),
       );
     });
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
* Fixes #9710
* Fixes #9223
* Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/677

### Proposed Changes
This PR backports the workspace focus and selection rings from the keyboard-experimentation repo, and adds a global key listener for `Tab` that makes keyboard navigation active. This means that tabbing to the workspace will immediately display a focus/selection indicator ring.