### PR TITLE
fix: Clamp transforms to sensible levels of precision

### DIFF
--- a/packages/blockly/core/utils/dom.ts
+++ b/packages/blockly/core/utils/dom.ts
@@ -308,7 +308,7 @@ export function getFastTextWidthWithSizeString(
   if (text && canvasContext) {
     // Set the desired font size and family.
     canvasContext.font = fontWeight + ' ' + fontSize + ' ' + fontFamily;
-    width = canvasContext.measureText(text).width;
+    width = Math.ceil(canvasContext.measureText(text).width);
   } else {
     width = 0;
   }

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -1931,8 +1931,8 @@ export class WorkspaceSvg
     // The scrollX and scrollY still need to have absoluteLeft and absoluteTop
     // subtracted from them, but we'll leave that for setScale so that they're
     // correctly updated for the new flyout size if we have a simple toolbox.
-    this.scrollX = matrix.e;
-    this.scrollY = matrix.f;
+    this.scrollX = Math.round(matrix.e);
+    this.scrollY = Math.round(matrix.f);
     this.setScale(newScale);
   }
 
@@ -2118,6 +2118,7 @@ export class WorkspaceSvg
    * @param newScale Zoom factor. Units: (pixels / workspaceUnit).
    */
   setScale(newScale: number) {
+    newScale = Math.round(newScale * 1000) / 1000;
     if (
       this.options.zoomOptions.maxScale &&
       newScale > this.options.zoomOptions.maxScale
@@ -2255,8 +2256,8 @@ export class WorkspaceSvg
       metrics.scrollHeight - metrics.viewHeight,
     );
     const maxYScroll = metrics.scrollTop + maxYDisplacement;
-    x = Math.max(x, -maxXScroll);
-    y = Math.max(y, -maxYScroll);
+    x = Math.round(Math.max(x, -maxXScroll));
+    y = Math.round(Math.max(y, -maxYScroll));
     this.scrollX = x;
     this.scrollY = y;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR clamps text width and workspace translation to integer values, and workspace scale to 3 decimals. Previously these were unbounded, typically leading to 14 digits of decimal precision, which is obviously unnecessary, and more computationally intensive.

### Test Coverage
All tests pass, and I visually inspected the blocks and zooming.