### PR TITLE
fix: restore focus on toast dismiss

### DIFF
--- a/packages/blockly/core/focus_manager.ts
+++ b/packages/blockly/core/focus_manager.ts
@@ -303,6 +303,14 @@ export class FocusManager {
   }
 
   /**
+   * Returns the IFocusableNode that held focus immediately before the current
+   * focused node, or null if there is no such node.
+   */
+  getPreviouslyFocusedNode(): IFocusableNode | null {
+    return this.previouslyFocusedNode;
+  }
+
+  /**
    * Focuses the specific IFocusableTree. This either means restoring active
    * focus to the tree's passively focused node, or focusing the tree's root
    * node.

--- a/packages/blockly/core/toast.ts
+++ b/packages/blockly/core/toast.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Css from './css.js';
+import {getFocusManager} from './focus_manager.js';
 import {Msg} from './msg.js';
 import * as aria from './utils/aria.js';
 import * as dom from './utils/dom.js';
@@ -139,8 +140,17 @@ export class Toast {
       closeIcon,
     );
     closeButton.addEventListener('click', () => {
+      const focusManager = getFocusManager();
+      const nodeToRestore = focusManager.getPreviouslyFocusedNode();
       toast.remove();
-      workspace.markFocused();
+      if (nodeToRestore?.canBeFocused()) {
+        focusManager.focusNode(nodeToRestore);
+      } else {
+        // No prior focus (e.g. a toast closed with the mouse before any
+        // Blockly node was focused). Park focus back on the workspace
+        // via FocusManager instead of dropping it on the document body.
+        focusManager.focusTree(workspace);
+      }
     });
 
     let timeout: ReturnType<typeof setTimeout>;

--- a/packages/blockly/tests/mocha/focus_manager_test.js
+++ b/packages/blockly/tests/mocha/focus_manager_test.js
@@ -418,6 +418,25 @@ suite('FocusManager', function () {
     });
   });
 
+  suite('getPreviouslyFocusedNode()', function () {
+    test('by default returns null', function () {
+      assert.isNull(this.focusManager.getPreviouslyFocusedNode());
+    });
+
+    test('after losing focus to untracked element returns prior node', function () {
+      this.focusManager.registerTree(this.testFocusableTree1);
+      this.focusManager.focusNode(this.testFocusableTree1Node1);
+
+      document.body.focus();
+
+      assert.isNull(this.focusManager.getFocusedNode());
+      assert.strictEqual(
+        this.focusManager.getPreviouslyFocusedNode(),
+        this.testFocusableTree1Node1,
+      );
+    });
+  });
+
   suite('focusTree()', function () {
     test('for not registered tree throws', function () {
       const errorMsgRegex = /Attempted to focus unregistered tree.+?/;

--- a/packages/blockly/tests/mocha/toast_test.js
+++ b/packages/blockly/tests/mocha/toast_test.js
@@ -139,4 +139,37 @@ suite('Toasts', function () {
     assert.isNull(toast.getAttribute('aria-live'));
     assert.notEqual(toast.getAttribute('role'), Blockly.utils.aria.Role.STATUS);
   });
+
+  suite('dismiss focus', function () {
+    function closeToast(workspace) {
+      const closeButton = workspace
+        .getInjectionDiv()
+        .querySelector('.blocklyToastCloseButton');
+      closeButton.focus();
+      closeButton.click();
+    }
+
+    test('restores previously focused node on click', function () {
+      const block = this.workspace.newBlock('text_print');
+      block.initSvg();
+      block.render();
+      Blockly.getFocusManager().focusNode(block);
+      Blockly.Toast.show(this.workspace, {message: 'texas toast'});
+
+      closeToast(this.workspace);
+      assert.isFalse(this.toastIsVisible('texas toast'));
+      assert.strictEqual(Blockly.getFocusManager().getFocusedNode(), block);
+    });
+
+    test('falls back to workspace focus when nothing was previously focused', function () {
+      Blockly.Toast.show(this.workspace, {message: 'texas toast'});
+
+      closeToast(this.workspace);
+      assert.isFalse(this.toastIsVisible('texas toast'));
+      assert.strictEqual(
+        Blockly.getFocusManager().getFocusedNode(),
+        this.workspace.getWorkspaceFocusTarget(),
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/8912
### Proposed Changes

When a toast is dismissed via the close button, focus is restored to the node that was focused before the close button took focus, instead of always calling `workspace.markFocused()`.


https://github.com/user-attachments/assets/c1a7d09f-3498-4a77-baaa-5eaffe04db10



To do this, a new `FocusManager.getPreviouslyFocusedNode()` method was created. We fall back to `focusTree(workspace)` if there is no focsuable previous node, so focus is parked on the workspace through `FocusManager`.

### Reason for Changes

Previously, manually dismissing a toast always focused the workspace SVG. If the user had a block or other node focused, that context was lost. 

### Test Coverage

- `focus_manager_test.js`: `getPreviouslyFocusedNode()` gets a basic unit test
- `toast_test.js` new suite:
  - Restores a previously focused block after closing the toast.
  - Falls back to the workspace focus target when nothing was previously focused.
