### PR TITLE
chore: check that translatewiki only touches allowed files

### DIFF
--- a/.github/workflows/translatewiki.yml
+++ b/.github/workflows/translatewiki.yml
@@ -14,9 +14,12 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
+      - synchronize
 
 jobs:
-  translatewiki:
+  retitle-translatewiki-prs:
+    name: Retitle translatewiki PRs
     runs-on: ubuntu-latest
     # Only run for the translatewiki bot's PRs, matching on both the author and
     # the source branch.
@@ -61,3 +64,43 @@ jobs:
               issue_number,
               labels: ['PR: chore'],
             });
+
+  validate-files:
+    runs-on: ubuntu-latest
+    # Only run for the translatewiki bot's PRs, matching on both the author and
+    # the source branch.
+    if: ${{ github.event.pull_request.user.login == 'translatewiki' && github.event.pull_request.head.ref == 'translatewiki' }}
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Ensure translatewiki PR only touches msg/
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const {number: pull_number} = context.payload.pull_request;
+
+            // translatewiki localisation PRs must only modify message files.
+            const allowedPrefix = 'packages/blockly/msg/';
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const offending = files
+              .map((file) => file.filename)
+              .filter((filename) => !filename.startsWith(allowedPrefix));
+
+            if (offending.length > 0) {
+              core.setFailed(
+                `translatewiki PR #${pull_number} touches files outside ` +
+                  `${allowedPrefix}:\n${offending.map((f) => `  - ${f}`).join('\n')}`,
+              );
+            } else {
+              core.info(
+                `translatewiki PR #${pull_number} only touches ${allowedPrefix} ` +
+                  `(${files.length} file(s) checked).`,
+              );
+            }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes n/a

### Proposed Changes

Adds a workflow that fails if translatewiki ever tries to modify files outside msg/

### Reason for Changes

hardening against malicious translatewiki?

### Test Coverage

yolo

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

This change was generated by claude and reviewed by me, a human
