### PR TITLE
fix: Block labels should not use custom input labels

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -2021,7 +2021,7 @@ export class BlockSvg
     aria.setState(
       this.getFocusableElement(),
       aria.State.LABEL,
-      computeAriaLabel(this),
+      this.getAriaLabel(aria.Verbosity.STANDARD),
     );
     configureAriaRole(this);
   }

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -504,6 +504,18 @@ suite('ARIA', function () {
       assert.notInclude(label, 'input');
     });
 
+    test('Blocks with custom input labels are properly labeled', function () {
+      const block = this.makeBlock('logic_negate');
+      const input = block.getInput('BOOL');
+      input.setAriaLabelProvider('condition');
+      const label = Blockly.utils.aria.getState(
+        block.getFocusableElement(),
+        Blockly.utils.aria.State.LABEL,
+      );
+      assert.include(label, 'not');
+      assert.notInclude(label, 'condition');
+    });
+
     test('Blocks with one input are properly labeled', function () {
       const block = this.makeBlock('logic_negate');
       const label = Blockly.utils.aria.getState(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes

Fixed a regression where custom input labels were incorrectly included in full block ARIA labels. Updated `recomputeAriaContext` to use `getAriaLabel` so block labels consistently exclude custom input labels while preserving their use for move announcements and connected input contexts.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Test Coverage

Added coverage that checks the actual applied ARIA label on the focusable element.
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
