### PR TITLE
chore: updated homepage/repo links for npm

### DIFF
--- a/packages/plugins/field-colour/package.json
+++ b/packages/plugins/field-colour/package.json
@@ -21,7 +21,7 @@
     "field",
     "colour"
   ],
-  "homepage": "packages/plugins/field-colour/package.jsonfield-colour#readme",
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly/tree/main/packages/plugins/field-colour#readme",
   "bugs": {
     "url": "https://github.com/RaspberryPiFoundation/blockly/issues"
   },

--- a/packages/plugins/sample-app-ts/package.json
+++ b/packages/plugins/sample-app-ts/package.json
@@ -12,6 +12,15 @@
   "keywords": [
     "blockly"
   ],
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly/tree/main/packages/plugins/sample-app-ts#readme",
+  "bugs": {
+    "url": "https://github.com/RaspberryPiFoundation/blockly/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly.git",
+    "directory": "packages/plugins/block-sample-app-ts"
+  },
   "author": "Blockly team",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/plugins/sample-app-ts/package.json
+++ b/packages/plugins/sample-app-ts/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/RaspberryPiFoundation/blockly.git",
-    "directory": "packages/plugins/block-sample-app-ts"
+    "directory": "packages/plugins/sample-app-ts"
   },
   "author": "Blockly team",
   "license": "Apache-2.0",

--- a/packages/plugins/sample-app/package.json
+++ b/packages/plugins/sample-app/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/RaspberryPiFoundation/blockly.git",
-    "directory": "packages/plugins/block-sample-app"
+    "directory": "packages/plugins/sample-app"
   },
   "author": "Blockly team",
   "license": "Apache-2.0",

--- a/packages/plugins/sample-app/package.json
+++ b/packages/plugins/sample-app/package.json
@@ -12,6 +12,15 @@
   "keywords": [
     "blockly"
   ],
+  "homepage": "https://github.com/RaspberryPiFoundation/blockly/tree/main/packages/plugins/sample-app#readme",
+  "bugs": {
+    "url": "https://github.com/RaspberryPiFoundation/blockly/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RaspberryPiFoundation/blockly.git",
+    "directory": "packages/plugins/block-sample-app"
+  },
   "author": "Blockly team",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes N/A 

### Proposed Changes

Update the links in a couple of package.json files that were missed or had copy/paste errors in the first pass.

### Reason for Changes

This sets us up for publishing the plugins on NPM from the core repo.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

