### PR TITLE
fix: Fix unexpected toast when committing a move with Space

### DIFF
--- a/packages/blockly/core/keyboard_nav/keyboard_mover.ts
+++ b/packages/blockly/core/keyboard_nav/keyboard_mover.ts
@@ -139,6 +139,7 @@ export class KeyboardMover {
             KeyCodes.UP,
             KeyCodes.DOWN,
             KeyCodes.ENTER,
+            KeyCodes.SPACE,
             KeyCodes.ESC,
             KeyCodes.M,
           ].includes(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9915

### Proposed Changes
This PR fixes an issue where committing a move with Space triggered a toast prompting the user to use arrow keys to navigate a block. This is because move mode registers a shortcut under the same keys as all other non-move-mode-related shortcuts to intercept them and commit the move before passing through to the other shortcuts in order to prevent chaos when running shortcuts targeting mid-move blocks. The list of move-related-shortcuts that are excluded from this fallback handler did not include Space, so the fallback handler (which allowed bubbling the shortcut to other handlers) was registered under Space in priority to the actual end-move handler, which does not allow bubbling. This led to the Space key bubbling to the perform action shortcut, which shows this toast when a user attempts to act on a block.