### PR TITLE
fix: keep tall field corners inside round caps with zelos

### DIFF
--- a/packages/blockly/core/renderers/zelos/info.ts
+++ b/packages/blockly/core/renderers/zelos/info.ts
@@ -8,8 +8,8 @@
 
 import type {BlockSvg} from '../../block_svg.js';
 import {FieldImage} from '../../field_image.js';
+import {FieldInput} from '../../field_input.js';
 import {FieldLabel} from '../../field_label.js';
-import {FieldTextInput} from '../../field_textinput.js';
 import {Align} from '../../inputs/align.js';
 import {DummyInput} from '../../inputs/dummy_input.js';
 import {EndRowInput} from '../../inputs/end_row_input.js';
@@ -30,6 +30,25 @@ import {RightConnectionShape} from './measurables/row_elements.js';
 import {TopRow} from './measurables/top_row.js';
 import type {PathObject} from './path_object.js';
 import type {Renderer} from './renderer.js';
+
+/**
+ * Horizontal inset from a round output-cap tip needed so content at the given
+ * vertical distance from the centerline stays inside the circle.
+ *
+ * @param radius Round cap radius (dynamic connection width).
+ * @param distanceFromCenter Vertical distance from the cap centerline.
+ * @returns Clearance from the tip to the content edge.
+ */
+export function roundCapClearance(
+  radius: number,
+  distanceFromCenter: number,
+): number {
+  if (radius <= 0) {
+    return 0;
+  }
+  const y = Math.min(Math.abs(distanceFromCenter), radius);
+  return radius - Math.sqrt(radius * radius - y * y);
+}
 
 /**
  * An object containing all sizing information needed to draw this block.
@@ -518,8 +537,7 @@ export class RenderInfo extends BaseRenderInfo {
           const maxWidth = this.constants_.MAX_DYNAMIC_CONNECTION_SHAPE_WIDTH;
           const width = this.height / 2 > maxWidth ? maxWidth : this.height / 2;
           const topPadding = this.constants_.SMALL_PADDING;
-          const roundPadding =
-            width * (1 - Math.sin(Math.acos((width - topPadding) / width)));
+          const roundPadding = roundCapClearance(width, width - topPadding);
           return connectionWidth - roundPadding;
         }
         default:
@@ -554,16 +572,30 @@ export class RenderInfo extends BaseRenderInfo {
         this.constants_.SHAPE_IN_SHAPE_PADDING[outerShape][innerShape]
       );
     } else if (Types.isField(elem)) {
-      // Special case for text inputs.
+      // Special case for text and number inputs.
       if (
         outerShape === constants.SHAPES.ROUND &&
-        elem.field instanceof FieldTextInput
+        elem.field instanceof FieldInput
       ) {
         return connectionWidth - 2.75 * constants.GRID_UNIT;
       }
-      return (
-        connectionWidth - this.constants_.SHAPE_IN_SHAPE_PADDING[outerShape][0]
-      );
+      const minClearance =
+        this.constants_.SHAPE_IN_SHAPE_PADDING[outerShape][0];
+      let clearance = minClearance;
+      if (outerShape === constants.SHAPES.ROUND) {
+        // Tall rectangular fields like bitmaps and images need more than the
+        // centerline minimum so their corners stay inside dynamic round caps.
+        // Pure geometry would put corners directly on the path so add a bit
+        // of padding so they don't visually touch.
+        const calculatedClearance =
+          roundCapClearance(connectionWidth, elem.height / 2) +
+          constants.SMALL_PADDING;
+        clearance = Math.min(
+          connectionWidth,
+          Math.max(minClearance, calculatedClearance),
+        );
+      }
+      return connectionWidth - clearance;
     } else if (Types.isIcon(elem)) {
       return this.constants_.SMALL_PADDING;
     }

--- a/packages/blockly/tests/mocha/zelos_info_test.js
+++ b/packages/blockly/tests/mocha/zelos_info_test.js
@@ -22,7 +22,8 @@ suite('Zelos RenderInfo', function () {
           {
             'type': 'field_image',
             'name': 'IMG',
-            'src': 'https://blockly-demo.appspot.com/static/tests/media/a.png',
+            // Layout uses width/height only; src need not resolve.
+            'src': 'about:blank',
             'width': 75,
             'height': 75,
             'alt': 'A',

--- a/packages/blockly/tests/mocha/zelos_info_test.js
+++ b/packages/blockly/tests/mocha/zelos_info_test.js
@@ -22,8 +22,7 @@ suite('Zelos RenderInfo', function () {
           {
             'type': 'field_image',
             'name': 'IMG',
-            'src':
-              'https://blockly-demo.appspot.com/static/tests/media/a.png',
+            'src': 'https://blockly-demo.appspot.com/static/tests/media/a.png',
             'width': 75,
             'height': 75,
             'alt': 'A',

--- a/packages/blockly/tests/mocha/zelos_info_test.js
+++ b/packages/blockly/tests/mocha/zelos_info_test.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {assert} from 'chai';
+import {
+  sharedTestSetup,
+  sharedTestTeardown,
+} from './test_helpers/setup_teardown.js';
+
+suite('Zelos RenderInfo', function () {
+  setup(function () {
+    sharedTestSetup.call(this);
+    this.workspace = Blockly.inject('blocklyDiv', {renderer: 'zelos'});
+    Blockly.defineBlocksWithJsonArray([
+      {
+        'type': 'tall_round_reporter',
+        'message0': '%1',
+        'args0': [
+          {
+            'type': 'field_image',
+            'name': 'IMG',
+            'src':
+              'https://blockly-demo.appspot.com/static/tests/media/a.png',
+            'width': 75,
+            'height': 75,
+            'alt': 'A',
+          },
+        ],
+        'output': null,
+      },
+    ]);
+  });
+
+  teardown(function () {
+    sharedTestTeardown.call(this);
+  });
+
+  test('tall image on round reporter keeps corners inside the caps', function () {
+    const block = this.workspace.newBlock('tall_round_reporter');
+    block.initSvg();
+    block.render();
+
+    const size = block.getHeightWidth();
+    const fieldSize = block.getField('IMG').getSize();
+    const horizontalPad = size.width - fieldSize.width;
+
+    // Height-aware round-cap clearance for a 75px field (radius 42) needs
+    // more than the centerline-only pad (24px) but less than keeping the
+    // full caps (84px), so the rectangle corners stay inside the curve.
+    assert.isAbove(horizontalPad, 24);
+    assert.isBelow(horizontalPad, 84);
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly-samples/issues/2021

### Proposed Changes

For round blocks using the Zelos renderer, negative (inset) cap spacing now uses height-aware circle clearance instead of a fixed centerline-only pad. Tall rectangular fields (images, bitmaps) no longer clip through the rounded ends.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
<img width="213" height="119" alt="bitmap field after" src="https://github.com/user-attachments/assets/1dd253e4-fc57-4fd4-82eb-46f8c41d2288" />
<img width="231" height="95" alt="image field after" src="https://github.com/user-attachments/assets/0f8a8d10-786c-4dab-b6c0-a5389def8fd3" />

This also widens an existing tight-nesting special case from `FieldTextInput` to `FieldInput`, so number fields get the same treatment as text inputs (about 2px narrower on simple number reporters).  This isn't related to the reported bug.

### Reason for Changes

With the Zelos renderer, round connections reserve a full rounded cap width on each side. Content is then pulled into those caps so it nests inside the curve rather than sitting in a rectangular box beside the cap.
If a tall rectangular field on the left/right edge of a pill-shaped block, the field’s corners stick out through the curved cap outline. This only happened when the field is tall enough relative to the cap radius (roughly >30). Normal short fields/icons looked fine. The old code treated every field like round centerline content, and under-padded tall rectangles inside round caps.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
<img width="184" height="110" alt="bitmap field before" src="https://github.com/user-attachments/assets/7a4e2953-ed14-42fb-8c06-875d039f3175" />
<img width="210" height="96" alt="image field before" src="https://github.com/user-attachments/assets/d2b3eeb0-7caa-4c31-b4ae-fb04948d37ec" />

Note that bug report was for bitmap fields specifically, but the bug applies to all potentially tall rectangular fields.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
- Added `tests/mocha/zelos_info_test.js`. The test renders a 75×75 image on a single-field block and checks that the total horizontal pad is above the old centerline-only pad (24px) and below full-cap width (84px).
- Manually verified tall bitmap and image reporters in the Zelos playground (before/after screenshots above), plus a simple `math_number` block for the `FieldInput` nesting tweak (nearly identical, now 2px narrower). No changes observed on any other field types.