### PR TITLE
chore: Fix minimap mirror test

### DIFF
--- a/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
+++ b/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
@@ -444,6 +444,7 @@ suite('Mirroring events', function () {
     window.HTMLCanvasElement.prototype.getContext = () => ({
       measureText: () => ({width: ''}),
     });
+    this.clock = sinon.useFakeTimers();
     window.requestAnimationFrame = (callback) => setTimeout(callback, 0);
     window.cancelAnimationFrame = (id) => clearTimeout(id);
     this.workspace = Blockly.inject('blocklyDiv', {
@@ -456,6 +457,8 @@ suite('Mirroring events', function () {
   teardown(function () {
     this.minimap.dispose();
     this.workspace.dispose();
+    this.clock.runAll();
+    sinon.restore();
     this.jsdomCleanup();
   });
 
@@ -463,10 +466,9 @@ suite('Mirroring events', function () {
     const variable = this.workspace.getVariableMap().createVariable('a');
     const block = this.workspace.newBlock('variables_set');
     block.getField('VAR').setValue(variable.getId());
-    await new Promise((resolve) => setTimeout(resolve, 0));
 
     this.workspace.getVariableMap().renameVariable(variable, 'b');
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    this.clock.tick(1);
 
     const minimapBlock = this.minimap.minimapWorkspace.getBlockById(block.id);
     assert.equal(

--- a/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
+++ b/packages/plugins/workspace-minimap/test/minimap_tests.mocha.js
@@ -462,7 +462,7 @@ suite('Mirroring events', function () {
     this.jsdomCleanup();
   });
 
-  test('Renaming a variable updates the minimap', async function () {
+  test('Renaming a variable updates the minimap', function () {
     const variable = this.workspace.getVariableMap().createVariable('a');
     const block = this.workspace.newBlock('variables_set');
     block.getField('VAR').setValue(variable.getId());


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes flaky tests

### Proposed Changes

- Removed calls to set timeout
- Added sinon fake timer handling to setup/teardown

### Reason for Changes

Timeouts were causing test flakiness