### PR TITLE
test: Avoid flakes by explicitly aligning blocks

### DIFF
--- a/packages/blockly/tests/mocha/render_management_test.js
+++ b/packages/blockly/tests/mocha/render_management_test.js
@@ -131,13 +131,20 @@ suite('Render Management', function () {
     setup(function () {
       this.workspace = Blockly.inject('blocklyDiv', {});
 
-      // Create and init two identical overlapping blocks so that the first
-      // render will need to bump one.
       this.block = this.workspace.newBlock('controls_if');
       this.block.initSvg();
 
       const block2 = this.workspace.newBlock('controls_if');
       block2.initSvg();
+      Blockly.renderManagement.triggerQueuedRenders();
+
+      // Align the blocks' next and previous connections without connecting them
+      // so that they'll need to bump one another.
+      this.block.moveBy(
+        block2.nextConnection.x - this.block.previousConnection.x,
+        block2.nextConnection.y - this.block.previousConnection.y,
+        ['test'],
+      );
     });
 
     test('does not record undo event when the render was queued with recordUndo disabled', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR fixes flakes in recently-added tests that were implicitly depending on timing/rendering to align blocks. Now, the blocks are explicitly aligned as needed for the tests in setup.