### PR TITLE
fix: Don't open the devtools in Firefox when toggling screenreader mode

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -1269,7 +1269,7 @@ export function registerToggleScreenreaderMode() {
   const toggleScreenreader: KeyboardShortcut = {
     name: names.TOGGLE_SCREENREADER,
     preconditionFn: () => true,
-    callback: (workspace) => {
+    callback: (workspace, e) => {
       enabled = !enabled;
       keyboardNavigationController.setScopeChangeAudioCuesEnabled(enabled);
       workspace.getNavigator().setNavigationLoops(!enabled);
@@ -1280,6 +1280,7 @@ export function registerToggleScreenreaderMode() {
         .getNavigator()
         .setNavigationLoops(!enabled);
       showScreenreaderModeHint(workspace, enabled);
+      e.preventDefault();
       return true;
     },
     keyCodes: [shortcut],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9877

### Proposed Changes
This PR fixes a bug where the shortcut for toggling screenreader mode collided with a shortcut to open the developer tools in Firefox. Now, the default behavior is prevented. The developer tools are also/still accessible via the more-universal Command Option I.