### PR TITLE
chore: excluded more steps on dry run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,7 @@ jobs:
           fi
 
       - name: Build core package
+        if: ${{ !inputs.dry_run }}
         working-directory: packages/blockly
         run: npm run package
 
@@ -119,6 +120,7 @@ jobs:
           fi
 
       - name: Create tarball
+        if: ${{ !inputs.dry_run }}
         working-directory: packages/blockly
         run: npm pack ./dist
         


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Makes it so dry run will stop once version bump is determined and printed out

