### PR TITLE
chore: Prune duplicate and dead code from `BlockSvg`

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -301,7 +301,6 @@ export class BlockSvg
       return;
     }
 
-    const oldXY = this.getRelativeToSurfaceXY();
     const focusedNode = getFocusManager().getFocusedNode();
     const restoreFocus = this.getSvgRoot().contains(
       focusedNode?.getFocusableElement() ?? null,
@@ -316,30 +315,17 @@ export class BlockSvg
         getFocusManager().focusNode(focusedNode);
       }
     } else if (oldParent) {
-      // If we are losing a parent, we want to move our DOM element to the
-      // root of the workspace.  Try to insert it before any top-level
-      // block being dragged, but note that blocks can have the
-      // blocklyDragging class even if they're not top blocks (especially
-      // at start and end of a drag).
-      const draggingBlockElement = this.workspace
-        .getCanvas()
-        .querySelector('.blocklyDragging');
-      const draggingParentElement = draggingBlockElement?.parentElement as
-        SVGElement | null | undefined;
-      const canvas = this.workspace.getCanvas();
-      if (draggingParentElement === canvas) {
-        canvas.insertBefore(svgRoot, draggingBlockElement);
-      } else {
-        canvas.appendChild(svgRoot);
-        // appendChild() clears focus state, so re-focus the previously focused
-        // node in case it was this block and would otherwise lose its focus. Once
-        // Element.moveBefore() has better browser support, it should be used
-        // instead.
-        if (restoreFocus && focusedNode) {
-          getFocusManager().focusNode(focusedNode);
-        }
-      }
+      const oldXY = this.getRelativeToSurfaceXY();
+      this.workspace.getCanvas().appendChild(svgRoot);
       this.translate(oldXY.x, oldXY.y);
+    }
+
+    // appendChild() clears focus state, so re-focus the previously focused
+    // node in case it was this block and would otherwise lose its focus. Once
+    // Element.moveBefore() has better browser support, it should be used
+    // instead.
+    if (restoreFocus && focusedNode) {
+      getFocusManager().focusNode(focusedNode);
     }
 
     this.applyColour();
@@ -421,7 +407,6 @@ export class BlockSvg
    */
   moveDuringDrag(newLoc: Coordinate) {
     this.translate(newLoc.x, newLoc.y);
-    this.getSvgRoot().setAttribute('transform', this.getTranslation());
     this.updateComponentLocations(newLoc);
   }
 

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -1227,10 +1227,7 @@ suite('Blocks', function () {
           this.textBlock.setParent.bind(this.textBlock, null),
         );
         assertNonParentAndOrphan(this.textJoinBlock, this.textBlock, 'ADD0');
-        assert.equal(
-          this.textBlock.getSvgRoot().nextSibling,
-          this.extraTopBlock.getSvgRoot(),
-        );
+        assert.equal(this.textBlock.getSvgRoot().nextSibling, null);
       });
       test('Setting parent to null with non-top dragging block', function () {
         this.extraNestedBlock.setDragging(true);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR cleans up some dead and redundant code in `BlockSvg`. `moveDuringDrag` was setting a transform, but the `translate` method it invoked already does that.

The `setParent` change is slightly more involved; the removed code has been dead since the drag layer was introduced, because anything being dragged lives on the drag layer, which is not a child of the block canvas. Thus, the `querySelector()` call would never find anything, so the if case could never happen. This caused a test to fail that was not actually exercising dragging, just calling `setDragging(true)` on a block, but not actually reparenting it to the drag layer as happens in reality, which in turn meant the test did go down the otherwise-unreachable codepath.
