### PR TITLE
fix: Fix visual glitch when dragging blocks

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -562,39 +562,40 @@ export class BlockDragStrategy implements IDragStrategy {
 
     if (!newCandidate) {
       // Position above or below the first/last block.
-      const connectedBlock = currCandidate?.neighbour.getSourceBlock();
-      let root = connectedBlock?.getRootBlock() ?? connectedBlock;
-      if (root === draggingBlock) root = connectedBlock;
-      const direction = this.getDirectionToNewLocation(
-        Coordinate.sum(this.startLoc!, delta),
-      );
-      const bounds = root?.getBoundingRectangle();
-      if (!bounds) return;
+      if (this.moveMode === MoveMode.CONSTRAINED) {
+        const connectedBlock = currCandidate?.neighbour.getSourceBlock();
+        let root = connectedBlock?.getRootBlock() ?? connectedBlock;
+        if (root === draggingBlock) root = connectedBlock;
+        const direction = this.getDirectionToNewLocation(
+          Coordinate.sum(this.startLoc!, delta),
+        );
+        const bounds = root?.getBoundingRectangle();
+        if (!bounds) return;
 
-      let destination: Coordinate;
-      switch (direction) {
-        case Direction.LEFT:
-        case Direction.UP:
-          destination = new Coordinate(
-            bounds.getOrigin().x,
-            bounds.getOrigin().y -
-              this.BLOCK_CONNECTION_OFFSET * 2 -
-              draggingBlock.getHeightWidth().height,
-          );
-          break;
-        case Direction.RIGHT:
-        case Direction.DOWN:
-        default:
-          destination = new Coordinate(
-            bounds.getOrigin().x,
-            bounds.getOrigin().y +
-              bounds.getHeight() +
-              this.BLOCK_CONNECTION_OFFSET * 2,
-          );
-          break;
+        let destination: Coordinate;
+        switch (direction) {
+          case Direction.LEFT:
+          case Direction.UP:
+            destination = new Coordinate(
+              bounds.getOrigin().x,
+              bounds.getOrigin().y -
+                this.BLOCK_CONNECTION_OFFSET * 2 -
+                draggingBlock.getHeightWidth().height,
+            );
+            break;
+          case Direction.RIGHT:
+          case Direction.DOWN:
+          default:
+            destination = new Coordinate(
+              bounds.getOrigin().x,
+              bounds.getOrigin().y +
+                bounds.getHeight() +
+                this.BLOCK_CONNECTION_OFFSET * 2,
+            );
+            break;
+        }
+        draggingBlock.moveDuringDrag(destination);
       }
-
-      draggingBlock.moveDuringDrag(destination);
 
       this.connectionPreviewer?.hidePreview();
       this.connectionCandidate = null;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9898

### Proposed Changes
This PR fixes a visual glitch where a mouse-dragged block would momentarily change its position when exceeding the snap radius.