### PR TITLE
fix: Fix bug when pasting mutatorarg blocks

### DIFF
--- a/packages/blockly/blocks/procedures.ts
+++ b/packages/blockly/blocks/procedures.ts
@@ -712,14 +712,32 @@ const PROCEDURES_MUTATORARGUMENT = {
       sourceBlock.workspace;
     const blocks = workspace.getAllBlocks(false);
     const caselessName = varName.toLowerCase();
+    const usedNames = [];
+    let isDuplicate = false;
     for (let i = 0; i < blocks.length; i++) {
       if (blocks[i].id === this.getSourceBlock()!.id) {
         continue;
       }
       // Other blocks values may not be set yet when this is loaded.
       const otherVar = blocks[i].getFieldValue('NAME');
-      if (otherVar && otherVar.toLowerCase() === caselessName) {
+      if (otherVar) {
+        if (!this.editingInteractively) {
+          usedNames.push(otherVar);
+        }
+        if (otherVar.toLowerCase() === caselessName) {
+          isDuplicate = true;
+        }
+      }
+    }
+
+    if (isDuplicate) {
+      if (this.editingInteractively) {
         return null;
+      } else {
+        varName = Variables.generateUniqueNameFromOptions(
+          Procedures.DEFAULT_ARG,
+          usedNames,
+        );
       }
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9865

### Proposed Changes

Updated `procedures_mutatorarg` block's `validator_` function, so that it generates unique name if current name is invalid, when user is pasting block

`this.editingInteractively` check for duplicates ensures that:

- if user is editing block manually, then we return `null` to reset to the previous valid state. It should always be valid
- if block is being created, then we generate new unique name instead. We will hit `isDuplicate` flag only if we copy-paste the block (as far as I understand at least)

Other code in `validator_` function relies on `this.editingInteractively` check aswell, so it should be fine

### Reason for Changes

Fix the issue with code generation

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

N/A