### PR TITLE
fix: always store initial drag connections

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -241,6 +241,7 @@ export class BlockDragStrategy implements IDragStrategy {
     blockAnimation.disconnectUiStop();
 
     const healStack = this.shouldHealStack(e);
+    this.storeInitialConnections(healStack);
 
     if (this.shouldDisconnect(healStack)) {
       this.disconnectBlock(healStack);
@@ -390,7 +391,6 @@ export class BlockDragStrategy implements IDragStrategy {
    * @param healStack Whether or not to heal the stack after disconnecting.
    */
   private disconnectBlock(healStack: boolean) {
-    this.storeInitialConnections(healStack);
     this.block.unplug(healStack);
     blockAnimation.disconnectUiEffect(this.block);
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This fixes an untracked bug that could cause `revertDrag()` to work incorrectly when the current drag had previously stored an initial valid parent or child connection.

https://github.com/user-attachments/assets/d655d9fa-2ca7-4ef1-bd20-0b13204dd441



### Proposed Changes

This change guarantees `BlockDragStrategy.storeInitialConnections()` will be called as part of every `startMove`.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This `BlockDragStrategy` method relies on `storeInitialConnections()` to store the current parent and child blocks at the start of a drag. However, this was only happening if a move was started that should cause a disconnect.


https://github.com/user-attachments/assets/0b40b75e-6ee5-4d7d-8980-a8e1f7385fad

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
