### PR TITLE
chore: scope toolbox click test to the toolbox under test

### DIFF
--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -257,14 +257,12 @@ suite('Toolbox', function () {
       sinon.assert.calledOnce(hideChaffStub);
     });
     test('Category clicked -> Should select category', function () {
-      const categoryXml = document.getElementsByClassName(
-        'blocklyToolboxCategory',
-      )[0];
+      const categoryXml = item.getClickTarget();
       const evt = {
         'target': categoryXml,
         'stopPropagation': () => {},
       };
-      const item = this.toolbox.contents.get(categoryXml.getAttribute('id'));
+      const item = this.toolbox.getToolboxItems()[0];
       const setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');
       const onClickSpy = sinon.spy(item, 'onClick');
       this.toolbox.onClick_(evt);

--- a/packages/blockly/tests/mocha/toolbox_test.js
+++ b/packages/blockly/tests/mocha/toolbox_test.js
@@ -257,12 +257,12 @@ suite('Toolbox', function () {
       sinon.assert.calledOnce(hideChaffStub);
     });
     test('Category clicked -> Should select category', function () {
+      const item = this.toolbox.getToolboxItems()[0];
       const categoryXml = item.getClickTarget();
       const evt = {
         'target': categoryXml,
         'stopPropagation': () => {},
       };
-      const item = this.toolbox.getToolboxItems()[0];
       const setSelectedSpy = sinon.spy(this.toolbox, 'setSelectedItem');
       const onClickSpy = sinon.spy(item, 'onClick');
       this.toolbox.onClick_(evt);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Test Changes

- Update `Category clicked -> Should select category` to use `this.toolbox.getToolboxItems()[0]` / `getClickTarget()` instead of a document-wide `.blocklyToolboxCategory` query.
- Avoids potential failures when earlier tests leave toolbox category nodes in the document
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

A document-wide lookup for `.blocklyToolboxCategory` can grab leftover nodes from earlier tests that focused a toolbox, leaving item undefined. This can be seen at https://github.com/RaspberryPiFoundation/blockly/pull/10215 with this failure: https://github.com/RaspberryPiFoundation/blockly/actions/runs/30694878852/job/93505795630?pr=10215

This change unblocks the PR linked above.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
