### PR TITLE
chore: remove field-colour plugin blocks from normal toolbox

### DIFF
--- a/packages/blockly/tests/playground.html
+++ b/packages/blockly/tests/playground.html
@@ -1228,44 +1228,6 @@
         <block type="lists_sort"></block>
         <block type="lists_reverse"></block>
       </category>
-      <category name="Colour" categorystyle="colour_category">
-        <block type="colour_picker"></block>
-        <block type="colour_random"></block>
-        <block type="colour_rgb">
-          <value name="RED">
-            <shadow type="math_number">
-              <field name="NUM">100</field>
-            </shadow>
-          </value>
-          <value name="GREEN">
-            <shadow type="math_number">
-              <field name="NUM">50</field>
-            </shadow>
-          </value>
-          <value name="BLUE">
-            <shadow type="math_number">
-              <field name="NUM">0</field>
-            </shadow>
-          </value>
-        </block>
-        <block type="colour_blend">
-          <value name="COLOUR1">
-            <shadow type="colour_picker">
-              <field name="COLOUR">#ff0000</field>
-            </shadow>
-          </value>
-          <value name="COLOUR2">
-            <shadow type="colour_picker">
-              <field name="COLOUR">#3333ff</field>
-            </shadow>
-          </value>
-          <value name="RATIO">
-            <shadow type="math_number">
-              <field name="NUM">0.5</field>
-            </shadow>
-          </value>
-        </block>
-      </category>
       <sep></sep>
       <category
         name="Variables"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes

This removes the Colour category and all its blocks from the playground's Categories (Typed Variables) toolbox.


<img width="694" height="265" alt="image" src="https://github.com/user-attachments/assets/8e0c9495-ad68-47d8-8dec-4d6576d682b3" />

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

These blocks were moved to a plugin, so they are no longer defined in core Blockly.

<img width="3024" height="586" alt="image (1)" src="https://github.com/user-attachments/assets/eb52af42-d3f7-4750-9396-2247377dce38" />

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
