### PR TITLE
fix: Fix bug that could cause renders to clobber the undo stack

### DIFF
--- a/packages/blockly/core/render_management.ts
+++ b/packages/blockly/core/render_management.ts
@@ -15,8 +15,13 @@ const rootBlocks = new Set<BlockSvg>();
 /** The set of all blocks in need of rendering. */
 const dirtyBlocks = new WeakSet<BlockSvg>();
 
-/** A map from queued blocks to the event group from when they were queued. */
-const eventGroups = new WeakMap<BlockSvg, string>();
+/**
+ * A map from queued blocks to the event context from when they were queued.
+ */
+const eventContexts = new WeakMap<
+  BlockSvg,
+  {group: string; recordUndo: boolean}
+>();
 
 /**
  * The promise which resolves after the current set of renders is completed. Or
@@ -107,7 +112,10 @@ function alwaysImmediatelyRender() {
  */
 function queueBlock(block: BlockSvg) {
   dirtyBlocks.add(block);
-  eventGroups.set(block, eventUtils.getGroup());
+  eventContexts.set(block, {
+    group: eventUtils.getGroup(),
+    recordUndo: eventUtils.getRecordUndo(),
+  });
   const parent = block.getParent();
   if (parent) {
     queueBlock(parent);
@@ -144,12 +152,17 @@ function doRenders(workspace?: WorkspaceSvg) {
   }
   for (const block of blocks) {
     const oldGroup = eventUtils.getGroup();
-    const newGroup = eventGroups.get(block);
-    if (newGroup) eventUtils.setGroup(newGroup);
+    const oldRecordUndo = eventUtils.getRecordUndo();
+    const context = eventContexts.get(block);
+    if (context) {
+      if (context.group) eventUtils.setGroup(context.group);
+      eventUtils.setRecordUndo(context.recordUndo);
+    }
 
     block.bumpNeighbours();
 
     eventUtils.setGroup(oldGroup);
+    eventUtils.setRecordUndo(oldRecordUndo);
   }
 
   for (const block of blocks) {
@@ -162,7 +175,7 @@ function doRenders(workspace?: WorkspaceSvg) {
 function dequeueBlock(block: BlockSvg) {
   rootBlocks.delete(block);
   dirtyBlocks.delete(block);
-  eventGroups.delete(block);
+  eventContexts.delete(block);
   for (const child of block.getChildren(false)) {
     dequeueBlock(child);
   }

--- a/packages/blockly/tests/mocha/render_management_test.js
+++ b/packages/blockly/tests/mocha/render_management_test.js
@@ -126,4 +126,75 @@ suite('Render Management', function () {
       assert.isFalse(block2.hasRendered, 'Expected block2 to not be rendered');
     });
   });
+
+  suite('Post-render bumpNeighbours', function () {
+    setup(function () {
+      this.workspace = Blockly.inject('blocklyDiv', {});
+
+      // Create and init two identical overlapping blocks so that the first
+      // render will need to bump one.
+      this.block = this.workspace.newBlock('controls_if');
+      this.block.initSvg();
+
+      const block2 = this.workspace.newBlock('controls_if');
+      block2.initSvg();
+    });
+
+    test('does not record undo event when the render was queued with recordUndo disabled', function () {
+      Blockly.Events.setRecordUndo(false);
+      Blockly.renderManagement.queueRender(this.block);
+      Blockly.Events.setRecordUndo(true);
+
+      Blockly.renderManagement.triggerQueuedRenders();
+
+      assert.isFalse(
+        this.workspace.getUndoStack().some((item) => {
+          return (
+            item.type === 'move' &&
+            item.reason[0] === 'bump' &&
+            item.blockId === this.block.id
+          );
+        }),
+      );
+    });
+
+    test('records undo event when the render was queued with recordUndo enabled', function () {
+      Blockly.Events.setRecordUndo(true);
+      Blockly.renderManagement.queueRender(this.block);
+      Blockly.Events.setRecordUndo(false);
+
+      Blockly.renderManagement.triggerQueuedRenders();
+
+      assert.isTrue(
+        this.workspace.getUndoStack().some((item) => {
+          return (
+            item.type === 'move' &&
+            item.reason[0] === 'bump' &&
+            item.blockId === this.block.id
+          );
+        }),
+      );
+    });
+
+    test('associates bump undo events with the event group from when the render was queued', function () {
+      Blockly.Events.setRecordUndo(true);
+      Blockly.Events.setGroup('test-group');
+      Blockly.renderManagement.queueRender(this.block);
+      Blockly.Events.setGroup(false);
+      Blockly.Events.setRecordUndo(false);
+
+      Blockly.renderManagement.triggerQueuedRenders();
+
+      assert.isTrue(
+        this.workspace.getUndoStack().some((item) => {
+          return (
+            item.type === 'move' &&
+            item.reason[0] === 'bump' &&
+            item.blockId === this.block.id &&
+            item.group === 'test-group'
+          );
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8129

### Proposed Changes
This PR fixes a bug that could result in the undo/redo stack state becoming invalid when an undo or redo triggered operations that (a) fired events and (b) performed a non-immediate render.

In the particular scenario described in the bug, undoing the collapse disabled recording undo events, called `setCollapsed(false)` on the various blocks, which as a side effect queued a render of each of them, and then re-enabled recording undo events once the undo was done. However, because the renders were queued but not immediately executed, the render happened after the undo infrastructure had re-enabled recording undo events. The render then called `bumpNeighbours()` on each rendered block, which fired move events, and since undo recording was enabled at that point, `Workspace.fireChangeListener()` cleared the redo stack. Thus, redoing the collapse became impossible.

The render infrastructure already had handling for this problem with regard to event grouping – when a render is queued, the current event group is recorded, and the same group is set when the block in question bumps its neighbours. The fix was just to extend this to enabling/disabling recording undo events, so that if a render of a block is queued while recording undo events is disabled, the post-render bump of that block's neighbours will not record undo events, even if recording undo events has been turned back on after the render was queued.

This change was LLM-assisted. I heavily modified the generated tests, and reviewed the actual implementation and believe that the root cause and the fix make sense.