### PR TITLE
chore: add nx build step before starting docusaurus

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,6 +10,14 @@
           "^build",
           {
             "projects": "blockly",
+            "target": "build"
+          },
+          {
+            "projects": "blockly",
+            "target": "package"
+          },
+          {
+            "projects": "blockly",
             "target": "docs"
           }
         ]
@@ -31,7 +39,7 @@
   },
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "npx nx run docusaurus start",
+    "start": "npx nx run build && docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes issue where nx wasn't kicking off build before starting the docusaurus server 

