### PR TITLE
fix: Reinstate "moving on workspace" announcements

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -536,8 +536,8 @@ export class BlockDragStrategy implements IDragStrategy {
 
         if (!wasConnected) {
           this.workspace.getAudioManager().playErrorBeep();
+          return;
         }
-        return;
       }
     }
     this.announceMove();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
https://github.com/RaspberryPiFoundation/blockly/pull/9890 unintentionally removed all "moving to workspace" announcements for move mode. This PR reinstates those announcements for non-error workspace moves.

### Proposed Changes

Moves the return statement so that `drag` only returns early when there is an error beep instead of for a legitimate move to the workspace.

### Reason for Changes

Fix for screen reader accessibility.

### Test Coverage

None

### Documentation

Not required

### Additional Information

N/A
