### PR TITLE
fix: Block labels should not use custom input labels (nested inputs)

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -308,7 +308,7 @@ export function getInputLabels(
 
   return inputsToLabel.map((input) => {
     const customLabel = useCustomLabels ? input.getAriaLabelText() : null;
-    return customLabel ?? input.getLabel(verbosity);
+    return customLabel ?? input.getLabel(verbosity, useCustomLabels);
   });
 }
 

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -405,7 +405,7 @@ export class Input {
    *
    * @internal
    */
-  getLabel(verbosity = Verbosity.STANDARD): string {
+  getLabel(verbosity = Verbosity.STANDARD, useCustomLabels = true): string {
     if (!this.isVisible()) return '';
 
     const labels = computeFieldRowLabel(this, false, verbosity);
@@ -414,7 +414,11 @@ export class Input {
       const childBlock = this.connection.targetBlock();
       if (childBlock && !childBlock.isInsertionMarker()) {
         labels.push(
-          getInputLabels(childBlock as BlockSvg, verbosity).join(' '),
+          getInputLabels(
+            childBlock as BlockSvg,
+            verbosity,
+            useCustomLabels,
+          ).join(' '),
         );
       }
     }

--- a/packages/blockly/core/inputs/input.ts
+++ b/packages/blockly/core/inputs/input.ts
@@ -418,7 +418,7 @@ export class Input {
             childBlock as BlockSvg,
             verbosity,
             useCustomLabels,
-          ).join(' '),
+          ).join(', '),
         );
       }
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Builds on https://github.com/RaspberryPiFoundation/blockly/pull/9886 to ensure that block labels do not use custom input labels if the block contains nested value blocks, etc. This change also ensures commas are consistent between inputs for nested value blocks, etc.

### Proposed Changes

Push `useCustomLabels` param through to the input `getLabel` method.

### Reason for Changes

Current behaviour: Nested block has focus, block label is as expected:
<img width="457" height="325" alt="Screenshot 2026-05-19 at 11 09 14" src="https://github.com/user-attachments/assets/abd95742-a839-4da9-bd45-1064499277f2" />

Current behaviour: Parent block has focus, block label for nested block is using custom input labels:
<img width="430" height="326" alt="Screenshot 2026-05-19 at 11 09 25" src="https://github.com/user-attachments/assets/eab31b8f-431e-4c42-a173-b06031581cd2" />

This changes fixes scenario 2, so that the output is now:
<img width="467" height="265" alt="Screenshot 2026-05-21 at 12 29 00" src="https://github.com/user-attachments/assets/6776f443-a10c-41c8-84c2-536228e94ce3" />

This seems to be missing a comma between "0 y", but will investigate this separately. Update: I pushed a change to fix this as well since it is trivial.

### Test Coverage

None added.

### Documentation

No

### Additional Information

N/A
