### PR TITLE
fix: Improve display of focus rings on workspace controls

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -559,7 +559,10 @@ input[type=number] {
 /* Icons with active focus. */
 .blocklyKeyboardNavigation
   .blocklyActiveFocus.blocklyIconGroup
-  > .blocklyIconShape:first-child {
+  > .blocklyIconShape:first-child,
+.blocklyKeyboardNavigation
+  .blocklyActiveFocus
+  > .blocklyFocusRing {
   stroke: var(--blockly-active-node-color);
   stroke-width: var(--blockly-selection-width);
 }

--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -530,7 +530,9 @@ input[type=number] {
   .blocklyComment,
   .blocklyBubble,
   .blocklyIconGroup,
-  .blocklyTextarea
+  .blocklyTextarea,
+  .blocklyZoom,
+  .blocklyTrash,
 ) {
   outline: none;
 }

--- a/packages/blockly/core/trashcan.ts
+++ b/packages/blockly/core/trashcan.ts
@@ -155,6 +155,21 @@ export class Trashcan
       'id': this.uniqueId,
     });
 
+    dom.createSvgElement(
+      Svg.RECT,
+      {
+        'width': WIDTH + 8,
+        'height': BODY_HEIGHT + LID_HEIGHT + 8,
+        'x': -4,
+        'y': -4,
+        'rx': 2,
+        'ry': 2,
+        'fill': 'none',
+        'class': 'blocklyFocusRing',
+      },
+      this.svgGroup,
+    );
+
     aria.setRole(this.svgGroup, aria.Role.BUTTON);
     aria.setState(this.svgGroup, aria.State.LABEL, Msg['OPEN_TRASH']);
 

--- a/packages/blockly/core/zoom_controls.ts
+++ b/packages/blockly/core/zoom_controls.ts
@@ -123,6 +123,20 @@ class ZoomInControl extends ZoomControl {
       zoomControlContainer,
     );
     aria.setState(group, aria.State.LABEL, Msg['ZOOM_IN']);
+    dom.createSvgElement(
+      Svg.RECT,
+      {
+        'width': 40,
+        'height': 40,
+        'x': -4,
+        'y': -4,
+        'rx': 2,
+        'ry': 2,
+        'fill': 'none',
+        'class': 'blocklyFocusRing',
+      },
+      group,
+    );
     const clip = dom.createSvgElement(
       Svg.CLIPPATH,
       {'id': 'blocklyZoominClipPath' + rnd},
@@ -170,6 +184,20 @@ class ZoomOutControl extends ZoomControl {
       zoomControlContainer,
     );
     aria.setState(group, aria.State.LABEL, Msg['ZOOM_OUT']);
+    dom.createSvgElement(
+      Svg.RECT,
+      {
+        'width': 40,
+        'height': 40,
+        'x': -4,
+        'y': -4,
+        'rx': 2,
+        'ry': 2,
+        'fill': 'none',
+        'class': 'blocklyFocusRing',
+      },
+      group,
+    );
     const clip = dom.createSvgElement(
       Svg.CLIPPATH,
       {'id': 'blocklyZoomoutClipPath' + rnd},
@@ -217,6 +245,20 @@ class ZoomResetControl extends ZoomControl {
       zoomControlContainer,
     );
     aria.setState(group, aria.State.LABEL, Msg['RESET_ZOOM']);
+    dom.createSvgElement(
+      Svg.RECT,
+      {
+        'width': 40,
+        'height': 40,
+        'x': -4,
+        'y': -4,
+        'rx': 2,
+        'ry': 2,
+        'fill': 'none',
+        'class': 'blocklyFocusRing',
+      },
+      group,
+    );
     const clip = dom.createSvgElement(
       Svg.CLIPPATH,
       {'id': 'blocklyZoomresetClipPath' + rnd},


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of #9792

### Proposed Changes
This PR improves the display of focus rings on the workspace zoom controls and trashcan by reducing their size to encompass only the relevant control rather than the full (hidden) bounds of the sprite sheet and using the same yellow focus ring style as is used elsewhere.