### PR TITLE
fix: Fix a bug that could cause unexpected block movement when inserting blocks from the toolbox

### DIFF
--- a/packages/blockly/core/keyboard_nav/keyboard_mover.ts
+++ b/packages/blockly/core/keyboard_nav/keyboard_mover.ts
@@ -75,6 +75,9 @@ export class KeyboardMover {
 
   static mover = new KeyboardMover();
 
+  /** Whether or not something is currently being moved. */
+  private moving = false;
+
   // Constructor is private to keep this class a singleton.
   private constructor() {}
 
@@ -94,7 +97,7 @@ export class KeyboardMover {
    * @returns True iff a workspace element is being moved.
    */
   isMoving() {
-    return !!this.draggable;
+    return this.moving;
   }
 
   /**
@@ -106,7 +109,7 @@ export class KeyboardMover {
    */
   startMove(draggable: IDraggable, event?: KeyboardEvent) {
     if (!this.canMove(draggable) || this.isMoving()) return false;
-
+    this.moving = true;
     const DraggerClass = registry.getClassFromOptions(
       registry.Type.BLOCK_DRAGGER,
       draggable.workspace.options,
@@ -354,6 +357,7 @@ export class KeyboardMover {
     this.dragger = undefined;
     this.startLocation = undefined;
     this.totalDelta = new Coordinate(0, 0);
+    this.moving = false;
   }
 
   /**


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10183

### Proposed Changes
This PR fixes a bug that caused blocks on the workspace to be bumped when inserting a new block from the flyout via the keyboard. When the newly-inserted block was rendered, it called `bumpNeighbors()`, which is normally suppressed when a drag is in progress. However, the workspace reported drag status based on the keyboard mover, and it reported its status based on having a draggable. The draggable wasn't actually set until after `onDragStart()`, so at the point the block was rendered and tried to bump neighbours it appeared that a drag was not in progress, thus allowing the bump to proceed and scooch blocks that should have remained stationary out of the way. Now, the `KeyboardMover` tracks its dragging/moving state with an instance variable explicitly for that, rather than relying on the presence of a draggable, which resolves the timing issue.

### Reason for Changes
Blocks shouldn't move by themselves.