### PR TITLE
fix: Fix bug that made some keyboard shortcuts non-idempotent

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -241,6 +241,7 @@ export class BlockDragStrategy implements IDragStrategy {
             recordUndo: true,
           },
         ) as BlockSvg;
+        newBlock.setDragging(true);
         eventUtils.setRecordUndo(false);
         newBlock.render();
         this.positionNewBlock(this.block, newBlock);

--- a/packages/blockly/core/dropdowndiv.ts
+++ b/packages/blockly/core/dropdowndiv.ts
@@ -147,7 +147,10 @@ export function createDom() {
     content,
     'keydown',
     null,
-    common.globalShortcutHandler,
+    (e: KeyboardEvent) => {
+      common.globalShortcutHandler(e);
+      e.stopPropagation();
+    },
   );
 
   arrow = document.createElement('div');

--- a/packages/blockly/core/widgetdiv.ts
+++ b/packages/blockly/core/widgetdiv.ts
@@ -102,7 +102,10 @@ export function createDom() {
     containerDiv,
     'keydown',
     null,
-    common.globalShortcutHandler,
+    (e: KeyboardEvent) => {
+      common.globalShortcutHandler(e);
+      e.stopPropagation();
+    },
   );
 
   container.appendChild(containerDiv);

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -1885,6 +1885,22 @@ suite('Keyboard Shortcut Items', function () {
       this.workspace.getInjectionDiv().dispatchEvent(event);
       assert.equal(this.workspace.getTopComments().length, 1);
     });
+
+    test('Is idempotent when a contextual menu is open', function () {
+      const comment = this.workspace.newComment();
+      comment.setText('Hello');
+      Blockly.getFocusManager().focusNode(comment);
+      comment.showContextMenu();
+      assert.equal(this.workspace.getTopComments().length, 1);
+      const event = createKeyDownEvent(Blockly.utils.KeyCodes.D);
+      // The WidgetDiv (used by the dropdown menu) registers the global shortcut
+      // handler for its own div, since it may live outside of the injection
+      // div. Ensure that it also prevents event bubbling to the main shortcut
+      // handler, which could cause shortcuts like Duplicate to be invoked
+      // multiple times from one keypress. See #10250.
+      Blockly.WidgetDiv.getDiv().dispatchEvent(event);
+      assert.equal(this.workspace.getTopComments().length, 2);
+    });
   });
 
   suite('Clean up workspace (C)', function () {

--- a/packages/blockly/tests/mocha/test_helpers/user_input.js
+++ b/packages/blockly/tests/mocha/test_helpers/user_input.js
@@ -39,6 +39,7 @@ export function dispatchPointerEvent(target, type, properties) {
 export function createKeyDownEvent(keyCode, modifiers) {
   const event = {
     keyCode: keyCode,
+    bubbles: true,
   };
   if (modifiers && modifiers.length > 0) {
     event.altKey = modifiers.includes(KeyCodes.ALT);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10250

### Proposed Changes
This PR fixes a bug that caused keyboard shortcuts to be run multiple times when a `WidgetDiv` or `DropDownDiv` was open. Because the *Divs may live outside of the injection div, they register the global keyboard shortcut handler for their own divs, so that keyboard shortcuts still work when a dropdown or contextual menu is open. However, in the typical case where they do live in the injection div, key events would then bubble up to the main global keyboard shortcut handler and be executed again, which in the particularly case of Duplicate had obvious effects. This PR stops propagation, so that events only get run through the keyboard shortcut handler once.

### Test Coverage
All tests pass, and I added a test specifically for this scenario with the `WidgetDiv`. In principle the problem and fix affect the `DropDownDiv` too, but Duplicate is the only shortcut with a keybinding that isn't inherently idempotent and isn't also suppressed when ephemeral focus is taken.