### PR TITLE
chore: Don't run reviewer assignment action for teams

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   requested-reviewer:
     runs-on: ubuntu-latest
+    if: ${{ github.event.requested_reviewer != null }}
     permissions:
       pull-requests: write
     steps:
@@ -26,18 +27,14 @@ jobs:
               if (context.payload.pull_request === undefined) {
               throw new Error("Can't get pull_request payload. " +
                               'Check a request reviewer event was triggered.');
-              }
-              const reviewers = context.payload.pull_request.requested_reviewers;
-              // Assignees takes in a list of logins rather than the
-              // reviewer object.
-              const reviewerNames = reviewers.map(reviewer => reviewer.login);
-              const {number:issue_number} = context.payload.pull_request;
-              github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue_number,
-                assignees: reviewerNames
-              });
-            } catch (error) {
-              core.setFailed(error.message);
             }
+            const {number:issue_number} = context.payload.pull_request;
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              assignees: [context.payload.requested_reviewer.login]
+            });
+          } catch (error) {
+            core.setFailed(error.message);
+          }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10284

### Proposed Changes
This PR fixes flakes in the reviewer assignment GitHub action. The investigation was LLM-assisted; the flake was caused by this action being triggered twice as Liz noted in the issue, once for the Blockly team and once for the individual team member that Github's reviewer assignment selected. The two action invocations could trample each other, depending on timing. Now, the action is skipped when it gets invoked for the team assignment, and only runs for the individual assignment. It also awaits the API call so errors actually get caught, and grabs the individual to assign the PR to from the event rather than the PR object.

### Reason for Changes
Flaky tooling is annoying.
