### PR TITLE
fix: Improve performance of `WorkspaceSvg.getNestedTrees()`

### DIFF
--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -39,7 +39,6 @@ import {getFocusManager} from './focus_manager.js';
 import {Gesture} from './gesture.js';
 import {Grid} from './grid.js';
 import * as hints from './hints.js';
-import {MutatorIcon} from './icons/mutator_icon.js';
 import {isAutoHideable} from './interfaces/i_autohideable.js';
 import type {IBoundedElement} from './interfaces/i_bounded_element.js';
 import type {IComponent} from './interfaces/i_component.js';
@@ -2876,15 +2875,11 @@ export class WorkspaceSvg
 
   /** See IFocusableTree.getNestedTrees. */
   getNestedTrees(): Array<IFocusableTree> {
-    const nestedWorkspaces = this.getAllBlocks()
-      .map((block) => block.getIcons())
-      .flat()
+    const nestedWorkspaces = common
+      .getAllWorkspaces()
       .filter(
-        (icon): icon is MutatorIcon =>
-          icon instanceof MutatorIcon && icon.bubbleIsVisible(),
-      )
-      .map((icon) => icon.getBubble()?.getWorkspace())
-      .filter((workspace) => !!workspace);
+        (w) => w.isMutator && w.options.parentWorkspace === this,
+      ) as WorkspaceSvg[];
 
     const ownFlyout = this.getFlyout(true);
     if (ownFlyout) {

--- a/packages/blockly/tests/mocha/workspace_svg_test.js
+++ b/packages/blockly/tests/mocha/workspace_svg_test.js
@@ -149,7 +149,7 @@ suite('WorkspaceSvg', function () {
     );
   });
 
-  suite('getRestoredFocusableNode', function () {
+  suite('Focus Management', function () {
     test('restores focus to the workspace focus target for a non-mutator non-flyout workspace', function () {
       Blockly.getFocusManager().focusTree(this.workspace);
       assert.strictEqual(
@@ -176,6 +176,30 @@ suite('WorkspaceSvg', function () {
         Blockly.getFocusManager().getFocusedNode(),
         firstBlock,
       );
+    });
+
+    test('includes mutators in nested trees', async function () {
+      const block = this.workspace.newBlock('controls_if');
+      block.initSvg();
+      block.render();
+      const icon = block.getIcon(Blockly.icons.MutatorIcon.TYPE);
+      await icon.setBubbleVisible(true);
+      const mutatorWorkspace = icon.getWorkspace();
+
+      const nestedTrees = this.workspace.getNestedTrees();
+      assert.sameMembers(nestedTrees, [mutatorWorkspace]);
+    });
+
+    test('includes flyouts in nested trees', async function () {
+      this.workspace.dispose();
+      const toolbox = document.getElementById('toolbox-simple');
+      this.workspace = Blockly.inject('blocklyDiv', {toolbox: toolbox});
+
+      const nestedTrees = this.workspace.getNestedTrees();
+      assert.isNotNull(this.workspace.getFlyout());
+      assert.sameMembers(nestedTrees, [
+        this.workspace.getFlyout().getWorkspace(),
+      ]);
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of #9162

### Proposed Changes
This PR updates `getNestedTrees()` to loop through workspaces and check if they are children, rather than looping through all blocks, looking for mutator icons, and checking if they have a visible bubble. This is less fragile, more readable, and more performant, especially for large workspaces.


### Test Coverage
I added some tests for this method as there were none previously.