### PR TITLE
chore: added nx to docs start

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -26,10 +26,6 @@
       "outputs": ["{projectRoot}/dist"],
       "cache": true
     },
-    "docusaurus": {
-      "dependsOn": ["^docusaurus"],
-      "cache": true
-    },
     "docs": {
       "outputs": ["{projectRoot}/../docs/docs/reference"],
       "cache": true
@@ -111,6 +107,9 @@
     },
     "prepack": {
       "cache": true
+    },
+    "start": {
+      "continuous": true
     }
   },
   "neverConnectToCloud": true,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,6 +15,7 @@
         ]
       },
       "build": {
+        "outputs": ["build", ".docusaurus", "node_modules/.cache"],
         "dependsOn": [
           {
             "projects": "blockly",
@@ -26,7 +27,7 @@
   },
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "npx nx run docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,7 +15,11 @@
         ]
       },
       "build": {
-        "outputs": ["build", ".docusaurus", "node_modules/.cache"],
+        "outputs": [
+          "{projectRoot}/build", 
+          "{projectRoot}/.docusaurus", 
+          "{projectRoot}/node_modules/.cache"
+        ],
         "dependsOn": [
           {
             "projects": "blockly",


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Adds nx to the blockly docs start command; this was missing from the previous PR as I needed to discuss with Zoë first.

### Reason for Changes

Previously one would need to run the docs command from blockly before being able to run start in docs. This change makes it so that running start automatically does all the steps needed before booting up the server. Additionally the steps with output are cached so that they don't need to re-run each time.
