### PR TITLE
chore: Don't copy node_modules into GitHub pages deployment

### DIFF
--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -48,7 +48,7 @@
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"gulp interactiveMocha\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "updateGithubPages": "npm ci && cp -R ../../node_modules/@blockly node_modules/ && gulp updateGithubPages --upstream",
+    "updateGithubPages": "gulp updateGithubPages --upstream",
     "updateGithubPages:staging": "npm ci && gulp updateGithubPages --use-local"
   },
   "exports": {

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -48,7 +48,7 @@
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && concurrently -n tsc,server \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"gulp interactiveMocha\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "updateGithubPages": "gulp updateGithubPages --upstream",
+    "updateGithubPages": "npm ci && gulp updateGithubPages --upstream",
     "updateGithubPages:staging": "npm ci && gulp updateGithubPages --use-local"
   },
   "exports": {

--- a/packages/blockly/scripts/gulpfiles/git_tasks.mjs
+++ b/packages/blockly/scripts/gulpfiles/git_tasks.mjs
@@ -43,7 +43,6 @@ const remoteToUse = argv.upstream ? UPSTREAM_URL : resolveRemote(argv.remote);
 const EXTRAS = [
   'build/msg',
   'dist/*_compressed.js*',
-  'node_modules/@blockly',
   'build/*.loader.mjs',
 ];
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes deployment of the GitHub pages once again. Post-#10207, the playground no longer depends on any other node_modules, and post-monorepo the assumptions we were making about copying them no longer held, leading to dead symlinks that confused the GitHub pages deployer.
