### PR TITLE
test: Use local media URL for tests

### DIFF
--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -7,9 +7,9 @@
 import {getInputLabelsSubset} from '#core/block_aria_composer.js';
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('ARIA', function () {
@@ -30,8 +30,7 @@ suite('ARIA', function () {
     ]);
     const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox,
     });
     this.liveRegion = document.getElementById('blocklyAriaAnnounce');

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -9,6 +9,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('ARIA', function () {
@@ -28,7 +29,11 @@ suite('ARIA', function () {
       },
     ]);
     const toolbox = document.getElementById('toolbox-categories');
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox,
+    });
     this.liveRegion = document.getElementById('blocklyAriaAnnounce');
   });
 

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -21,6 +21,7 @@ import {MockBubbleIcon, MockIcon} from './test_helpers/icon_mocks.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -479,7 +480,10 @@ suite('Blocks', function () {
 
     suite('Disposing selected shadow block', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         this.parentBlock = this.workspace.newBlock('row_block');
         this.parentBlock.initSvg();
         this.parentBlock.render();
@@ -579,7 +583,10 @@ suite('Blocks', function () {
 
   suite('Connection Tracking', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv');
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
 
       this.getInputs = function () {
         return this.workspace.connectionDBList[ConnectionType.INPUT_VALUE]
@@ -1401,6 +1408,8 @@ suite('Blocks', function () {
       suite('Rendered', function () {
         setup(function () {
           this.workspace = Blockly.inject('blocklyDiv', {
+            media: TEST_MEDIA_PATH,
+            sounds: false,
             comments: true,
             scrollbars: true,
           });
@@ -1491,7 +1500,10 @@ suite('Blocks', function () {
       }
 
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {});
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1555,7 +1567,10 @@ suite('Blocks', function () {
 
   suite('Getting/Setting Field (Values)', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv');
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       this.block = Blockly.Xml.domToBlock(
         Blockly.utils.xml.textToDom(
           '<block type="text"><field name = "TEXT">test</field></block>',
@@ -1664,7 +1679,10 @@ suite('Blocks', function () {
 
     suite('Adding icons', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {});
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1706,7 +1724,10 @@ suite('Blocks', function () {
 
     suite('Removing icons', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1806,7 +1827,10 @@ suite('Blocks', function () {
 
     suite('Warning icons', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1952,7 +1976,10 @@ suite('Blocks', function () {
 
     suite('Warning icons and collapsing', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         this.parentBlock = Blockly.serialization.blocks.append(
           {
             'type': 'statement_block',
@@ -2025,7 +2052,10 @@ suite('Blocks', function () {
 
     suite('Bubbles and collapsing', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
       });
 
       teardown(function () {
@@ -2145,7 +2175,10 @@ suite('Blocks', function () {
     setup(function () {
       eventUtils.disable();
       // We need a visible workspace.
-      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       Blockly.defineBlocksWithJsonArray([
         {
           'type': 'variable_block',
@@ -2724,7 +2757,10 @@ suite('Blocks', function () {
     });
     suite('Rendered', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {});
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         this.block = Blockly.Xml.domToBlock(
           Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
           this.workspace,
@@ -2957,7 +2993,10 @@ suite('Blocks', function () {
 
   suite('Dragging', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv');
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       this.blocks = createTestBlocks(this.workspace, false);
       for (const block of Object.values(this.blocks)) {
         block.initSvg();
@@ -3003,7 +3042,10 @@ suite('Blocks', function () {
 
   suite('Disposal focus management', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv');
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       const firstBlock = this.workspace.newBlock('stack_block');
       firstBlock.moveBy(-500, -500);
     });

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -19,9 +19,9 @@ import {
 } from './test_helpers/events.js';
 import {MockBubbleIcon, MockIcon} from './test_helpers/icon_mocks.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -480,10 +480,7 @@ suite('Blocks', function () {
 
     suite('Disposing selected shadow block', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
         this.parentBlock = this.workspace.newBlock('row_block');
         this.parentBlock.initSvg();
         this.parentBlock.render();
@@ -583,10 +580,7 @@ suite('Blocks', function () {
 
   suite('Connection Tracking', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
 
       this.getInputs = function () {
         return this.workspace.connectionDBList[ConnectionType.INPUT_VALUE]
@@ -1408,8 +1402,7 @@ suite('Blocks', function () {
       suite('Rendered', function () {
         setup(function () {
           this.workspace = Blockly.inject('blocklyDiv', {
-            media: TEST_MEDIA_PATH,
-            sounds: false,
+            ...DEFAULT_INJECT_OPTIONS,
             comments: true,
             scrollbars: true,
           });
@@ -1500,10 +1493,7 @@ suite('Blocks', function () {
       }
 
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1567,10 +1557,7 @@ suite('Blocks', function () {
 
   suite('Getting/Setting Field (Values)', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       this.block = Blockly.Xml.domToBlock(
         Blockly.utils.xml.textToDom(
           '<block type="text"><field name = "TEXT">test</field></block>',
@@ -1679,10 +1666,7 @@ suite('Blocks', function () {
 
     suite('Adding icons', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1724,10 +1708,7 @@ suite('Blocks', function () {
 
     suite('Removing icons', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1827,10 +1808,7 @@ suite('Blocks', function () {
 
     suite('Warning icons', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
 
         this.block = this.workspace.newBlock('stack_block');
         this.block.initSvg();
@@ -1976,10 +1954,7 @@ suite('Blocks', function () {
 
     suite('Warning icons and collapsing', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
         this.parentBlock = Blockly.serialization.blocks.append(
           {
             'type': 'statement_block',
@@ -2052,10 +2027,7 @@ suite('Blocks', function () {
 
     suite('Bubbles and collapsing', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       });
 
       teardown(function () {
@@ -2175,10 +2147,7 @@ suite('Blocks', function () {
     setup(function () {
       eventUtils.disable();
       // We need a visible workspace.
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       Blockly.defineBlocksWithJsonArray([
         {
           'type': 'variable_block',
@@ -2757,10 +2726,7 @@ suite('Blocks', function () {
     });
     suite('Rendered', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
         this.block = Blockly.Xml.domToBlock(
           Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
           this.workspace,
@@ -2993,10 +2959,7 @@ suite('Blocks', function () {
 
   suite('Dragging', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       this.blocks = createTestBlocks(this.workspace, false);
       for (const block of Object.values(this.blocks)) {
         block.initSvg();
@@ -3042,10 +3005,7 @@ suite('Blocks', function () {
 
   suite('Disposal focus management', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       const firstBlock = this.workspace.newBlock('stack_block');
       firstBlock.moveBy(-500, -500);
     });

--- a/packages/blockly/tests/mocha/blocks/loops_test.js
+++ b/packages/blockly/tests/mocha/blocks/loops_test.js
@@ -9,12 +9,16 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from '../test_helpers/setup_teardown.js';
 
 suite('Loops', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/blocks/loops_test.js
+++ b/packages/blockly/tests/mocha/blocks/loops_test.js
@@ -7,18 +7,15 @@
 import * as Blockly from '#core/blockly.js';
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from '../test_helpers/setup_teardown.js';
 
 suite('Loops', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/blocks/procedures_test.js
+++ b/packages/blockly/tests/mocha/blocks/procedures_test.js
@@ -19,13 +19,17 @@ import {
   createGenUidStubWithReturns,
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from '../test_helpers/setup_teardown.js';
 
 suite('Procedures', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.workspace
       .getVariableMap()
       .createVariable('preCreatedVar', '', 'preCreatedVarId');

--- a/packages/blockly/tests/mocha/blocks/procedures_test.js
+++ b/packages/blockly/tests/mocha/blocks/procedures_test.js
@@ -17,19 +17,16 @@ import {
 import {runSerializationTestSuite} from '../test_helpers/serialization.js';
 import {
   createGenUidStubWithReturns,
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from '../test_helpers/setup_teardown.js';
 
 suite('Procedures', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.workspace
       .getVariableMap()
       .createVariable('preCreatedVar', '', 'preCreatedVarId');

--- a/packages/blockly/tests/mocha/clipboard_test.js
+++ b/packages/blockly/tests/mocha/clipboard_test.js
@@ -10,18 +10,15 @@ import {
   createChangeListenerSpy,
 } from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Clipboard', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
   });
 
   teardown(function () {
@@ -164,8 +161,7 @@ suite('Clipboard', function () {
       test('pasted blocks are bumped to not overlap in RTL', function () {
         this.workspace.dispose();
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           rtl: true,
         });
         const block = Blockly.serialization.blocks.append(
@@ -190,10 +186,7 @@ suite('Clipboard', function () {
 
         // Restore an LTR workspace.
         this.workspace.dispose();
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       });
 
       test('pasted blocks are bumped to be outside the connection snap radius', function () {
@@ -251,8 +244,7 @@ suite('Clipboard', function () {
     test('pasted comments are bumped to not overlap in RTL', function () {
       this.workspace.dispose();
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         rtl: true,
       });
       Blockly.Xml.domToWorkspace(
@@ -272,10 +264,7 @@ suite('Clipboard', function () {
       );
       // Restore an LTR workspace.
       this.workspace.dispose();
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     });
   });
 });

--- a/packages/blockly/tests/mocha/clipboard_test.js
+++ b/packages/blockly/tests/mocha/clipboard_test.js
@@ -12,12 +12,16 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Clipboard', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
   });
 
   teardown(function () {
@@ -159,7 +163,11 @@ suite('Clipboard', function () {
 
       test('pasted blocks are bumped to not overlap in RTL', function () {
         this.workspace.dispose();
-        this.workspace = Blockly.inject('blocklyDiv', {rtl: true});
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+          rtl: true,
+        });
         const block = Blockly.serialization.blocks.append(
           {
             'type': 'controls_if',
@@ -182,7 +190,10 @@ suite('Clipboard', function () {
 
         // Restore an LTR workspace.
         this.workspace.dispose();
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
       });
 
       test('pasted blocks are bumped to be outside the connection snap radius', function () {
@@ -239,7 +250,11 @@ suite('Clipboard', function () {
 
     test('pasted comments are bumped to not overlap in RTL', function () {
       this.workspace.dispose();
-      this.workspace = Blockly.inject('blocklyDiv', {rtl: true});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+        rtl: true,
+      });
       Blockly.Xml.domToWorkspace(
         Blockly.utils.xml.textToDom(
           '<xml><comment id="test" x=10 y=10/></xml>',
@@ -257,7 +272,10 @@ suite('Clipboard', function () {
       );
       // Restore an LTR workspace.
       this.workspace.dispose();
-      this.workspace = Blockly.inject('blocklyDiv');
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
     });
   });
 });

--- a/packages/blockly/tests/mocha/comment_deserialization_test.js
+++ b/packages/blockly/tests/mocha/comment_deserialization_test.js
@@ -8,6 +8,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -31,6 +32,8 @@ suite('Comment Deserialization', function () {
     </xml>
     `;
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       comments: true,
       scrollbars: true,
       trashcan: true,

--- a/packages/blockly/tests/mocha/comment_deserialization_test.js
+++ b/packages/blockly/tests/mocha/comment_deserialization_test.js
@@ -6,9 +6,9 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -32,8 +32,7 @@ suite('Comment Deserialization', function () {
     </xml>
     `;
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       comments: true,
       scrollbars: true,
       trashcan: true,

--- a/packages/blockly/tests/mocha/comment_test.js
+++ b/packages/blockly/tests/mocha/comment_test.js
@@ -10,6 +10,7 @@ import {assertEventFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Comments', function () {
@@ -23,6 +24,8 @@ suite('Comments', function () {
       },
     ]);
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       comments: true,
       scrollbars: true,
     });

--- a/packages/blockly/tests/mocha/comment_test.js
+++ b/packages/blockly/tests/mocha/comment_test.js
@@ -8,9 +8,9 @@ import {EventType} from '#core/events/type.js';
 import {assert} from 'chai';
 import {assertEventFired} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Comments', function () {
@@ -24,8 +24,7 @@ suite('Comments', function () {
       },
     ]);
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       comments: true,
       scrollbars: true,
     });

--- a/packages/blockly/tests/mocha/comment_view_test.js
+++ b/packages/blockly/tests/mocha/comment_view_test.js
@@ -6,18 +6,15 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Workspace comment', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = new Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = new Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.commentView = new Blockly.comments.CommentView(this.workspace);
   });
 

--- a/packages/blockly/tests/mocha/comment_view_test.js
+++ b/packages/blockly/tests/mocha/comment_view_test.js
@@ -8,12 +8,16 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Workspace comment', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = new Blockly.inject('blocklyDiv', {});
+    this.workspace = new Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.commentView = new Blockly.comments.CommentView(this.workspace);
   });
 

--- a/packages/blockly/tests/mocha/connection_checker_test.js
+++ b/packages/blockly/tests/mocha/connection_checker_test.js
@@ -9,6 +9,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Connection checker', function () {
@@ -515,7 +516,10 @@ suite('Connection checker', function () {
   suite('Dragging Checks', function () {
     suite('Stacks', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         // Load in three blocks: A and B are connected (next/prev); B is unmovable.
         Blockly.Xml.domToWorkspace(
           Blockly.utils.xml
@@ -626,7 +630,10 @@ suite('Connection checker', function () {
     });
     suite('Rows', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv');
+        this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         // Load 3 blocks: A and B are connected (input/output); B is unmovable.
         Blockly.Xml.domToWorkspace(
           Blockly.utils.xml

--- a/packages/blockly/tests/mocha/connection_checker_test.js
+++ b/packages/blockly/tests/mocha/connection_checker_test.js
@@ -7,9 +7,9 @@
 import {ConnectionType} from '#core/connection_type.js';
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Connection checker', function () {
@@ -516,10 +516,7 @@ suite('Connection checker', function () {
   suite('Dragging Checks', function () {
     suite('Stacks', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
         // Load in three blocks: A and B are connected (next/prev); B is unmovable.
         Blockly.Xml.domToWorkspace(
           Blockly.utils.xml
@@ -630,10 +627,7 @@ suite('Connection checker', function () {
     });
     suite('Rows', function () {
       setup(function () {
-        this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
         // Load 3 blocks: A and B are connected (input/output); B is unmovable.
         Blockly.Xml.domToWorkspace(
           Blockly.utils.xml

--- a/packages/blockly/tests/mocha/connection_test.js
+++ b/packages/blockly/tests/mocha/connection_test.js
@@ -12,9 +12,9 @@ import {
 } from './test_helpers/block_definitions.js';
 import {
   createGenUidStubWithReturns,
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -102,10 +102,7 @@ suite('Connection', function () {
       {
         title: 'Rendered',
         createWorkspace: () => {
-          return Blockly.inject('blocklyDiv', {
-            media: TEST_MEDIA_PATH,
-            sounds: false,
-          });
+          return Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
         },
       },
       {

--- a/packages/blockly/tests/mocha/connection_test.js
+++ b/packages/blockly/tests/mocha/connection_test.js
@@ -14,6 +14,7 @@ import {
   createGenUidStubWithReturns,
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -101,7 +102,10 @@ suite('Connection', function () {
       {
         title: 'Rendered',
         createWorkspace: () => {
-          return Blockly.inject('blocklyDiv');
+          return Blockly.inject('blocklyDiv', {
+            media: TEST_MEDIA_PATH,
+            sounds: false,
+          });
         },
       },
       {

--- a/packages/blockly/tests/mocha/contextmenu_items_test.js
+++ b/packages/blockly/tests/mocha/contextmenu_items_test.js
@@ -8,6 +8,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -17,7 +18,11 @@ suite('Context Menu Items', function () {
 
     // Creates a WorkspaceSVG
     const toolbox = document.getElementById('toolbox-categories');
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox: toolbox,
+    });
 
     this.registry = Blockly.ContextMenuRegistry.registry;
     this.registry.reset();

--- a/packages/blockly/tests/mocha/contextmenu_items_test.js
+++ b/packages/blockly/tests/mocha/contextmenu_items_test.js
@@ -6,9 +6,9 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -19,8 +19,7 @@ suite('Context Menu Items', function () {
     // Creates a WorkspaceSVG
     const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
     });
 

--- a/packages/blockly/tests/mocha/contextmenu_test.js
+++ b/packages/blockly/tests/mocha/contextmenu_test.js
@@ -12,9 +12,9 @@ import {
   defineStackBlock,
 } from './test_helpers/block_definitions.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Context Menu', function () {
@@ -24,8 +24,7 @@ suite('Context Menu', function () {
     // Creates a WorkspaceSVG
     const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
     });
   });

--- a/packages/blockly/tests/mocha/contextmenu_test.js
+++ b/packages/blockly/tests/mocha/contextmenu_test.js
@@ -14,6 +14,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Context Menu', function () {
@@ -22,7 +23,11 @@ suite('Context Menu', function () {
 
     // Creates a WorkspaceSVG
     const toolbox = document.getElementById('toolbox-categories');
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox: toolbox,
+    });
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/dialog_test.js
+++ b/packages/blockly/tests/mocha/dialog_test.js
@@ -8,12 +8,16 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Dialog utilities', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/dialog_test.js
+++ b/packages/blockly/tests/mocha/dialog_test.js
@@ -6,18 +6,15 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Dialog utilities', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/dropdowndiv_test.js
+++ b/packages/blockly/tests/mocha/dropdowndiv_test.js
@@ -10,13 +10,17 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('DropDownDiv', function () {
   setup(function () {
     sharedTestSetup.call(this);
     Blockly.common.setParentContainer(document.firstElementChild);
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.setUpBlockWithField = function () {
       const blockJson = {
         'type': 'text',
@@ -150,7 +154,10 @@ suite('DropDownDiv', function () {
           width: 100,
           height: 100,
         });
-      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
     });
     teardown(function () {
       this.boundsStub.restore();

--- a/packages/blockly/tests/mocha/dropdowndiv_test.js
+++ b/packages/blockly/tests/mocha/dropdowndiv_test.js
@@ -8,19 +8,16 @@ import {Rect} from '#core/utils/rect.js';
 import * as style from '#core/utils/style.js';
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('DropDownDiv', function () {
   setup(function () {
     sharedTestSetup.call(this);
     Blockly.common.setParentContainer(document.firstElementChild);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.setUpBlockWithField = function () {
       const blockJson = {
         'type': 'text',
@@ -154,10 +151,7 @@ suite('DropDownDiv', function () {
           width: 100,
           height: 100,
         });
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     });
     teardown(function () {
       this.boundsStub.restore();

--- a/packages/blockly/tests/mocha/event_selected_test.js
+++ b/packages/blockly/tests/mocha/event_selected_test.js
@@ -10,13 +10,17 @@ import {createChangeListenerSpy} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Selected Event', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
     defineRowBlock();
-    this.workspace = new Blockly.inject('blocklyDiv', {});
+    this.workspace = new Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.eventSpy = createChangeListenerSpy(this.workspace);
   });
 

--- a/packages/blockly/tests/mocha/event_selected_test.js
+++ b/packages/blockly/tests/mocha/event_selected_test.js
@@ -8,19 +8,16 @@ import {assert} from 'chai';
 import {defineRowBlock} from './test_helpers/block_definitions.js';
 import {createChangeListenerSpy} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Selected Event', function () {
   setup(function () {
     sharedTestSetup.call(this, {fireEventsNow: false});
     defineRowBlock();
-    this.workspace = new Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = new Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.eventSpy = createChangeListenerSpy(this.workspace);
   });
 

--- a/packages/blockly/tests/mocha/event_test.js
+++ b/packages/blockly/tests/mocha/event_test.js
@@ -16,6 +16,7 @@ import {
   createGenUidStubWithReturns,
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {assertVariableValues} from './test_helpers/variables.js';
@@ -1367,7 +1368,11 @@ suite('Events', function () {
       let workspaceSvg;
       try {
         const toolbox = document.getElementById('toolbox-categories');
-        workspaceSvg = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+        workspaceSvg = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+          toolbox: toolbox,
+        });
         const TEST_BLOCK_ID = 'test_block_id';
         const genUidStub = createGenUidStubWithReturns([
           TEST_BLOCK_ID,
@@ -1530,7 +1535,11 @@ suite('Events', function () {
     setup(function () {
       // disableOrphans needs a WorkspaceSVG
       const toolbox = document.getElementById('toolbox-categories');
-      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+        toolbox: toolbox,
+      });
     });
     teardown(function () {
       workspaceTeardown.call(this, this.workspace);

--- a/packages/blockly/tests/mocha/event_test.js
+++ b/packages/blockly/tests/mocha/event_test.js
@@ -14,9 +14,9 @@ import {
 } from './test_helpers/events.js';
 import {
   createGenUidStubWithReturns,
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {assertVariableValues} from './test_helpers/variables.js';
@@ -1369,8 +1369,7 @@ suite('Events', function () {
       try {
         const toolbox = document.getElementById('toolbox-categories');
         workspaceSvg = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           toolbox: toolbox,
         });
         const TEST_BLOCK_ID = 'test_block_id';
@@ -1536,8 +1535,7 @@ suite('Events', function () {
       // disableOrphans needs a WorkspaceSVG
       const toolbox = document.getElementById('toolbox-categories');
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         toolbox: toolbox,
       });
     });

--- a/packages/blockly/tests/mocha/event_toolbox_item_select_test.js
+++ b/packages/blockly/tests/mocha/event_toolbox_item_select_test.js
@@ -8,12 +8,15 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Toolbox Item Select Event', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: {
         'kind': 'categoryToolbox',
         'contents': [

--- a/packages/blockly/tests/mocha/event_toolbox_item_select_test.js
+++ b/packages/blockly/tests/mocha/event_toolbox_item_select_test.js
@@ -6,17 +6,16 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Toolbox Item Select Event', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: {
         'kind': 'categoryToolbox',
         'contents': [

--- a/packages/blockly/tests/mocha/field_checkbox_test.js
+++ b/packages/blockly/tests/mocha/field_checkbox_test.js
@@ -14,9 +14,9 @@ import {
   runSetValueTests,
 } from './test_helpers/fields.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -298,8 +298,7 @@ suite('Checkbox Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('test_fields_checkbox');

--- a/packages/blockly/tests/mocha/field_checkbox_test.js
+++ b/packages/blockly/tests/mocha/field_checkbox_test.js
@@ -16,6 +16,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -297,6 +298,8 @@ suite('Checkbox Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('test_fields_checkbox');

--- a/packages/blockly/tests/mocha/field_dropdown_test.js
+++ b/packages/blockly/tests/mocha/field_dropdown_test.js
@@ -19,6 +19,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -329,6 +330,8 @@ suite('Dropdown Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
     });
@@ -583,6 +586,8 @@ suite('Dropdown Fields', function () {
     suite('Full block fields', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
           renderer: 'zelos',
         });
         this.block = this.workspace.newBlock('variables_get');

--- a/packages/blockly/tests/mocha/field_dropdown_test.js
+++ b/packages/blockly/tests/mocha/field_dropdown_test.js
@@ -17,9 +17,9 @@ import {
   runSetValueTests,
 } from './test_helpers/fields.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -330,8 +330,7 @@ suite('Dropdown Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
     });
@@ -586,8 +585,7 @@ suite('Dropdown Fields', function () {
     suite('Full block fields', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           renderer: 'zelos',
         });
         this.block = this.workspace.newBlock('variables_get');

--- a/packages/blockly/tests/mocha/field_image_test.js
+++ b/packages/blockly/tests/mocha/field_image_test.js
@@ -13,18 +13,15 @@ import {
   runSetValueTests,
 } from './test_helpers/fields.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Image Fields', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
   });
   teardown(function () {
     sharedTestTeardown.call(this);
@@ -363,8 +360,7 @@ suite('Image Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
     });

--- a/packages/blockly/tests/mocha/field_image_test.js
+++ b/packages/blockly/tests/mocha/field_image_test.js
@@ -15,12 +15,16 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Image Fields', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
   });
   teardown(function () {
     sharedTestTeardown.call(this);
@@ -359,6 +363,8 @@ suite('Image Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
     });

--- a/packages/blockly/tests/mocha/field_label_test.js
+++ b/packages/blockly/tests/mocha/field_label_test.js
@@ -14,9 +14,9 @@ import {
   runSetValueTests,
 } from './test_helpers/fields.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Label Fields', function () {
@@ -228,8 +228,7 @@ suite('Label Fields', function () {
   suite('ARIA', function () {
     test('Is hidden', function () {
       const workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
       const block = workspace.newBlock('text_print');

--- a/packages/blockly/tests/mocha/field_label_test.js
+++ b/packages/blockly/tests/mocha/field_label_test.js
@@ -16,6 +16,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Label Fields', function () {
@@ -227,6 +228,8 @@ suite('Label Fields', function () {
   suite('ARIA', function () {
     test('Is hidden', function () {
       const workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
       const block = workspace.newBlock('text_print');

--- a/packages/blockly/tests/mocha/field_number_test.js
+++ b/packages/blockly/tests/mocha/field_number_test.js
@@ -15,9 +15,9 @@ import {
   runSetValueTests,
 } from './test_helpers/fields.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -506,8 +506,7 @@ suite('Number Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('math_number');
@@ -599,8 +598,7 @@ suite('Number Fields', function () {
     suite('Full block fields', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           renderer: 'zelos',
         });
         this.block = this.workspace.newBlock('math_number');

--- a/packages/blockly/tests/mocha/field_number_test.js
+++ b/packages/blockly/tests/mocha/field_number_test.js
@@ -17,6 +17,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -505,6 +506,8 @@ suite('Number Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('math_number');
@@ -596,6 +599,8 @@ suite('Number Fields', function () {
     suite('Full block fields', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
           renderer: 'zelos',
         });
         this.block = this.workspace.newBlock('math_number');

--- a/packages/blockly/tests/mocha/field_textinput_test.js
+++ b/packages/blockly/tests/mocha/field_textinput_test.js
@@ -19,6 +19,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -347,6 +348,8 @@ suite('Text Input Fields', function () {
     suite('Geras theme', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
           renderer: 'geras',
         });
         Blockly.serialization.blocks.append(this.blockJson, this.workspace);
@@ -540,6 +543,8 @@ suite('Text Input Fields', function () {
     suite('Zelos theme', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
           renderer: 'zelos',
         });
         Blockly.serialization.blocks.append(this.blockJson, this.workspace);
@@ -623,6 +628,8 @@ suite('Text Input Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('text');

--- a/packages/blockly/tests/mocha/field_textinput_test.js
+++ b/packages/blockly/tests/mocha/field_textinput_test.js
@@ -17,9 +17,9 @@ import {
   runSetValueTests,
 } from './test_helpers/fields.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -348,8 +348,7 @@ suite('Text Input Fields', function () {
     suite('Geras theme', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           renderer: 'geras',
         });
         Blockly.serialization.blocks.append(this.blockJson, this.workspace);
@@ -543,8 +542,7 @@ suite('Text Input Fields', function () {
     suite('Zelos theme', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           renderer: 'zelos',
         });
         Blockly.serialization.blocks.append(this.blockJson, this.workspace);
@@ -628,8 +626,7 @@ suite('Text Input Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('text');

--- a/packages/blockly/tests/mocha/field_variable_test.js
+++ b/packages/blockly/tests/mocha/field_variable_test.js
@@ -18,9 +18,9 @@ import {
 } from './test_helpers/fields.js';
 import {
   createGenUidStubWithReturns,
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -653,8 +653,7 @@ suite('Variable Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('variables_set');

--- a/packages/blockly/tests/mocha/field_variable_test.js
+++ b/packages/blockly/tests/mocha/field_variable_test.js
@@ -20,6 +20,7 @@ import {
   createGenUidStubWithReturns,
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -652,6 +653,8 @@ suite('Variable Fields', function () {
   suite('ARIA', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         renderer: 'geras',
       });
       this.block = this.workspace.newBlock('variables_set');

--- a/packages/blockly/tests/mocha/flyout_test.js
+++ b/packages/blockly/tests/mocha/flyout_test.js
@@ -8,6 +8,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {
@@ -34,6 +35,8 @@ suite('Flyout', function () {
     ]);
     this.toolboxXml = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: this.toolboxXml,
     });
   });
@@ -106,6 +109,8 @@ suite('Flyout', function () {
         setup(function () {
           const toolbox = document.getElementById('toolbox-categories');
           this.workspace = Blockly.inject('blocklyDiv', {
+            media: TEST_MEDIA_PATH,
+            sounds: false,
             toolbox: toolbox,
           });
           this.flyout = this.workspace.getToolbox().getFlyout();
@@ -194,6 +199,8 @@ suite('Flyout', function () {
     suite('horizontal flyout', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
           toolbox: this.toolboxXml,
           horizontalLayout: true,
         });
@@ -242,6 +249,8 @@ suite('Flyout', function () {
         setup(function () {
           const toolbox = document.getElementById('toolbox-categories');
           this.workspace = Blockly.inject('blocklyDiv', {
+            media: TEST_MEDIA_PATH,
+            sounds: false,
             toolbox: toolbox,
             horizontalLayout: true,
           });

--- a/packages/blockly/tests/mocha/flyout_test.js
+++ b/packages/blockly/tests/mocha/flyout_test.js
@@ -6,9 +6,9 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {
@@ -35,8 +35,7 @@ suite('Flyout', function () {
     ]);
     this.toolboxXml = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: this.toolboxXml,
     });
   });
@@ -109,8 +108,7 @@ suite('Flyout', function () {
         setup(function () {
           const toolbox = document.getElementById('toolbox-categories');
           this.workspace = Blockly.inject('blocklyDiv', {
-            media: TEST_MEDIA_PATH,
-            sounds: false,
+            ...DEFAULT_INJECT_OPTIONS,
             toolbox: toolbox,
           });
           this.flyout = this.workspace.getToolbox().getFlyout();
@@ -199,8 +197,7 @@ suite('Flyout', function () {
     suite('horizontal flyout', function () {
       setup(function () {
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           toolbox: this.toolboxXml,
           horizontalLayout: true,
         });
@@ -249,8 +246,7 @@ suite('Flyout', function () {
         setup(function () {
           const toolbox = document.getElementById('toolbox-categories');
           this.workspace = Blockly.inject('blocklyDiv', {
-            media: TEST_MEDIA_PATH,
-            sounds: false,
+            ...DEFAULT_INJECT_OPTIONS,
             toolbox: toolbox,
             horizontalLayout: true,
           });

--- a/packages/blockly/tests/mocha/gesture_test.js
+++ b/packages/blockly/tests/mocha/gesture_test.js
@@ -9,9 +9,9 @@ import {assert} from 'chai';
 import {defineBasicBlockWithField} from './test_helpers/block_definitions.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {getProperSimpleJson} from './test_helpers/toolbox_definitions.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
@@ -62,8 +62,7 @@ suite('Gesture', function () {
       'type': 'test_field_block',
     });
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox,
     });
   });

--- a/packages/blockly/tests/mocha/gesture_test.js
+++ b/packages/blockly/tests/mocha/gesture_test.js
@@ -11,6 +11,7 @@ import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {getProperSimpleJson} from './test_helpers/toolbox_definitions.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
@@ -60,7 +61,11 @@ suite('Gesture', function () {
       'kind': 'block',
       'type': 'test_field_block',
     });
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox,
+    });
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/icon_test.js
+++ b/packages/blockly/tests/mocha/icon_test.js
@@ -9,9 +9,9 @@ import {assert} from 'chai';
 import {defineEmptyBlock} from './test_helpers/block_definitions.js';
 import {MockIcon, MockSerializableIcon} from './test_helpers/icon_mocks.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -392,10 +392,7 @@ suite('Icon', function () {
   suite('Contextual menus', function () {
     setup(function () {
       Blockly.common.setParentContainer(document.firstElementChild);
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       Blockly.icons.registry.register(
         new Blockly.icons.IconType('test'),
         TestIcon,

--- a/packages/blockly/tests/mocha/icon_test.js
+++ b/packages/blockly/tests/mocha/icon_test.js
@@ -11,6 +11,7 @@ import {MockIcon, MockSerializableIcon} from './test_helpers/icon_mocks.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -391,7 +392,10 @@ suite('Icon', function () {
   suite('Contextual menus', function () {
     setup(function () {
       Blockly.common.setParentContainer(document.firstElementChild);
-      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       Blockly.icons.registry.register(
         new Blockly.icons.IconType('test'),
         TestIcon,

--- a/packages/blockly/tests/mocha/input_test.js
+++ b/packages/blockly/tests/mocha/input_test.js
@@ -7,9 +7,9 @@
 import {assert} from 'chai';
 import {createRenderedBlock} from './test_helpers/block_definitions.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Inputs', function () {
@@ -23,10 +23,7 @@ suite('Inputs', function () {
       },
     ]);
 
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.block = Blockly.Xml.domToBlock(
       Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
       this.workspace,

--- a/packages/blockly/tests/mocha/input_test.js
+++ b/packages/blockly/tests/mocha/input_test.js
@@ -9,6 +9,7 @@ import {createRenderedBlock} from './test_helpers/block_definitions.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Inputs', function () {
@@ -22,7 +23,10 @@ suite('Inputs', function () {
       },
     ]);
 
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.block = Blockly.Xml.domToBlock(
       Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
       this.workspace,

--- a/packages/blockly/tests/mocha/insertion_marker_test.js
+++ b/packages/blockly/tests/mocha/insertion_marker_test.js
@@ -8,12 +8,17 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('InsertionMarkers', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {renderer: 'geras'});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      renderer: 'geras',
+    });
     Blockly.defineBlocksWithJsonArray([
       {
         'type': 'stack_block',

--- a/packages/blockly/tests/mocha/insertion_marker_test.js
+++ b/packages/blockly/tests/mocha/insertion_marker_test.js
@@ -6,17 +6,16 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('InsertionMarkers', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       renderer: 'geras',
     });
     Blockly.defineBlocksWithJsonArray([

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -12,9 +12,9 @@ import {
 } from './test_helpers/move_test_blocks.js';
 import {p5blocks} from './test_helpers/p5_blocks.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
@@ -42,8 +42,7 @@ suite('Keyboard-driven movement', function () {
     };
 
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
     });
     Blockly.common.defineBlocks(p5blocks);
@@ -1122,8 +1121,7 @@ suite('Keyboard-driven movement', function () {
             setup(function () {
               const toolbox = document.getElementById('toolbox-simple');
               this.workspace = Blockly.inject('blocklyDiv', {
-                media: TEST_MEDIA_PATH,
-                sounds: false,
+                ...DEFAULT_INJECT_OPTIONS,
                 toolbox: toolbox,
                 renderer: renderer,
               });

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -14,6 +14,7 @@ import {p5blocks} from './test_helpers/p5_blocks.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
@@ -40,7 +41,11 @@ suite('Keyboard-driven movement', function () {
       ],
     };
 
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox: toolbox,
+    });
     Blockly.common.defineBlocks(p5blocks);
     Blockly.KeyboardMover.mover.setMoveDistance(20);
   });
@@ -1117,6 +1122,8 @@ suite('Keyboard-driven movement', function () {
             setup(function () {
               const toolbox = document.getElementById('toolbox-simple');
               this.workspace = Blockly.inject('blocklyDiv', {
+                media: TEST_MEDIA_PATH,
+                sounds: false,
                 toolbox: toolbox,
                 renderer: renderer,
               });

--- a/packages/blockly/tests/mocha/keyboard_navigation_controller_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_controller_test.js
@@ -8,12 +8,16 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Keyboard Navigation Controller', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     Blockly.keyboardNavigationController.setIsActive(false);
   });
 

--- a/packages/blockly/tests/mocha/keyboard_navigation_controller_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_controller_test.js
@@ -6,18 +6,15 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Keyboard Navigation Controller', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     Blockly.keyboardNavigationController.setIsActive(false);
   });
 

--- a/packages/blockly/tests/mocha/keyboard_navigation_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_test.js
@@ -9,9 +9,9 @@ import {assert} from 'chai';
 import {navigationTestBlocks} from './test_helpers/navigation_test_blocks.js';
 import {p5blocks} from './test_helpers/p5_blocks.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
@@ -133,8 +133,7 @@ suite('Keyboard navigation on Blocks', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
       renderer: 'zelos',
     });
@@ -410,8 +409,7 @@ suite('Keyboard navigation on Fields', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
       renderer: 'zelos',
     });
@@ -478,8 +476,7 @@ suite('Workspace comment navigation', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
       renderer: 'zelos',
     });
@@ -664,8 +661,7 @@ suite('Toolbox and flyout arrow navigation by layout', function () {
         ]);
         const toolbox = document.getElementById('toolbox-categories');
         this.workspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
+          ...DEFAULT_INJECT_OPTIONS,
           toolbox,
           rtl: layout.rtl,
           horizontalLayout: layout.horizontalLayout,
@@ -897,8 +893,7 @@ suite('Flyout heading navigation (H / Shift+H)', function () {
     // Build a flyout toolbox that mixes blocks and headings (labels) so we
     // can verify that the H shortcut jumps over non-heading items.
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: {
         kind: 'flyoutToolbox',
         contents: [
@@ -1048,8 +1043,7 @@ suite('Flyout heading navigation with no headings', function () {
       },
     ]);
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: {
         kind: 'flyoutToolbox',
         contents: [

--- a/packages/blockly/tests/mocha/keyboard_navigation_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_test.js
@@ -11,6 +11,7 @@ import {p5blocks} from './test_helpers/p5_blocks.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
@@ -132,6 +133,8 @@ suite('Keyboard navigation on Blocks', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: toolbox,
       renderer: 'zelos',
     });
@@ -407,6 +410,8 @@ suite('Keyboard navigation on Fields', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: toolbox,
       renderer: 'zelos',
     });
@@ -473,6 +478,8 @@ suite('Workspace comment navigation', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-simple');
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: toolbox,
       renderer: 'zelos',
     });
@@ -657,6 +664,8 @@ suite('Toolbox and flyout arrow navigation by layout', function () {
         ]);
         const toolbox = document.getElementById('toolbox-categories');
         this.workspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
           toolbox,
           rtl: layout.rtl,
           horizontalLayout: layout.horizontalLayout,
@@ -888,6 +897,8 @@ suite('Flyout heading navigation (H / Shift+H)', function () {
     // Build a flyout toolbox that mixes blocks and headings (labels) so we
     // can verify that the H shortcut jumps over non-heading items.
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: {
         kind: 'flyoutToolbox',
         contents: [
@@ -1037,6 +1048,8 @@ suite('Flyout heading navigation with no headings', function () {
       },
     ]);
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       toolbox: {
         kind: 'flyoutToolbox',
         contents: [

--- a/packages/blockly/tests/mocha/layering_test.js
+++ b/packages/blockly/tests/mocha/layering_test.js
@@ -7,12 +7,16 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Layering', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.layerManager = this.workspace.getLayerManager();
   });
 

--- a/packages/blockly/tests/mocha/layering_test.js
+++ b/packages/blockly/tests/mocha/layering_test.js
@@ -5,18 +5,15 @@
  */
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Layering', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.layerManager = this.workspace.getLayerManager();
   });
 

--- a/packages/blockly/tests/mocha/mutator_test.js
+++ b/packages/blockly/tests/mocha/mutator_test.js
@@ -13,6 +13,7 @@ import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Mutator', function () {
@@ -22,7 +23,10 @@ suite('Mutator', function () {
 
   suite('Firing change event', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       defineMutatorBlocks();
     });
 
@@ -86,7 +90,10 @@ suite('Mutator', function () {
   });
   suite('ARIA', function () {
     setup(async function () {
-      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       const block = createRenderedBlock(this.workspace, 'controls_if');
       this.icon = block.getIcon(Blockly.icons.MutatorIcon.TYPE);
       await this.icon.setBubbleVisible(true);

--- a/packages/blockly/tests/mocha/mutator_test.js
+++ b/packages/blockly/tests/mocha/mutator_test.js
@@ -11,9 +11,9 @@ import {
 } from './test_helpers/block_definitions.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Mutator', function () {
@@ -23,10 +23,7 @@ suite('Mutator', function () {
 
   suite('Firing change event', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       defineMutatorBlocks();
     });
 
@@ -90,10 +87,7 @@ suite('Mutator', function () {
   });
   suite('ARIA', function () {
     setup(async function () {
-      this.workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       const block = createRenderedBlock(this.workspace, 'controls_if');
       this.icon = block.getIcon(Blockly.icons.MutatorIcon.TYPE);
       await this.icon.setBubbleVisible(true);

--- a/packages/blockly/tests/mocha/navigation_test.js
+++ b/packages/blockly/tests/mocha/navigation_test.js
@@ -6,9 +6,9 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -88,10 +88,7 @@ suite('Navigation', function () {
         ],
       },
     ]);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.navigator = this.workspace.getNavigator();
     const statementInput1 = this.workspace.newBlock('input_statement');
     const statementInput2 = this.workspace.newBlock('input_statement');
@@ -707,10 +704,7 @@ suite('Navigation', function () {
       setup(function () {
         const container = document.createElement('div');
         document.body.appendChild(container);
-        this.emptyWorkspace = Blockly.inject(container, {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.emptyWorkspace = Blockly.inject(container, DEFAULT_INJECT_OPTIONS);
       });
       teardown(function () {
         workspaceTeardown.call(this, this.emptyWorkspace);

--- a/packages/blockly/tests/mocha/navigation_test.js
+++ b/packages/blockly/tests/mocha/navigation_test.js
@@ -8,6 +8,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -87,7 +88,10 @@ suite('Navigation', function () {
         ],
       },
     ]);
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.navigator = this.workspace.getNavigator();
     const statementInput1 = this.workspace.newBlock('input_statement');
     const statementInput2 = this.workspace.newBlock('input_statement');
@@ -703,7 +707,10 @@ suite('Navigation', function () {
       setup(function () {
         const container = document.createElement('div');
         document.body.appendChild(container);
-        this.emptyWorkspace = Blockly.inject(container, {});
+        this.emptyWorkspace = Blockly.inject(container, {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
       });
       teardown(function () {
         workspaceTeardown.call(this, this.emptyWorkspace);

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -11,9 +11,9 @@ import {
   defineStackBlock,
 } from './test_helpers/block_definitions.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
@@ -23,8 +23,7 @@ suite('Keyboard Shortcut Items', function () {
     const toolbox = document.getElementById('toolbox-test');
     // Zelos has full-block fields, which we want to exercise in tests.
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox,
       renderer: 'zelos',
     });
@@ -1576,8 +1575,7 @@ suite('Keyboard Shortcut Items', function () {
     test('Shows a toast with RTL navigation hints for navigable blocks', function () {
       const toolbox = document.getElementById('toolbox-test');
       const ws = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         toolbox,
         renderer: 'zelos',
         rtl: true,
@@ -1605,8 +1603,7 @@ suite('Keyboard Shortcut Items', function () {
 
     test('Shows a toast with navigation hints for flyout labels', function () {
       const ws = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
+        ...DEFAULT_INJECT_OPTIONS,
         toolbox: {
           kind: 'flyoutToolbox',
           contents: [

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -13,6 +13,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {createKeyDownEvent} from './test_helpers/user_input.js';
 
@@ -21,7 +22,12 @@ suite('Keyboard Shortcut Items', function () {
     sharedTestSetup.call(this);
     const toolbox = document.getElementById('toolbox-test');
     // Zelos has full-block fields, which we want to exercise in tests.
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox, renderer: 'zelos'});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox,
+      renderer: 'zelos',
+    });
     this.injectionDiv = this.workspace.getInjectionDiv();
     Blockly.ContextMenuRegistry.registry.reset();
     Blockly.ContextMenuItems.registerDefaultOptions();
@@ -1570,6 +1576,8 @@ suite('Keyboard Shortcut Items', function () {
     test('Shows a toast with RTL navigation hints for navigable blocks', function () {
       const toolbox = document.getElementById('toolbox-test');
       const ws = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         toolbox,
         renderer: 'zelos',
         rtl: true,
@@ -1597,6 +1605,8 @@ suite('Keyboard Shortcut Items', function () {
 
     test('Shows a toast with navigation hints for flyout labels', function () {
       const ws = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
         toolbox: {
           kind: 'flyoutToolbox',
           contents: [

--- a/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
+++ b/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
@@ -23,7 +23,6 @@ const TEST_MEDIA_PATH = '../../media/';
  */
 export const DEFAULT_INJECT_OPTIONS = Object.freeze({
   media: TEST_MEDIA_PATH,
-  sounds: false,
 });
 
 /**

--- a/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
+++ b/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
@@ -16,8 +16,8 @@ const TEST_MEDIA_PATH = '../../media/';
 
 /**
  * Default options for Blockly.inject in tests. Media is loaded from the local
- * checkout and sounds are disabled so that tests never fetch assets over the
- * network. Spread this to add or override options, e.g.
+ * instance so that tests never fetch assets over the network. Spread this to
+ * add or override options, e.g.
  *
  *     Blockly.inject('blocklyDiv', {...DEFAULT_INJECT_OPTIONS, rtl: true});
  */

--- a/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
+++ b/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
@@ -8,6 +8,14 @@ import * as eventUtils from '#core/events/utils.js';
 import {FocusManager} from '#core/focus_manager.js';
 
 /**
+ * Path to Blockly's media directory, relative to the test harness page
+ * (tests/mocha/index.html). Tests pass this to Blockly.inject so that media is
+ * loaded from the local checkout rather than fetched from the public CDN.
+ * @type {string}
+ */
+export const TEST_MEDIA_PATH = '../../media/';
+
+/**
  * Safely disposes of Blockly workspace, logging any errors.
  * Assumes that sharedTestSetup has also been called. This should be called
  * using workspaceTeardown.call(this).

--- a/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
+++ b/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
@@ -9,11 +9,22 @@ import {FocusManager} from '#core/focus_manager.js';
 
 /**
  * Path to Blockly's media directory, relative to the test harness page
- * (tests/mocha/index.html). Tests pass this to Blockly.inject so that media is
- * loaded from the local checkout rather than fetched from the public CDN.
+ * (tests/mocha/index.html).
  * @type {string}
  */
-export const TEST_MEDIA_PATH = '../../media/';
+const TEST_MEDIA_PATH = '../../media/';
+
+/**
+ * Default options for Blockly.inject in tests. Media is loaded from the local
+ * checkout and sounds are disabled so that tests never fetch assets over the
+ * network. Spread this to add or override options, e.g.
+ *
+ *     Blockly.inject('blocklyDiv', {...DEFAULT_INJECT_OPTIONS, rtl: true});
+ */
+export const DEFAULT_INJECT_OPTIONS = Object.freeze({
+  media: TEST_MEDIA_PATH,
+  sounds: false,
+});
 
 /**
  * Safely disposes of Blockly workspace, logging any errors.

--- a/packages/blockly/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/packages/blockly/tests/mocha/test_helpers/toolbox_definitions.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {TEST_MEDIA_PATH} from './setup_teardown.js';
+
 /**
  * Get JSON for a toolbox that contains categories.
  * @return {Blockly.utils.toolbox.ToolboxJson} The array holding information
@@ -229,6 +231,8 @@ export function getInjectedToolbox() {
    */
   const toolboxXml = document.getElementById('toolbox-test');
   const workspace = Blockly.inject('blocklyDiv', {
+    media: TEST_MEDIA_PATH,
+    sounds: false,
     toolbox: toolboxXml,
   });
   return workspace.getToolbox();

--- a/packages/blockly/tests/mocha/test_helpers/toolbox_definitions.js
+++ b/packages/blockly/tests/mocha/test_helpers/toolbox_definitions.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {TEST_MEDIA_PATH} from './setup_teardown.js';
+import {DEFAULT_INJECT_OPTIONS} from './setup_teardown.js';
 
 /**
  * Get JSON for a toolbox that contains categories.
@@ -231,8 +231,7 @@ export function getInjectedToolbox() {
    */
   const toolboxXml = document.getElementById('toolbox-test');
   const workspace = Blockly.inject('blocklyDiv', {
-    media: TEST_MEDIA_PATH,
-    sounds: false,
+    ...DEFAULT_INJECT_OPTIONS,
     toolbox: toolboxXml,
   });
   return workspace.getToolbox();

--- a/packages/blockly/tests/mocha/theme_test.js
+++ b/packages/blockly/tests/mocha/theme_test.js
@@ -8,9 +8,9 @@ import {EventType} from '#core/events/type.js';
 import {assert} from 'chai';
 import {assertEventFired} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -128,10 +128,7 @@ suite('Theme', function () {
     try {
       const blockStyles = createBlockStyles();
       const theme = new Blockly.Theme('themeName', blockStyles);
-      workspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
       const blockA = workspace.newBlock('stack_block');
 
       blockA.setStyle = function () {

--- a/packages/blockly/tests/mocha/theme_test.js
+++ b/packages/blockly/tests/mocha/theme_test.js
@@ -10,6 +10,7 @@ import {assertEventFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -127,7 +128,10 @@ suite('Theme', function () {
     try {
       const blockStyles = createBlockStyles();
       const theme = new Blockly.Theme('themeName', blockStyles);
-      workspace = Blockly.inject('blocklyDiv', {});
+      workspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
       const blockA = workspace.newBlock('stack_block');
 
       blockA.setStyle = function () {

--- a/packages/blockly/tests/mocha/toast_test.js
+++ b/packages/blockly/tests/mocha/toast_test.js
@@ -8,12 +8,16 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Toasts', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.liveRegion = document.getElementById('blocklyAriaAnnounce');
     this.toastIsVisible = (message) => {
       const toast = this.workspace

--- a/packages/blockly/tests/mocha/toast_test.js
+++ b/packages/blockly/tests/mocha/toast_test.js
@@ -6,18 +6,15 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Toasts', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.liveRegion = document.getElementById('blocklyAriaAnnounce');
     this.toastIsVisible = (message) => {
       const toast = this.workspace

--- a/packages/blockly/tests/mocha/tooltip_test.js
+++ b/packages/blockly/tests/mocha/tooltip_test.js
@@ -6,9 +6,9 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -38,10 +38,10 @@ suite('Tooltip', function () {
 
   suite('Custom Tooltip', function () {
     setup(function () {
-      this.renderedWorkspace = Blockly.inject('blocklyDiv', {
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      });
+      this.renderedWorkspace = Blockly.inject(
+        'blocklyDiv',
+        DEFAULT_INJECT_OPTIONS,
+      );
     });
 
     teardown(function () {
@@ -149,10 +149,10 @@ suite('Tooltip', function () {
 
     suite('Rendered Blocks', function () {
       setup(function () {
-        this.renderedWorkspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.renderedWorkspace = Blockly.inject(
+          'blocklyDiv',
+          DEFAULT_INJECT_OPTIONS,
+        );
         this.block = this.renderedWorkspace.newBlock('test_block');
         this.block.initSvg();
         this.block.render();
@@ -234,10 +234,10 @@ suite('Tooltip', function () {
 
     suite('Rendered Fields', function () {
       setup(function () {
-        this.renderedWorkspace = Blockly.inject('blocklyDiv', {
-          media: TEST_MEDIA_PATH,
-          sounds: false,
-        });
+        this.renderedWorkspace = Blockly.inject(
+          'blocklyDiv',
+          DEFAULT_INJECT_OPTIONS,
+        );
         this.block = this.renderedWorkspace.newBlock('test_block');
         this.block.initSvg();
         this.block.render();

--- a/packages/blockly/tests/mocha/tooltip_test.js
+++ b/packages/blockly/tests/mocha/tooltip_test.js
@@ -8,6 +8,7 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 
@@ -37,7 +38,10 @@ suite('Tooltip', function () {
 
   suite('Custom Tooltip', function () {
     setup(function () {
-      this.renderedWorkspace = Blockly.inject('blocklyDiv', {});
+      this.renderedWorkspace = Blockly.inject('blocklyDiv', {
+        media: TEST_MEDIA_PATH,
+        sounds: false,
+      });
     });
 
     teardown(function () {
@@ -145,7 +149,10 @@ suite('Tooltip', function () {
 
     suite('Rendered Blocks', function () {
       setup(function () {
-        this.renderedWorkspace = Blockly.inject('blocklyDiv');
+        this.renderedWorkspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         this.block = this.renderedWorkspace.newBlock('test_block');
         this.block.initSvg();
         this.block.render();
@@ -227,7 +234,10 @@ suite('Tooltip', function () {
 
     suite('Rendered Fields', function () {
       setup(function () {
-        this.renderedWorkspace = Blockly.inject('blocklyDiv');
+        this.renderedWorkspace = Blockly.inject('blocklyDiv', {
+          media: TEST_MEDIA_PATH,
+          sounds: false,
+        });
         this.block = this.renderedWorkspace.newBlock('test_block');
         this.block.initSvg();
         this.block.render();

--- a/packages/blockly/tests/mocha/trashcan_test.js
+++ b/packages/blockly/tests/mocha/trashcan_test.js
@@ -16,9 +16,9 @@ import {
 } from './test_helpers/block_definitions.js';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -55,8 +55,7 @@ suite('Trashcan', function () {
     defineStackBlock('stack_block2');
     defineMutatorBlocks();
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       'trashcan': true,
       'maxTrashcanContents': Infinity,
     });

--- a/packages/blockly/tests/mocha/trashcan_test.js
+++ b/packages/blockly/tests/mocha/trashcan_test.js
@@ -18,6 +18,7 @@ import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -54,6 +55,8 @@ suite('Trashcan', function () {
     defineStackBlock('stack_block2');
     defineMutatorBlocks();
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
       'trashcan': true,
       'maxTrashcanContents': Infinity,
     });

--- a/packages/blockly/tests/mocha/widget_div_test.js
+++ b/packages/blockly/tests/mocha/widget_div_test.js
@@ -6,19 +6,16 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('WidgetDiv', function () {
   setup(function () {
     sharedTestSetup.call(this);
     Blockly.common.setParentContainer(document.firstElementChild);
-    this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
     this.setUpBlockWithField = function () {
       const blockJson = {
         'type': 'text',

--- a/packages/blockly/tests/mocha/widget_div_test.js
+++ b/packages/blockly/tests/mocha/widget_div_test.js
@@ -8,13 +8,17 @@ import {assert} from 'chai';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('WidgetDiv', function () {
   setup(function () {
     sharedTestSetup.call(this);
     Blockly.common.setParentContainer(document.firstElementChild);
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
     this.setUpBlockWithField = function () {
       const blockJson = {
         'type': 'text',

--- a/packages/blockly/tests/mocha/workspace_comment_test.js
+++ b/packages/blockly/tests/mocha/workspace_comment_test.js
@@ -10,18 +10,15 @@ import {
   createChangeListenerSpy,
 } from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Workspace comment', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
-    this.workspace = new Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
-    });
+    this.workspace = new Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/workspace_comment_test.js
+++ b/packages/blockly/tests/mocha/workspace_comment_test.js
@@ -12,12 +12,16 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 
 suite('Workspace comment', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
-    this.workspace = new Blockly.inject('blocklyDiv', {});
+    this.workspace = new Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+    });
   });
 
   teardown(function () {

--- a/packages/blockly/tests/mocha/workspace_svg_test.js
+++ b/packages/blockly/tests/mocha/workspace_svg_test.js
@@ -13,9 +13,9 @@ import {
   createChangeListenerSpy,
 } from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
 import {testAWorkspace} from './test_helpers/workspace.js';
@@ -25,8 +25,7 @@ suite('WorkspaceSvg', function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     const toolbox = document.getElementById('toolbox-categories');
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
     });
     Blockly.defineBlocksWithJsonArray([

--- a/packages/blockly/tests/mocha/workspace_svg_test.js
+++ b/packages/blockly/tests/mocha/workspace_svg_test.js
@@ -15,6 +15,7 @@ import {
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {dispatchPointerEvent} from './test_helpers/user_input.js';
 import {testAWorkspace} from './test_helpers/workspace.js';
@@ -23,7 +24,11 @@ suite('WorkspaceSvg', function () {
   setup(function () {
     this.clock = sharedTestSetup.call(this, {fireEventsNow: false}).clock;
     const toolbox = document.getElementById('toolbox-categories');
-    this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      toolbox: toolbox,
+    });
     Blockly.defineBlocksWithJsonArray([
       {
         'type': 'simple_test_block',

--- a/packages/blockly/tests/mocha/xml_test.js
+++ b/packages/blockly/tests/mocha/xml_test.js
@@ -10,6 +10,7 @@ import {
   createGenUidStubWithReturns,
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {assertVariableValues} from './test_helpers/variables.js';
@@ -368,7 +369,11 @@ suite('XML', function () {
       suite('Rendered', function () {
         setup(function () {
           // Let the parent teardown dispose of it.
-          this.workspace = Blockly.inject('blocklyDiv', {comments: true});
+          this.workspace = Blockly.inject('blocklyDiv', {
+            media: TEST_MEDIA_PATH,
+            sounds: false,
+            comments: true,
+          });
           this.block = Blockly.Xml.domToBlock(
             Blockly.utils.xml.textToDom('<block type="empty_block"/>'),
             this.workspace,
@@ -616,7 +621,11 @@ suite('XML', function () {
       });
       suite('Rendered', function () {
         setup(function () {
-          this.workspace = Blockly.inject('blocklyDiv', {comments: true});
+          this.workspace = Blockly.inject('blocklyDiv', {
+            media: TEST_MEDIA_PATH,
+            sounds: false,
+            comments: true,
+          });
         });
         teardown(function () {
           workspaceTeardown.call(this, this.workspace);
@@ -896,6 +905,8 @@ suite('XML', function () {
     setup(function () {
       const options = {
         comments: true,
+        media: TEST_MEDIA_PATH,
+        sounds: false,
       };
       this.renderedWorkspace = Blockly.inject('blocklyDiv', options);
       this.headlessWorkspace = new Blockly.Workspace(

--- a/packages/blockly/tests/mocha/xml_test.js
+++ b/packages/blockly/tests/mocha/xml_test.js
@@ -8,9 +8,9 @@ import {assert} from 'chai';
 import {
   addBlockTypeToCleanup,
   createGenUidStubWithReturns,
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
   workspaceTeardown,
 } from './test_helpers/setup_teardown.js';
 import {assertVariableValues} from './test_helpers/variables.js';
@@ -370,8 +370,7 @@ suite('XML', function () {
         setup(function () {
           // Let the parent teardown dispose of it.
           this.workspace = Blockly.inject('blocklyDiv', {
-            media: TEST_MEDIA_PATH,
-            sounds: false,
+            ...DEFAULT_INJECT_OPTIONS,
             comments: true,
           });
           this.block = Blockly.Xml.domToBlock(
@@ -622,8 +621,7 @@ suite('XML', function () {
       suite('Rendered', function () {
         setup(function () {
           this.workspace = Blockly.inject('blocklyDiv', {
-            media: TEST_MEDIA_PATH,
-            sounds: false,
+            ...DEFAULT_INJECT_OPTIONS,
             comments: true,
           });
         });
@@ -903,11 +901,7 @@ suite('XML', function () {
   });
   suite('workspaceToDom -> domToWorkspace -> workspaceToDom', function () {
     setup(function () {
-      const options = {
-        comments: true,
-        media: TEST_MEDIA_PATH,
-        sounds: false,
-      };
+      const options = {...DEFAULT_INJECT_OPTIONS, comments: true};
       this.renderedWorkspace = Blockly.inject('blocklyDiv', options);
       this.headlessWorkspace = new Blockly.Workspace(
         new Blockly.Options(options),

--- a/packages/blockly/tests/mocha/zoom_controls_test.js
+++ b/packages/blockly/tests/mocha/zoom_controls_test.js
@@ -8,9 +8,9 @@ import {EventType} from '#core/events/type.js';
 import {assert} from 'chai';
 import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
-  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
@@ -18,8 +18,7 @@ suite('Zoom Controls', function () {
   setup(function () {
     sharedTestSetup.call(this);
     this.workspace = Blockly.inject('blocklyDiv', {
-      media: TEST_MEDIA_PATH,
-      sounds: false,
+      ...DEFAULT_INJECT_OPTIONS,
       'zoom': {'controls': true},
     });
     this.zoomControls = this.workspace.zoomControls_;

--- a/packages/blockly/tests/mocha/zoom_controls_test.js
+++ b/packages/blockly/tests/mocha/zoom_controls_test.js
@@ -10,13 +10,18 @@ import {assertEventFired, assertEventNotFired} from './test_helpers/events.js';
 import {
   sharedTestSetup,
   sharedTestTeardown,
+  TEST_MEDIA_PATH,
 } from './test_helpers/setup_teardown.js';
 import {simulateClick} from './test_helpers/user_input.js';
 
 suite('Zoom Controls', function () {
   setup(function () {
     sharedTestSetup.call(this);
-    this.workspace = Blockly.inject('blocklyDiv', {'zoom': {'controls': true}});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: TEST_MEDIA_PATH,
+      sounds: false,
+      'zoom': {'controls': true},
+    });
     this.zoomControls = this.workspace.zoomControls_;
   });
   teardown(function () {

--- a/packages/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/packages/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -44,7 +44,6 @@ suite('Procedures', function () {
 
     this.workspace = Blockly.inject('blocklyDiv', {
       media: 'media/',
-      sounds: false,
     });
 
     this.eventSpy = this.sandbox.spy();

--- a/packages/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/packages/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -42,7 +42,10 @@ suite('Procedures', function () {
 
     registerProcedureSerializer();
 
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: 'media/',
+      sounds: false,
+    });
 
     this.eventSpy = this.sandbox.spy();
     this.workspace.addChangeListener(this.eventSpy);

--- a/packages/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
+++ b/packages/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
@@ -166,7 +166,6 @@ suite('FieldMultilineInput', function () {
       window.cancelAnimationFrame = (id) => clearTimeout(id);
       this.workspace = Blockly.inject('blocklyDiv', {
         media: 'media/',
-        sounds: false,
       });
 
       if (!Blockly.Blocks['multiline_block']) {

--- a/packages/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
+++ b/packages/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
@@ -164,7 +164,10 @@ suite('FieldMultilineInput', function () {
       this.clock = sinon.useFakeTimers();
       window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
       window.cancelAnimationFrame = (id) => clearTimeout(id);
-      this.workspace = Blockly.inject('blocklyDiv');
+      this.workspace = Blockly.inject('blocklyDiv', {
+        media: 'media/',
+        sounds: false,
+      });
 
       if (!Blockly.Blocks['multiline_block']) {
         Blockly.defineBlocksWithJsonArray([

--- a/packages/plugins/modal/test/modal_test.mocha.js
+++ b/packages/plugins/modal/test/modal_test.mocha.js
@@ -22,7 +22,6 @@ suite('Modal', function () {
     );
     this.workspace = Blockly.inject('blocklyDiv', {
       media: 'media/',
-      sounds: false,
     });
     this.modal = new Modal('Title', this.workspace);
   });

--- a/packages/plugins/modal/test/modal_test.mocha.js
+++ b/packages/plugins/modal/test/modal_test.mocha.js
@@ -20,7 +20,10 @@ suite('Modal', function () {
     this.jsdomCleanup = require('jsdom-global')(
       '<!DOCTYPE html><div id="blocklyDiv"></div>',
     );
-    this.workspace = Blockly.inject('blocklyDiv', {});
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: 'media/',
+      sounds: false,
+    });
     this.modal = new Modal('Title', this.workspace);
   });
 

--- a/packages/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
+++ b/packages/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
@@ -41,7 +41,6 @@ suite('shadowBlockConversionChangeListener', function () {
 
     this.workspace = Blockly.inject('blocklyDiv', {
       media: 'media/',
-      sounds: false,
     });
     this.workspace.addChangeListener(shadowBlockConversionChangeListener);
 

--- a/packages/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
+++ b/packages/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
@@ -39,7 +39,10 @@ suite('shadowBlockConversionChangeListener', function () {
     // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528 for context.
     global.SVGElement = window.SVGElement;
 
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: 'media/',
+      sounds: false,
+    });
     this.workspace.addChangeListener(shadowBlockConversionChangeListener);
 
     // Prevent rendering, which does not work correctly in a headless jsdom

--- a/packages/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
+++ b/packages/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
@@ -24,7 +24,7 @@ suite('TypedVariableModal', function () {
    * @returns {Blockly.WorkspaceSvg} The workspace to use for testing.
    */
   function workspaceSetup(toolbox, types) {
-    const options = {};
+    const options = {media: 'media/', sounds: false};
     const createFlyout = function (workspace) {
       let xmlList = [];
       const button = document.createElement('button');

--- a/packages/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
+++ b/packages/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
@@ -24,7 +24,7 @@ suite('TypedVariableModal', function () {
    * @returns {Blockly.WorkspaceSvg} The workspace to use for testing.
    */
   function workspaceSetup(toolbox, types) {
-    const options = {media: 'media/', sounds: false};
+    const options = {media: 'media/'};
     const createFlyout = function (workspace) {
       let xmlList = [];
       const button = document.createElement('button');

--- a/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
+++ b/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
@@ -443,6 +443,8 @@ suite('Keyboard navigation', function () {
     // jsdom does not implement SVGElement natively; expose the shim.
     global.SVGElement = window.SVGElement;
     this.workspace = Blockly.inject('blocklyDiv', {
+      media: 'media/',
+      sounds: false,
       move: {scrollbars: true},
     });
     this.minimap = new Minimap(this.workspace);

--- a/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
+++ b/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
@@ -444,7 +444,6 @@ suite('Keyboard navigation', function () {
     global.SVGElement = window.SVGElement;
     this.workspace = Blockly.inject('blocklyDiv', {
       media: 'media/',
-      sounds: false,
       move: {scrollbars: true},
     });
     this.minimap = new Minimap(this.workspace);

--- a/packages/plugins/workspace-search/test/workspace_search_test.mocha.js
+++ b/packages/plugins/workspace-search/test/workspace_search_test.mocha.js
@@ -68,7 +68,10 @@ suite('WorkspaceSearch', function () {
       '<!DOCTYPE html><div id="blocklyDiv"></div>',
     );
     this.clock = sinon.useFakeTimers();
-    this.workspace = Blockly.inject('blocklyDiv');
+    this.workspace = Blockly.inject('blocklyDiv', {
+      media: 'media/',
+      sounds: false,
+    });
     this.workspaceSearch = new WorkspaceSearch(this.workspace);
     // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528 for context.
     global.SVGElement = window.SVGElement;

--- a/packages/plugins/workspace-search/test/workspace_search_test.mocha.js
+++ b/packages/plugins/workspace-search/test/workspace_search_test.mocha.js
@@ -70,7 +70,6 @@ suite('WorkspaceSearch', function () {
     this.clock = sinon.useFakeTimers();
     this.workspace = Blockly.inject('blocklyDiv', {
       media: 'media/',
-      sounds: false,
     });
     this.workspaceSearch = new WorkspaceSearch(this.workspace);
     // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528 for context.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR specifies a local media path for all Blockly injection sites across the tests. This reduces unnecessary network requests when tests run in a browser, and avoids making actual across-the-internet network requests to the default media URL when running tests. This in turn resolves the test failures in #10223. This change was LLM-generated, and I reviewed it to ensure the changes were correctly made (but a second pair of eyes is still appreciated!).