### PR TITLE
fix: Fix bug that could cause blocks to be inadvertently deleted

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -222,6 +222,8 @@ export class BlockDragStrategy implements IDragStrategy {
       return alternateTarget.startDrag(e);
     }
 
+    this.block.workspace.recordDragTargets();
+
     this.dragging = true;
     this.fireDragStartEvent();
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9853

### Proposed Changes
This PR fixes a bug that could cause blocks to be inadvertently deleted when dragging out of a horizontal simple flyout that was initially below the fold. This likely originated from some issue in metrics/bounds calculations, but is simply and robustly resolved by just recalculating delete areas when the drag starts, at which point the workspace will necessarily be on screen and bounds of the various delete areas up to date.