### PR TITLE
fix: CSS back to <style> for Safari/cascade reasons

### DIFF
--- a/packages/blockly/core/css.ts
+++ b/packages/blockly/core/css.ts
@@ -5,9 +5,8 @@
  */
 
 // Former goog.module ID: Blockly.Css
-/** Has CSS already been injected? */
 const injectionSites = new WeakSet<Document | ShadowRoot>();
-const registeredStyleSheets: Array<CSSStyleSheet> = [];
+const registeredCss: Array<string> = [];
 import * as userAgent from './utils/useragent.js';
 
 /**
@@ -17,11 +16,7 @@ import * as userAgent from './utils/useragent.js';
  * @param cssContent Multiline CSS string or an array of single lines of CSS.
  */
 export function register(cssContent: string) {
-  if (typeof window === 'undefined' || !window.CSSStyleSheet) return;
-
-  const sheet = new CSSStyleSheet();
-  sheet.replace(cssContent);
-  registeredStyleSheets.push(sheet);
+  registeredCss.push(cssContent);
 }
 
 /**
@@ -41,24 +36,26 @@ export function inject(
   hasCss: boolean,
   pathToMedia: string,
 ) {
-  if (!hasCss || typeof window === 'undefined' || !window.CSSStyleSheet) {
-    return;
-  }
+  if (!hasCss || typeof window === 'undefined') return;
 
   const root = container.getRootNode() as Document | ShadowRoot;
-  // Only inject the CSS once.
   if (injectionSites.has(root)) return;
   injectionSites.add(root);
 
   // Strip off any trailing slash (either Unix or Windows).
   const mediaPath = pathToMedia.replace(/[\\/]$/, '');
-  const cssContent = content.replace(/<<<PATH>>>/g, mediaPath);
+  const cssText = [content, ...registeredCss]
+    .join('\n')
+    .replace(/<<<PATH>>>/g, mediaPath);
 
-  const sheet = new CSSStyleSheet();
-  sheet.replace(cssContent);
-  root.adoptedStyleSheets.push(sheet);
-
-  registeredStyleSheets.forEach((sheet) => root.adoptedStyleSheets.push(sheet));
+  const styleEl = document.createElement('style');
+  styleEl.id = 'blockly-common-style';
+  styleEl.textContent = cssText;
+  // Prepend so Blockly's rules sit at the start of the cascade; any user
+  // stylesheet declared later wins by document order. Style elements appended
+  // to the light DOM don't apply inside shadow roots, so for the shadow DOM
+  // case we prepend the style element to the shadow root itself.
+  (root instanceof ShadowRoot ? root : document.head).prepend(styleEl);
 }
 
 /**

--- a/packages/blockly/core/renderers/common/constants.ts
+++ b/packages/blockly/core/renderers/common/constants.ts
@@ -1126,17 +1126,15 @@ export class ConstantProvider {
    * @param selector The CSS selector to interpolate into the stylesheet.
    */
   protected injectCSS_(root: Document | ShadowRoot, selector: string) {
-    if (
-      typeof window === 'undefined' ||
-      !window.CSSStyleSheet ||
-      injectionSites.get(selector)?.has(root)
-    ) {
-      return;
-    }
+    if (typeof window === 'undefined') return;
+    if (injectionSites.get(selector)?.has(root)) return;
 
-    const sheet = new CSSStyleSheet();
-    sheet.replace(this.getCSS_(selector).join('\n'));
-    root.adoptedStyleSheets.push(sheet);
+    const styleEl = document.createElement('style');
+    styleEl.className = 'blockly-renderer-style';
+    styleEl.textContent = this.getCSS_(selector).join('\n');
+    // See css.ts inject() for the rationale on prepending and shadow root
+    // handling.
+    (root instanceof ShadowRoot ? root : document.head).prepend(styleEl);
 
     const sitesForSelector =
       injectionSites.get(selector) ?? new WeakSet<Document | ShadowRoot>();


### PR DESCRIPTION
Reverts the storage mechanism introduced in #9611 (constructable stylesheets via `adoptedStyleSheets`) while keeping the per-root injection-site tracking that #9611 added for shadow-DOM support.

Motivations:

- Safari 15.4 compatibility. `new CSSStyleSheet()` and `adoptedStyleSheets` require Safari 16.4+
- Cascade order. `adoptedStyleSheets` apply after `<style>`/`<link>` elements in the document, so Blockly's defaults silently overrode host stylesheets. Prepending a `<style>` to the head (or to the shadow root) restores the pre-#9611 behavior where any author stylesheet declared later wins on specificity ties.

Trade-offs:

- Per-shadow-root CSS text is duplicated rather than shared via a single adopted sheet object. Negligible for typical use.
- `Css.register()` calls made after the first `inject()` no longer reach already-injected roots (same as #9611's behavior); subsequent `inject()` calls into other roots still pick them up. Web-component consumers can legitimately register late, so this is preferred to reinstating the pre-#9611 throw.

@gonfunko this is one possible take with the downsides noted above. Another option is to use both mechanisms (tag and adoptedStylesheets) either based on feature detection or based on the root. Then to fix the cascade issue consistently use "`@layer` blockly" for Blockly's CSS. That will require auditing of the !important use in Blockly as they would become [impossible to override](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer#:~:text=As%20noted%20in%20the%20above%20diagram). If relying on feature detection note it is not sufficient to check for CSSStyleSheet being defined as that significantly predates constructable stylesheets.

Please feel free to make changes to this PR and/or replace it with one of your own.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

~~I didn't format as it made a large unrelated diff~~ whoops, I had outdated prettier, all good now.

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9876

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

I checked the web component playground added in the previous PR.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
