### PR TITLE
feat: allow chaining with setAriaLabelProvider

### DIFF
--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -297,9 +297,13 @@ export class Input {
    * deterministic and idempotent ARIA representation each time the provider is
    * called for a given input. It's also fine to reuse providers across multiple
    * Input implementations.
+   *
+   * @param provider The string or function to use to set the ARIA label for the input
+   * @returns The input being modified (to allow chaining).
    */
-  setAriaLabelProvider(provider: AriaLabelProvider | null) {
+  setAriaLabelProvider(provider: AriaLabelProvider | null): Input {
     this.ariaLabelProvider = provider;
+    return this;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Updates the `Input` method `setAriaLabelProvider` to return itself in order to allow chaining.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Other `Input` methods already allow chaining, such as `appendField`, `setAlign`, and `setCheck`.
This changes make it setting a provider more flexible. For example, this makes it possible to define and set a reference to a new `Input` while also setting its provider in the same line. 
Ex. `const input = this.appendDummyInput().setAriaLabelProvider('dummy');`
