### PR TITLE
fix: Make IDs of comment bar buttons consistent

### DIFF
--- a/packages/blockly/core/comments/collapse_comment_bar_button.ts
+++ b/packages/blockly/core/comments/collapse_comment_bar_button.ts
@@ -41,19 +41,24 @@ export class CollapseCommentBarButton extends CommentBarButton {
    * @param container An SVG group that this button should be a child of.
    */
   constructor(
-    protected readonly id: string,
-    protected readonly workspace: WorkspaceSvg,
-    protected readonly container: SVGGElement,
-    protected readonly commentView: CommentView,
+    id: string,
+    workspace: WorkspaceSvg,
+    container: SVGGElement,
+    commentView: CommentView,
   ) {
-    super(id, workspace, container, commentView);
+    super(
+      `${id}${COMMENT_COLLAPSE_BAR_BUTTON_FOCUS_IDENTIFIER}`,
+      workspace,
+      container,
+      commentView,
+    );
 
     this.icon = dom.createSvgElement(
       Svg.IMAGE,
       {
         'class': 'blocklyFoldoutIcon',
         'href': `${this.workspace.options.pathToMedia}foldout-icon.svg`,
-        'id': `${this.id}${COMMENT_COLLAPSE_BAR_BUTTON_FOCUS_IDENTIFIER}`,
+        'id': this.id,
       },
       this.container,
     );

--- a/packages/blockly/core/comments/comment_bar_button.ts
+++ b/packages/blockly/core/comments/comment_bar_button.ts
@@ -28,7 +28,7 @@ export abstract class CommentBarButton implements IFocusableNode {
    * @param container An SVG group that this button should be a child of.
    */
   constructor(
-    protected readonly id: string,
+    readonly id: string,
     protected readonly workspace: WorkspaceSvg,
     protected readonly container: SVGGElement,
     protected readonly commentView: CommentView,

--- a/packages/blockly/core/comments/delete_comment_bar_button.ts
+++ b/packages/blockly/core/comments/delete_comment_bar_button.ts
@@ -41,19 +41,24 @@ export class DeleteCommentBarButton extends CommentBarButton {
    * @param container An SVG group that this button should be a child of.
    */
   constructor(
-    protected readonly id: string,
-    protected readonly workspace: WorkspaceSvg,
-    protected readonly container: SVGGElement,
-    protected readonly commentView: CommentView,
+    id: string,
+    workspace: WorkspaceSvg,
+    container: SVGGElement,
+    commentView: CommentView,
   ) {
-    super(id, workspace, container, commentView);
+    super(
+      `${id}${COMMENT_DELETE_BAR_BUTTON_FOCUS_IDENTIFIER}`,
+      workspace,
+      container,
+      commentView,
+    );
 
     this.icon = dom.createSvgElement(
       Svg.IMAGE,
       {
         'class': 'blocklyDeleteIcon',
         'href': `${this.workspace.options.pathToMedia}delete-icon.svg`,
-        'id': `${this.id}${COMMENT_DELETE_BAR_BUTTON_FOCUS_IDENTIFIER}`,
+        'id': this.id,
       },
       container,
     );

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -254,7 +254,8 @@ export class WorkspaceSvg
    * @param e The right-click event that triggered the context menu.
    */
   configureContextMenu:
-    ((menuOptions: ContextMenuOption[], e: Event) => void) | null = null;
+    | ((menuOptions: ContextMenuOption[], e: Event) => void)
+    | null = null;
 
   /**
    * A dummy wheel event listener used as a workaround for a Safari scrolling issue.
@@ -2977,8 +2978,7 @@ export class WorkspaceSvg
           return (
             comment.view
               .getCommentBarButtons()
-              .find((button) => button.getFocusableElement().id.includes(id)) ??
-            null
+              .find((button) => button.id.includes(id)) ?? null
           );
         }
       }

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -253,7 +253,8 @@ export class WorkspaceSvg
    * @param options List of menu options to add to.
    * @param e The right-click event that triggered the context menu.
    */
-  configureContextMenu: ((menuOptions: ContextMenuOption[], e: Event) => void) | null = null;
+  configureContextMenu:
+    ((menuOptions: ContextMenuOption[], e: Event) => void) | null = null;
 
   /**
    * A dummy wheel event listener used as a workaround for a Safari scrolling issue.

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -253,9 +253,7 @@ export class WorkspaceSvg
    * @param options List of menu options to add to.
    * @param e The right-click event that triggered the context menu.
    */
-  configureContextMenu:
-    | ((menuOptions: ContextMenuOption[], e: Event) => void)
-    | null = null;
+  configureContextMenu: ((menuOptions: ContextMenuOption[], e: Event) => void) | null = null;
 
   /**
    * A dummy wheel event listener used as a workaround for a Safari scrolling issue.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR makes the ID of comment bar button objects consistent with value of the `id` attribute of their focusable elements. Previously, the ID of the objects was identical to that of their parent comment, and different from the `id` attribute of their representation in the DOM. It also makes the `id` field publicly accessible.

In addition to making things more consistent and sensible, this also lays the groundwork for making these buttons focusable in block comments in Scratch; core Blockly only uses them in workspace comments, and hardcodes that logic in `WorkspaceSvg`'s implementation of `lookupFocusableNode()`. With consistent (and public) IDs, they could be registered with the workspace's `ComponentManager` as having the `FOCUSABLE` capability, and the node resolution in `lookupFocusableNode()` would work. I actually plan to do another refactor to replace the entirety of `lookupFocusableNode()`'s implementation in core to depend on the `ComponentManager`, as doing so would make all lookups constant-time and thereby resolve #9162, along with making the code much simpler.