### PR TITLE
fix: Make reverting block drags from the flyout delete the dragged block

### DIFF
--- a/packages/blockly/core/dragging/dragger.ts
+++ b/packages/blockly/core/dragging/dragger.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {BlockSvg} from '../block_svg.js';
 import {ComponentManager} from '../component_manager.js';
 import * as eventUtils from '../events/utils.js';
 import {getFocusManager} from '../focus_manager.js';
@@ -22,7 +23,14 @@ export class Dragger implements IDragger {
 
   protected dragTarget: IDragTarget | null = null;
 
+  protected revertShouldDelete = false;
+
   constructor(protected draggable: IDraggable) {
+    // Blocks originating from the flyout should be deleted if the drag is
+    // reverted.
+    if (draggable instanceof BlockSvg && draggable.workspace.isFlyout) {
+      this.revertShouldDelete = true;
+    }
     this.startLoc = draggable.getRelativeToSurfaceXY();
   }
 
@@ -167,7 +175,13 @@ export class Dragger implements IDragger {
   }
 
   /** Handles a drag being reverted. */
-  onDragRevert() {
+  onDragRevert(e?: PointerEvent | KeyboardEvent) {
+    if (this.revertShouldDelete && isDeletable(this.draggable)) {
+      this.draggable.endDrag(e, DragDisposition.DELETE);
+      this.draggable.dispose();
+      return;
+    }
+
     this.draggable.revertDrag();
     if (isFocusableNode(this.draggable)) {
       getFocusManager().focusNode(this.draggable);

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -547,6 +547,23 @@ suite('Keyboard-driven movement', function () {
       this.modifiers = [Blockly.utils.KeyCodes.CTRL_CMD];
     });
 
+    test('deletes blocks dragged from the flyout when a drag is reverted', function () {
+      // One block is on the workspace to start.
+      let blocks = this.workspace.getTopBlocks();
+      assert.equal(blocks.length, 1);
+
+      // Starting a move from the toolbox creates a new block on the main workspace.
+      focusToolbox(this.workspace);
+      startMove(this.workspace);
+      blocks = this.workspace.getTopBlocks();
+      assert.equal(blocks.length, 2);
+
+      // Canceling the move originating from the toolbox deletes the new block.
+      cancelMove(this.workspace);
+      blocks = this.workspace.getTopBlocks();
+      assert.equal(blocks.length, 1);
+    });
+
     suite('in unconstrained mode', function () {
       testMovingUp();
       testMovingDown();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10055

### Proposed Changes
This PR fixes an issue where blocks inserted from the flyout via keyboard would not be deleted if the drag/insert was cancelled via Escape. The linked issue no longer repros as well, now that we can actually revert inserts.