### PR TITLE
fix: Fix bug that caused blocks to skip valid destinations when moving with looping disabled

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -476,6 +476,7 @@ export class BlockDragStrategy implements IDragStrategy {
 
   /** Moves the block and updates any connection previews. */
   drag(newLoc: Coordinate, e?: PointerEvent | KeyboardEvent): void {
+    console.log(this.allConnectionPairs);
     this.moveMode =
       e instanceof KeyboardEvent && !(e.ctrlKey || e.metaKey)
         ? MoveMode.CONSTRAINED
@@ -989,7 +990,8 @@ export class BlockDragStrategy implements IDragStrategy {
     for (let i = start; i >= 0 && i < topBlocks.length; i += delta) {
       const topBlock = topBlocks[i];
       for (const a of blockConnections) {
-        for (const b of topBlock.getConnections_(false)) {
+        const stackConnections = this.getAllConnections(topBlock);
+        for (const b of stackConnections) {
           if (
             block.workspace.connectionChecker.canConnect(a, b, true, Infinity)
           ) {

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -476,7 +476,6 @@ export class BlockDragStrategy implements IDragStrategy {
 
   /** Moves the block and updates any connection previews. */
   drag(newLoc: Coordinate, e?: PointerEvent | KeyboardEvent): void {
-    console.log(this.allConnectionPairs);
     this.moveMode =
       e instanceof KeyboardEvent && !(e.ctrlKey || e.metaKey)
         ? MoveMode.CONSTRAINED


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9882

### Proposed Changes
This PR fixed a bug that caused moving blocks in constrained mode to skip valid destinations when navigation looping was disabled. The check for whether a block was in a terminal position, i.e. unattached on the workspace above or below all other blocks with valid connections, was only checking connections on top-level blocks to see if the block in question could connect. It now checks all connections in each block stack.