### PR TITLE
fix: Fix bug that could cause dragged blocks to connect to and delete others

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -902,7 +902,11 @@ export class BlockDragStrategy implements IDragStrategy {
     blockAnimation.disconnectUiStop();
     this.connectionPreviewer?.hidePreview();
 
-    if (!this.block.isDeadOrDying() && this.dragging) {
+    if (
+      !this.block.isDeadOrDying() &&
+      this.dragging &&
+      disposition !== DragDisposition.DELETE
+    ) {
       // These are expensive and don't need to be done if we're deleting, or
       // if we've already stopped dragging because we moved back to the start.
       this.workspace
@@ -921,7 +925,7 @@ export class BlockDragStrategy implements IDragStrategy {
       this.redisableAllDraggedBlocks(this.block);
     }
 
-    if (this.connectionCandidate) {
+    if (this.connectionCandidate && disposition !== DragDisposition.DELETE) {
       // Applying connections also rerenders the relevant blocks.
       this.applyConnections(this.connectionCandidate);
       this.disposeStep();

--- a/packages/blockly/tests/browser/test/dragger_test.mjs
+++ b/packages/blockly/tests/browser/test/dragger_test.mjs
@@ -391,7 +391,6 @@ suite('Dragging into a delete area', function () {
 
         // Move the existing block near the trash so that the dragged block will
         // attempt to connect on top of it.
-        existingBlock.moveTo(new Blockly.utils.Coordinate(0, 0));
         existingBlock.moveTo(
           new Blockly.utils.Coordinate(
             deleteRectCenter.x - workspace.toolbox.getClientRect().right - 30,

--- a/packages/blockly/tests/browser/test/dragger_test.mjs
+++ b/packages/blockly/tests/browser/test/dragger_test.mjs
@@ -372,4 +372,51 @@ suite('Dragging into a delete area', function () {
       });
     });
   });
+
+  test('does not delete blocks already on the workspace within the connection radius of a dragged block dropped on a delete area', async function () {
+    const {blockHasDeleteStyle, blockIsDeadOrDying, existingBlockDeleted} =
+      await this.browser.execute(() => {
+        const workspace = Blockly.getMainWorkspace();
+
+        const existingBlock = workspace.newBlock('controls_repeat');
+        existingBlock.initSvg();
+        existingBlock.render();
+
+        const draggingBlock = workspace.newBlock('controls_if');
+        draggingBlock.initSvg();
+        draggingBlock.render();
+
+        const deleteRect = workspace.trashcan.getClientRect();
+        const deleteRectCenter = rectCenterClient(deleteRect);
+
+        // Move the existing block near the trash so that the dragged block will
+        // attempt to connect on top of it.
+        existingBlock.moveTo(new Blockly.utils.Coordinate(0, 0));
+        existingBlock.moveTo(
+          new Blockly.utils.Coordinate(
+            deleteRectCenter.x - workspace.toolbox.getClientRect().right - 30,
+            deleteRectCenter.y + existingBlock.height / 2,
+          ),
+        );
+
+        const state = getAssertionState(
+          draggingBlock,
+          deleteRectCenter,
+          deleteRect,
+        );
+
+        return {
+          ...state,
+          existingBlockDeleted: existingBlock.isDeadOrDying(),
+        };
+      });
+
+    chai.assert.isFalse(
+      existingBlockDeleted,
+      'Expected existing block to not be deleted',
+    );
+
+    chai.assert.isTrue(blockHasDeleteStyle);
+    chai.assert.isTrue(blockIsDeadOrDying);
+  });
 });


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10281

### Proposed Changes
This PR fixes a bug where dragged blocks that were dropped onto a delete area could connect to other blocks on the workspace just before they were deleted, causing the non-dragged blocks to be deleted as well.

### Test Coverage

I added a browser test to exercise this scenario, and verified that it failed without the change in place.