### PR TITLE
fix: add comma to block labels except on Apple devices

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -67,6 +67,7 @@ import {Rect} from './utils/rect.js';
 import {Svg} from './utils/svg.js';
 import * as svgMath from './utils/svg_math.js';
 import {FlyoutItemInfo} from './utils/toolbox.js';
+import * as userAgent from './utils/useragent.js';
 import type {Workspace} from './workspace.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
 
@@ -2020,11 +2021,13 @@ export class BlockSvg
       fullBlockField.recomputeAriaContext();
       return;
     }
-    aria.setState(
-      this.getFocusableElement(),
-      aria.State.LABEL,
-      this.getAriaLabel(aria.Verbosity.STANDARD),
-    );
+    let label = this.getAriaLabel(aria.Verbosity.STANDARD);
+    // VoiceOver inserts a comma between aria-label and aria-roledescription.
+    // Specific screen readers are not detectable, so OS is used as a proxy.
+    if (label && !userAgent.APPLE && !label.endsWith(',')) {
+      label += ',';
+    }
+    aria.setState(this.getFocusableElement(), aria.State.LABEL, label);
     configureAriaRole(this);
   }
 

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -555,7 +555,7 @@ suite('ARIA', function () {
         block.getFocusableElement(),
         Blockly.utils.aria.State.LABEL,
       );
-      assert.isTrue(label.endsWith('has input'));
+      assert.isTrue(label.replace(/,$/, '').endsWith('has input'));
     });
 
     test('Blocks with multiple inputs are properly labeled', function () {
@@ -564,7 +564,7 @@ suite('ARIA', function () {
         block.getFocusableElement(),
         Blockly.utils.aria.State.LABEL,
       );
-      assert.isTrue(label.endsWith('has inputs'));
+      assert.isTrue(label.replace(/,$/, '').endsWith('has inputs'));
     });
     test('Blocks with multiple statement inputs are properly labeled', function () {
       const json = {
@@ -592,7 +592,7 @@ suite('ARIA', function () {
       );
       assert.isFalse(label.includes('else if, do'));
       assert.isFalse(label.includes('else,'));
-      assert.isTrue(label.endsWith('has 4 branches'));
+      assert.isTrue(label.replace(/,$/, '').endsWith('has 4 branches'));
     });
   });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10185

### Proposed Changes

Conditionally adds a comma to the end of valid block ARIA labels except on Apple devices.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

> NVDA (and probably JAWS) output information as "...has input statement" which might be confusing for some users. VoiceOver automatically places commas between the aria-label and aria-roledescription, so outputs "...has input, statement".

It is not possible to detect what screen reader is in use, if any. This uses OS as a proxy so that the users with the most common screen reader readers will get the optimal output.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

3 tests needed to be relaxed as the expected strings did not each include an ending comma.

I tested for regressions on my Mac and found none. I was not able to manually test on Windows, but I believe the fix is straight-forward enough.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
