### PR TITLE
fix: Improve initial block placement

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -112,10 +112,9 @@ export class BlockDragStrategy implements IDragStrategy {
   /**
    * Positions a cloned block on its new workspace.
    *
-   * @param oldBlock The flyout block that was cloned.
    * @param newBlock The new block to position.
    */
-  private positionNewBlock(oldBlock: BlockSvg, newBlock: BlockSvg) {
+  private positionNewBlock(newBlock: BlockSvg) {
     const workspace = newBlock.workspace;
     const initialY = 10;
     const initialX = 10;
@@ -215,7 +214,7 @@ export class BlockDragStrategy implements IDragStrategy {
           },
         ) as BlockSvg;
         eventUtils.setRecordUndo(false);
-        this.positionNewBlock(this.block, newBlock);
+        this.positionNewBlock(newBlock);
         eventUtils.setRecordUndo(true);
 
         return newBlock;

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -93,6 +93,11 @@ export class BlockDragStrategy implements IDragStrategy {
 
   protected readonly BLOCK_CONNECTION_OFFSET = 10;
 
+  /**
+   * How far in from the edges of the workspace to position newly placed blocks.
+   */
+  protected readonly WORKSPACE_MARGIN = 10;
+
   constructor(private block: BlockSvg) {
     this.workspace = block.workspace;
   }
@@ -116,9 +121,13 @@ export class BlockDragStrategy implements IDragStrategy {
    */
   private positionNewBlock(newBlock: BlockSvg) {
     const workspace = newBlock.workspace;
-    const initialY = 10;
-    const initialX = 10;
+    const initialY = this.WORKSPACE_MARGIN;
+    const initialX = this.WORKSPACE_MARGIN;
+    // How far apart the new block should be placed horizontally from an
+    // existing one.
     const xSpacing = 80;
+    const blockPadding =
+      Math.max(config.connectingSnapRadius, config.snapRadius) + 2;
 
     const filteredTopBlocks = workspace
       .getTopBlocks(true)
@@ -128,10 +137,10 @@ export class BlockDragStrategy implements IDragStrategy {
       // Expand the bounds to avoid the new block being placed within snapping
       // distance.
       return new Rect(
-        bounds.top - 30,
-        bounds.bottom + 30,
-        bounds.left - 30,
-        bounds.right + 30,
+        bounds.top - blockPadding,
+        bounds.bottom + blockPadding,
+        bounds.left - blockPadding,
+        bounds.right + blockPadding,
       );
     });
 

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -35,7 +35,7 @@ import * as blocks from '../serialization/blocks.js';
 import {Coordinate} from '../utils.js';
 import * as aria from '../utils/aria.js';
 import * as dom from '../utils/dom.js';
-import * as svgMath from '../utils/svg_math.js';
+import {Rect} from '../utils/rect.js';
 import type {WorkspaceSvg} from '../workspace_svg.js';
 
 /** Represents a valid pair of connections between the dragging block and a block on the workspace. */
@@ -116,15 +116,80 @@ export class BlockDragStrategy implements IDragStrategy {
    * @param newBlock The new block to position.
    */
   private positionNewBlock(oldBlock: BlockSvg, newBlock: BlockSvg) {
-    const screenCoordinate = svgMath.wsToScreenCoordinates(
-      oldBlock.workspace,
-      oldBlock.getRelativeToSurfaceXY(),
-    );
-    const workspaceCoordinates = svgMath.screenToWsCoordinates(
-      newBlock.workspace,
-      screenCoordinate,
-    );
-    newBlock.moveDuringDrag(workspaceCoordinates);
+    const workspace = newBlock.workspace;
+    const initialY = 10;
+    const initialX = 10;
+    const xSpacing = 80;
+
+    const filteredTopBlocks = workspace
+      .getTopBlocks(true)
+      .filter((block) => block.id !== newBlock.id);
+    const allBlockBounds = filteredTopBlocks.map((block) => {
+      const bounds = block.getBoundingRectangle();
+      // Expand the bounds to avoid the new block being placed within snapping
+      // distance.
+      return new Rect(
+        bounds.top - 30,
+        bounds.bottom + 30,
+        bounds.left - 30,
+        bounds.right + 30,
+      );
+    });
+
+    const toolboxWidth = workspace.getToolbox()?.getWidth();
+    const workspaceWidth =
+      workspace.getParentSvg().clientWidth - (toolboxWidth ?? 0);
+    const workspaceHeight = workspace.getParentSvg().clientHeight;
+    const {height: newBlockHeight, width: newBlockWidth} =
+      newBlock.getHeightWidth();
+
+    const getNextIntersectingBlock = function (
+      newBlockRect: Rect,
+    ): Rect | null {
+      for (const rect of allBlockBounds) {
+        if (newBlockRect.intersects(rect)) {
+          return rect;
+        }
+      }
+      return null;
+    };
+
+    let cursorY = initialY;
+    let cursorX = initialX;
+    const minBlockHeight = workspace
+      .getRenderer()
+      .getConstants().MIN_BLOCK_HEIGHT;
+    // Make the initial movement of shifting the block to its best possible
+    // position.
+    let boundingRect = newBlock.getBoundingRectangle();
+    newBlock.moveBy(cursorX - boundingRect.left, cursorY - boundingRect.top, [
+      'cleanup',
+    ]);
+
+    boundingRect = newBlock.getBoundingRectangle();
+    let conflictingRect = getNextIntersectingBlock(boundingRect);
+    while (conflictingRect != null) {
+      const newCursorX =
+        conflictingRect.left + conflictingRect.getWidth() + xSpacing;
+      const newCursorY =
+        conflictingRect.top + conflictingRect.getHeight() + minBlockHeight;
+      if (newCursorX + newBlockWidth <= workspaceWidth) {
+        cursorX = newCursorX;
+      } else if (newCursorY + newBlockHeight <= workspaceHeight) {
+        cursorY = newCursorY;
+        cursorX = initialX;
+      } else {
+        // Off screen, but new blocks will be selected which will scroll them
+        // into view.
+        cursorY = newCursorY;
+        cursorX = initialX;
+      }
+      newBlock.moveBy(cursorX - boundingRect.left, cursorY - boundingRect.top, [
+        'cleanup',
+      ]);
+      boundingRect = newBlock.getBoundingRectangle();
+      conflictingRect = getNextIntersectingBlock(boundingRect);
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9878

### Proposed Changes
This PR improves the placement of newly-inserted blocks when using keyboard navigation. It's a near-exact backport of the logic from the keyboard-experimentation repo, with the adjustment of increasing the bounds of existing blocks to avoid placing the new block within snapping range. Generally new blocks will be placed wherever free space is available while scanning across the workspace row by row.