### PR TITLE
fix: Improve narration of modifier keys

### DIFF
--- a/packages/blockly/msg/json/en.json
+++ b/packages/blockly/msg/json/en.json
@@ -1,7 +1,7 @@
 {
   "@metadata": {
     "author": "Ellen Spertus <ellen.spertus@gmail.com>",
-    "lastupdated": "2026-05-21 08:19:50.563628",
+    "lastupdated": "2026-05-22 09:11:23.194850",
     "locale": "en",
     "messagedocumentation": "qqq"
   },
@@ -437,14 +437,14 @@
   "CHROME_OS": "ChromeOS",
   "LINUX": "Linux",
   "UNKNOWN": "Unknown",
-  "CONTROL_KEY": "Ctrl",
-  "COMMAND_KEY": "⌘ Command",
-  "OPTION_KEY": "⌥ Option",
+  "CONTROL_KEY": "Control",
+  "COMMAND_KEY": "Command",
+  "OPTION_KEY": "Option",
   "ALT_KEY": "Alt",
   "ENTER_KEY": "Enter",
   "BACKSPACE_KEY": "Backspace",
   "DELETE_KEY": "Delete",
-  "ESCAPE": "Esc",
+  "ESCAPE": "Escape",
   "TAB_KEY": "Tab",
   "SHIFT_KEY": "Shift",
   "CAPS_LOCK_KEY": "Caps Lock",

--- a/packages/blockly/msg/messages.js
+++ b/packages/blockly/msg/messages.js
@@ -1745,13 +1745,13 @@ Blockly.Msg.LINUX = 'Linux';
 Blockly.Msg.UNKNOWN = 'Unknown';
 /** @type {string} */
 /// {{Optional}} Representation of the Control key used in keyboard shortcuts.
-Blockly.Msg.CONTROL_KEY = 'Ctrl';
+Blockly.Msg.CONTROL_KEY = 'Control';
 /** @type {string} */
 /// {{Optional}} Representation of the Mac Command key used in keyboard shortcuts.
-Blockly.Msg.COMMAND_KEY = '⌘ Command';
+Blockly.Msg.COMMAND_KEY = 'Command';
 /** @type {string} */
 /// {{Optional}} Representation of the Mac Option key used in keyboard shortcuts.
-Blockly.Msg.OPTION_KEY = '⌥ Option';
+Blockly.Msg.OPTION_KEY = 'Option';
 /** @type {string} */
 /// {{Optional}} Representation of the Alt key used in keyboard shortcuts.
 Blockly.Msg.ALT_KEY = 'Alt';
@@ -1766,7 +1766,7 @@ Blockly.Msg.BACKSPACE_KEY = 'Backspace';
 Blockly.Msg.DELETE_KEY = 'Delete';
 /** @type {string} */
 /// {{Optional}} Representation of the Escape key used in keyboard shortcuts.
-Blockly.Msg.ESCAPE = 'Esc';
+Blockly.Msg.ESCAPE = 'Escape';
 /** @type {string} */
 /// {{Optional}} Representation of the Tab key used in keyboard shortcuts.
 Blockly.Msg.TAB_KEY = 'Tab';

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -569,8 +569,8 @@ suite('Keyboard-driven movement', function () {
         assert.equal(
           toastSpy.args[0][1]['message'],
           Blockly.utils.userAgent.MAC
-            ? 'Hold ⌘ Command and use arrow keys to move freely, then Enter to accept the position.'
-            : 'Hold Ctrl and use arrow keys to move freely, then Enter to accept the position.',
+            ? 'Hold Command and use arrow keys to move freely, then Enter to accept the position.'
+            : 'Hold Control and use arrow keys to move freely, then Enter to accept the position.',
         );
         sinon.assert.calledOnce(beepSpy);
         beepSpy.restore();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9906

### Proposed Changes
This PR avoids an issue where certain keyboard shortcuts could be read out twice by a screenreader. We had been using the symbol for certain modifier keys in conjunction with their name. These strings have been updated to just use the name. I also fully spelled out "Control" and "Escape" to avoid screenreaders stumbling over trying to pronounce the abbreviations, and for general consistency.