### PR TITLE
fix: Beep when attempting to move past a dead end

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -484,6 +484,9 @@ export class BlockDragStrategy implements IDragStrategy {
     if (this.moveMode === MoveMode.UNCONSTRAINED) {
       this.block.moveDuringDrag(newLoc);
     }
+
+    const wasConnected = !!this.connectionCandidate;
+
     this.updateConnectionPreview(
       this.block,
       Coordinate.difference(newLoc, this.startLoc!),
@@ -526,12 +529,15 @@ export class BlockDragStrategy implements IDragStrategy {
       // No connection was available or adequately close to the dragged block;
       // suggest using unconstrained mode to arbitrarily position the block if
       // we're in keyboard-driven constrained mode.
-      if (
-        this.moveMode === MoveMode.CONSTRAINED &&
-        !this.allConnectionPairs.length
-      ) {
-        showUnconstrainedMoveHint(this.workspace, true);
-        this.workspace.getAudioManager().playErrorBeep();
+      if (this.moveMode === MoveMode.CONSTRAINED) {
+        if (!this.allConnectionPairs.length) {
+          showUnconstrainedMoveHint(this.workspace, true);
+        }
+
+        if (!wasConnected) {
+          this.workspace.getAudioManager().playErrorBeep();
+        }
+        return;
       }
     }
     this.announceMove();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9887

### Proposed Changes
This PR adjusts block movement behavior when looping is disabled. Previously, when a block moved past all available connections to the workspace, continuing to attempt to move it would do nothing but announce "moving on workspace" to screenreaders. Now:

* The announcement will be suppressed, since the block is not in fact moving
* Attempting to move a block that is already in a terminal position workspace will play an error beep