### PR TITLE
feat: Relax access restrictions on `BlockDragStrategy`

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -64,7 +64,7 @@ enum MoveMode {
 }
 
 export class BlockDragStrategy implements IDragStrategy {
-  private workspace: WorkspaceSvg;
+  protected workspace: WorkspaceSvg;
 
   /** The parent block at the start of the drag. */
   private startParentConn: RenderedConnection | null = null;
@@ -75,11 +75,11 @@ export class BlockDragStrategy implements IDragStrategy {
    */
   private startChildConn: RenderedConnection | null = null;
 
-  private startLoc: Coordinate | null = null;
+  protected startLoc: Coordinate | null = null;
 
   private connectionCandidate: ConnectionCandidate | null = null;
 
-  private connectionPreviewer: IConnectionPreviewer | null = null;
+  protected connectionPreviewer: IConnectionPreviewer | null = null;
 
   private dragging = false;
 
@@ -87,7 +87,7 @@ export class BlockDragStrategy implements IDragStrategy {
   private allConnectionPairs: ConnectionPair[] = [];
 
   /** The current movement mode. */
-  private moveMode = MoveMode.UNCONSTRAINED;
+  protected moveMode = MoveMode.UNCONSTRAINED;
 
   /** Used to persist an event group when snapping is done async. */
   private originalEventGroup = '';
@@ -105,7 +105,7 @@ export class BlockDragStrategy implements IDragStrategy {
    */
   protected readonly WORKSPACE_MARGIN = 10;
 
-  constructor(private block: BlockSvg) {
+  constructor(protected block: BlockSvg) {
     this.workspace = block.workspace;
   }
 
@@ -127,7 +127,7 @@ export class BlockDragStrategy implements IDragStrategy {
    * @param oldBlock The flyout block that was cloned.
    * @param newBlock The new block to position.
    */
-  private positionNewBlock(oldBlock: BlockSvg, newBlock: BlockSvg) {
+  protected positionNewBlock(oldBlock: BlockSvg, newBlock: BlockSvg) {
     const screenCoordinate = svgMath.wsToScreenCoordinates(
       oldBlock.workspace,
       oldBlock.getRelativeToSurfaceXY(),
@@ -469,7 +469,7 @@ export class BlockDragStrategy implements IDragStrategy {
    * @param healStack Whether or not to heal the stack after disconnecting.
    * @returns True to disconnect the block, false otherwise.
    */
-  private shouldDisconnect(healStack: boolean): boolean {
+  protected shouldDisconnect(healStack: boolean): boolean {
     return !!(
       this.block.getParent() ||
       (healStack &&


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR switches a number of fields and methods in `BlockDragStrategy` from `private` to `protected`.

### Reason for Changes
`BlockDragStrategy` can reasonably be expected to be subclassed, and the existing access restrictions made this challenging. The members that have been changed are those that I'm reasonably confident are stable, would likely be needed by subclasses, and have not-hideous APIs. These changes would ease or enable implementation of several drag strategies in Scratch, for e.g. duplicating blocks on drag, using a parent block as a drag target instead of the clicked block, and always using a new ID when dragging blocks out of the flyout to the main workspace.