### PR TITLE
feat: Play error beeps when shortcuts fail

### DIFF
--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -108,15 +108,18 @@ export function registerDelete() {
     name: names.DELETE,
     preconditionFn(workspace, scope) {
       const focused = scope.focusedNode;
-      return (
+      const result =
         !workspace.isReadOnly() &&
         focused != null &&
         isIDeletable(focused) &&
         focused.isDeletable() &&
         !workspace.isDragging() &&
         // Don't delete the block if a field editor is open
-        !getFocusManager().ephemeralFocusTaken()
-      );
+        !getFocusManager().ephemeralFocusTaken();
+      if (!result) {
+        workspace.getAudioManager().playErrorBeep();
+      }
+      return result;
     },
     callback(workspace, e, shortcut, scope) {
       // Delete or backspace.
@@ -194,13 +197,16 @@ export function registerCopy() {
       const targetWorkspace = workspace.isFlyout
         ? workspace.targetWorkspace
         : workspace;
-      return (
+      const result =
         !!focused &&
         !!targetWorkspace &&
         !targetWorkspace.isDragging() &&
         !getFocusManager().ephemeralFocusTaken() &&
-        isCopyable(focused)
-      );
+        isCopyable(focused);
+      if (!result) {
+        workspace.getAudioManager().playErrorBeep();
+      }
+      return result;
     },
     callback(workspace, e, shortcut, scope) {
       // Prevent the default copy behavior, which may beep or otherwise indicate
@@ -247,13 +253,16 @@ export function registerCut() {
     name: names.CUT,
     preconditionFn(workspace, scope) {
       const focused = scope.focusedNode;
-      return (
+      const result =
         !!focused &&
         !workspace.isReadOnly() &&
         !workspace.isDragging() &&
         !getFocusManager().ephemeralFocusTaken() &&
-        isCuttable(focused)
-      );
+        isCuttable(focused);
+      if (!result) {
+        workspace.getAudioManager().playErrorBeep();
+      }
+      return result;
     },
     callback(workspace, e, shortcut, scope) {
       const focused = scope.focusedNode;
@@ -308,13 +317,16 @@ export function registerPaste() {
       const targetWorkspace = workspace.isFlyout
         ? workspace.targetWorkspace
         : workspace;
-      return (
+      const result =
         !!clipboard.getLastCopiedData() &&
         !!targetWorkspace &&
         !targetWorkspace.isReadOnly() &&
         !targetWorkspace.isDragging() &&
-        !getFocusManager().ephemeralFocusTaken()
-      );
+        !getFocusManager().ephemeralFocusTaken();
+      if (!result) {
+        workspace.getAudioManager().playErrorBeep();
+      }
+      return result;
     },
     callback(workspace: WorkspaceSvg, e: Event) {
       const copyData = clipboard.getLastCopiedData();
@@ -931,8 +943,17 @@ export function registerDisconnectBlock() {
   ]);
   const disconnectShortcut: ShortcutRegistry.KeyboardShortcut = {
     name: names.DISCONNECT,
-    preconditionFn: (workspace) =>
-      !workspace.isDragging() && !workspace.isReadOnly(),
+    preconditionFn: (workspace, scope) => {
+      const result =
+        !workspace.isDragging() &&
+        !workspace.isReadOnly() &&
+        scope.focusedNode instanceof BlockSvg;
+
+      if (!result) {
+        workspace.getAudioManager().playErrorBeep();
+      }
+      return result;
+    },
     callback: (_workspace, event) => {
       keyboardNavigationController.setIsActive(true);
       const curNode = getFocusManager().getFocusedNode();
@@ -1186,12 +1207,15 @@ export function registerDuplicate() {
     name: names.DUPLICATE,
     preconditionFn: (workspace, scope) => {
       const {focusedNode} = scope;
-      return (
+      const result =
         !workspace.isDragging() &&
         !workspace.isReadOnly() &&
         !workspace.isFlyout &&
-        (focusedNode instanceof BlockSvg ? focusedNode.isDuplicatable() : true)
-      );
+        (focusedNode instanceof BlockSvg ? focusedNode.isDuplicatable() : true);
+      if (!result) {
+        workspace.getAudioManager().playErrorBeep();
+      }
+      return result;
     },
     callback: (workspace, _e, _shortcut, scope) => {
       keyboardNavigationController.setIsActive(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/506

### Proposed Changes
This PR plays the standard error beep when some keyboard shortcuts fail. This is intended to alert users to a condition that may otherwise have no indication of things being awry, particularly for screen reader users.