### PR TITLE
fix: Fix bug that caused an incorrect count of inputs on blocks when generating ARIA labels

### DIFF
--- a/packages/blockly/core/block_aria_composer.ts
+++ b/packages/blockly/core/block_aria_composer.ts
@@ -627,7 +627,7 @@ function getInputCountLabel(block: BlockSvg) {
     return (
       input.fieldRow.reduce((fieldCount, field) => {
         return field.EDITABLE && !field.isFullBlockField()
-          ? fieldCount++
+          ? ++fieldCount
           : fieldCount;
       }, totalSum) +
       (input.connection?.type === ConnectionType.INPUT_VALUE ? 1 : 0)

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -496,7 +496,7 @@ suite('ARIA', function () {
     });
 
     test('Blocks without inputs are properly labeled', function () {
-      const block = this.makeBlock('logic_boolean');
+      const block = this.makeBlock('logic_null');
       const label = Blockly.utils.aria.getState(
         block.getFocusableElement(),
         Blockly.utils.aria.State.LABEL,


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #9923

### Proposed Changes
This PR fixed a bug that caused the number of fields on a block to be undercounted when determining how many inputs/fields it has while generating its ARIA label. It also corrects a test for blocks without inputs that was actually exercising a block *with* an input and therefore passing due to this bug.