### PR TITLE
fix: Fix resolution of parent toolbox category for block descriptions

### DIFF
--- a/packages/blockly/core/toolbox/category.ts
+++ b/packages/blockly/core/toolbox/category.ts
@@ -359,6 +359,15 @@ export class ToolboxCategory
   }
 
   /**
+   * Returns the colour of this category.
+   *
+   * @internal
+   */
+  getColour() {
+    return this.colour_;
+  }
+
+  /**
    * Sets the colour for the category using the style name and returns the new
    * colour as a hex string.
    *

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -843,7 +843,7 @@ suite('Keyboard Shortcut Items', function () {
       block.initSvg();
       block.render();
       Blockly.getFocusManager().focusNode(block);
-      this.assertAnnouncement('Begin stack, if, do, has input');
+      this.assertAnnouncement('Begin stack, if, do, First category, has input');
     });
 
     test('Icon', function () {
@@ -853,7 +853,7 @@ suite('Keyboard Shortcut Items', function () {
       Blockly.getFocusManager().focusNode(
         block.getIcon(Blockly.icons.IconType.MUTATOR),
       );
-      this.assertAnnouncement('Begin stack, if, do, has input');
+      this.assertAnnouncement('Begin stack, if, do, First category, has input');
     });
 
     test('Field', function () {
@@ -869,7 +869,7 @@ suite('Keyboard Shortcut Items', function () {
       block.initSvg();
       block.render();
       Blockly.getFocusManager().focusNode(block.getInput('DO0').connection);
-      this.assertAnnouncement('Begin stack, if, do, has input');
+      this.assertAnnouncement('Begin stack, if, do, First category, has input');
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9889

### Proposed Changes
This PR adds an internal `getColour()` method to the toolbox category class so that identifying the parent toolbox category of a block when generating an extended description works correctly.