### PR TITLE
fix: Fix positioning of keyboard-driven workspace context menu in RTL

### DIFF
--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -1784,8 +1784,8 @@ export class WorkspaceSvg
     if (e instanceof PointerEvent) {
       location = new Coordinate(e.clientX, e.clientY);
     } else {
-      // TODO: Get the location based on the workspace cursor location
-      location = svgMath.wsToScreenCoordinates(this, new Coordinate(5, 5));
+      const x = this.RTL ? this.getWidth() - 5 : 5;
+      location = svgMath.wsToScreenCoordinates(this, new Coordinate(x, 5));
     }
 
     ContextMenu.show(e, menuOptions, this.RTL, this, location);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9852

### Proposed Changes
This PR adjusts the placement of the workspace context menu when displayed via keyboard shortcut in an RTL workspace. Previously, it would be rendered almost entirely outside the bounds of the workspace. It is now positioned in an analogous location to its LTR position.