### PR TITLE
fix(blocks): use static tooltip for controls_ifelse block

### DIFF
--- a/packages/blockly/blocks/logic.ts
+++ b/packages/blockly/blocks/logic.ts
@@ -100,10 +100,9 @@ export const blocks = createBlockDefinitionsFromJsonArray([
     'previousStatement': null,
     'nextStatement': null,
     'style': 'logic_blocks',
-    'tooltip': '%{BKYCONTROLS_IF_TOOLTIP_2}',
+    'tooltip': '%{BKY_CONTROLS_IF_TOOLTIP_2}',
     'helpUrl': '%{BKY_CONTROLS_IF_HELPURL}',
     'suppressPrefixSuffix': true,
-    'extensions': ['controls_if_tooltip'],
   },
   // Block for comparison operator.
   {


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #9813

### Proposed Changes

In `packages/blockly/blocks/logic.ts`, on the `controls_ifelse` block definition:

1. Drop the `controls_if_tooltip` extension (intended for the mutable `controls_if` block).
2. Fix a typo in the static `tooltip` field: `BKYCONTROLS_IF_TOOLTIP_2` becomes `BKY_CONTROLS_IF_TOOLTIP_2` (missing underscore after `BKY`).

### Reason for Changes

The `controls_if_tooltip` extension reads `this.elseifCount_` and `this.elseCount_`, which are populated by `controls_if_mutator`. The `controls_ifelse` block has no mutator, so both counts are `undefined`. The extension always falls into its first branch and returns `Msg['CONTROLS_IF_TOOLTIP_1']` ("If a value is true, then do some statements."), which is the tooltip for a simple `if` block rather than the `if/else` shape that `controls_ifelse` actually has.

The block already declared a static `tooltip` pointing to `CONTROLS_IF_TOOLTIP_2` ("If a value is true, then do the first block of statements. Otherwise, do the second block of statements."), which is the correct text. However the message reference was misspelled (`BKYCONTROLS_IF_TOOLTIP_2` instead of `BKY_CONTROLS_IF_TOOLTIP_2`), so it would not have resolved even if the extension was not there to override it.

Removing the extension lets the static tooltip take effect, and fixing the typo makes that static tooltip actually resolve to the right message.

### Test Coverage

Verified manually by hovering the `controls_ifelse` block in the Blockly playground before and after the change. Before: shows the `if`-only tooltip. After: shows the `if/else` tooltip as defined in `CONTROLS_IF_TOOLTIP_2` in `msg/json/en.json`.

The change does not touch any code path covered by automated unit tests.

### Documentation

No documentation changes needed. The message strings in `msg/json/en.json` and `msg/messages.js` are already correct (`CONTROLS_IF_TOOLTIP_2` exists with the proper text); the bug was only in how the block referenced them.

### Additional Information

The fix was suggested directly by @NeilFraser in #9813.