### PR TITLE
fix: Fix bug that prevented display of move indicators in mutator workspaces

### DIFF
--- a/packages/blockly/core/keyboard_nav/move_indicator.ts
+++ b/packages/blockly/core/keyboard_nav/move_indicator.ts
@@ -27,7 +27,10 @@ export class MoveIndicator {
     this.svgRoot = dom.createSvgElement(
       Svg.G,
       {},
-      workspace.getLayerManager()?.getDragLayer(),
+      // Mutator workspaces don't have a drag layer, so fall back to the block
+      // layer.
+      workspace.getLayerManager()?.getDragLayer() ??
+        workspace.getLayerManager()?.getBlockLayer(),
     );
     this.svgRoot.classList.add('blocklyMoveIndicator');
     const rtl = workspace.RTL;


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9850

### Proposed Changes
This PR makes the move indicator append itself to the block layer if there is no drag layer, as is the case in mutator workspaces.