### PR TITLE
test: Adjust timeouts on browser tests

### DIFF
--- a/packages/blockly/tests/browser/test/dragger_test.mjs
+++ b/packages/blockly/tests/browser/test/dragger_test.mjs
@@ -8,6 +8,8 @@ import * as chai from 'chai';
 import {testFileLocations, testSetup} from './test_setup.mjs';
 
 suite('Dragging into a delete area', function () {
+  this.timeout(0);
+
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.PLAYGROUND);
 

--- a/packages/blockly/tests/browser/test/dropdowndiv_test.mjs
+++ b/packages/blockly/tests/browser/test/dropdowndiv_test.mjs
@@ -8,6 +8,8 @@ import * as chai from 'chai';
 import {testFileLocations, testSetup} from './test_setup.mjs';
 
 suite('DropDownDiv', function () {
+  this.timeout(0);
+
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.PLAYGROUND);
   });

--- a/packages/blockly/tests/browser/test/focus_manager_test.mjs
+++ b/packages/blockly/tests/browser/test/focus_manager_test.mjs
@@ -55,6 +55,8 @@ async function installFocusTestHelpers(browser, fixtureHtml) {
 }
 
 suite('FocusManager', function () {
+  this.timeout(0);
+
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.PLAYGROUND);
     await installFocusTestHelpers(this.browser, FIXTURE_HTML);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR adds the same `this.timeout(0)` to the new browser tests that were split off in #10208 that is present in all of the other browser tests, to hopefully fix them under CI. They did and continue to pass locally.