### PR TITLE
fix: Don't prepend "begin stack" to blocks inserted from the flyout

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -71,7 +71,9 @@ export function computeAriaLabel(
     }
   }
   return [
-    verbosity >= Verbosity.STANDARD && getBeginStackLabel(block),
+    verbosity >= Verbosity.STANDARD &&
+      !block.isDragging() &&
+      getBeginStackLabel(block),
     getParentInputLabel(block),
     ...getInputLabels(block, verbosity, useCustomInputLabels),
     verbosity === Verbosity.LOQUACIOUS && getParentToolboxCategoryLabel(block),

--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -71,9 +71,7 @@ export function computeAriaLabel(
     }
   }
   return [
-    verbosity >= Verbosity.STANDARD &&
-      !block.isDragging() &&
-      getBeginStackLabel(block),
+    verbosity >= Verbosity.STANDARD && getBeginStackLabel(block),
     getParentInputLabel(block),
     ...getInputLabels(block, verbosity, useCustomInputLabels),
     verbosity === Verbosity.LOQUACIOUS && getParentToolboxCategoryLabel(block),
@@ -260,7 +258,7 @@ function getParentInputLabel(block: BlockSvg) {
 function getBeginStackLabel(block: BlockSvg) {
   // Don't include the "begin stack" label for blocks that are moving
   // or blocks in the flyout
-  if (block.isInFlyout || block.workspace.isDragging()) return undefined;
+  if (block.isInFlyout || block.isDragging()) return undefined;
   return block.getRootBlock() === block
     ? Msg['BLOCK_LABEL_BEGIN_STACK']
     : undefined;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves
Omits the "begin stack" label to blocks inserted from the flyout in move mode. At this point, the block can be positioned anywhere. It is arguably only a stack once is has been placed on the workspace in a certain position.

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9802

### Proposed Changes
Use the `block.isDragging` method to determine whether a block is inserted on the workspace in move mode.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes
This reduces the amount of information in the screen reader output which should make it easier to parse for screen reader users. Arguably improves the label accuracy.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage
None

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation
No

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
N/A

<!-- Anything else we should know? -->
