### PR TITLE
fix!: Flyout follows toolbox in DOM

### DIFF
--- a/packages/blockly/core/inject.ts
+++ b/packages/blockly/core/inject.ts
@@ -176,7 +176,7 @@ function createMainWorkspace(
   if (!wsOptions.hasCategories && wsOptions.languageTree) {
     // Add flyout as an <svg> that is a sibling of the workspace SVG.
     const flyout = mainWorkspace.addFlyout(Svg.SVG);
-    dom.insertAfter(flyout, svg);
+    injectionDiv.insertBefore(flyout, svg);
   }
   if (wsOptions.hasTrashcan) {
     mainWorkspace.addTrashcan();

--- a/packages/blockly/core/toolbox/toolbox.ts
+++ b/packages/blockly/core/toolbox/toolbox.ts
@@ -156,8 +156,8 @@ export class Toolbox
 
     this.HtmlDiv = this.createDom_(this.workspace_);
     const flyoutDom = this.flyout.createDom('svg');
+    workspace.getInjectionDiv().insertBefore(flyoutDom, svg);
     dom.addClass(flyoutDom, 'blocklyToolboxFlyout');
-    dom.insertAfter(flyoutDom, svg);
     this.setVisible(true);
     this.flyout.init(workspace);
 

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -216,6 +216,24 @@ suite('Toolbox', function () {
       Blockly.getFocusManager().focusNode(this.toolbox.getWorkspace());
       assert.isTrue(this.toolbox.getFlyout().isVisible());
     });
+
+    test('Tab order follows toolbox, flyout, workspace DOM order', function () {
+      const injectionDiv = this.toolbox.getWorkspace().getInjectionDiv();
+      const children = Array.from(injectionDiv.children);
+
+      const toolboxIndex = children.indexOf(this.toolbox.HtmlDiv);
+      const flyoutIndex = children.indexOf(this.toolbox.getFlyout().svgGroup_);
+      const workspaceIndex = children.indexOf(
+        this.toolbox.getWorkspace().getParentSvg(),
+      );
+
+      assert.isAtLeast(toolboxIndex, 0);
+      assert.isAtLeast(flyoutIndex, 0);
+      assert.isAtLeast(workspaceIndex, 0);
+
+      assert.isBelow(toolboxIndex, flyoutIndex);
+      assert.isBelow(flyoutIndex, workspaceIndex);
+    });
   });
 
   suite('onClick_', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9796

### Proposed Changes

This  change ensures that flyout appears in the DOM directly before the workspace in order to aid in tab navigation. 

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

As reported by @microbit-robert:
> When tabbing from the toolbox, the workspace takes focus. In the previous implementation, tabbing from the toolbox focused the flyout (or the first item in the flyout to be exact).
> When tabbing from the flyout, whatever comes after the blockly injection div takes focus (the workspace is skipped, that includes the trashcan and zoom controls). In the previous implementation, tabbing from the flyout focused the workspace. This feels particularly confusing and it's easy to get lost.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

A new test ensures that the toolbox, flyout, and workspace are all contained in the injection div in the correct order. The ordering is relative rather than absolute in order to permit flexibility with other children, such as scrollbars.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### BREAKING CHANGE

This change may affect you if you application relies on the specific child order of elements in the Blockly injective div.

Previously the DOM structure was:
1. toolbox
2. workspace
3. flyout

It is now:
1. toolbox
2. flyout
3. workspace
