### PR TITLE
fix: Do not re-announce moves that stay on the same connection target

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -93,6 +93,15 @@ export class BlockDragStrategy implements IDragStrategy {
   private originalEventGroup = '';
 
   /**
+   * Half of the connection of the last announced candidate, or null if that
+   * announcement was for the workspace. Undefined if nothing has been
+   * announced yet this drag.
+   */
+  private lastAnnouncedLocal: RenderedConnection | null | undefined = undefined;
+  private lastAnnouncedNeighbour: RenderedConnection | null | undefined =
+    undefined;
+
+  /**
    * Map from block IDs to reason(s) why it was disabled, used to restore
    * disabled state post-drag.
    */
@@ -277,6 +286,21 @@ export class BlockDragStrategy implements IDragStrategy {
       announcementTemplate = Msg['ANNOUNCE_MOVE_WORKSPACE'];
       announcement = announcementTemplate.replace('%1', blockLabel);
     }
+
+    // Skip only when the connection target is unchanged, so identically
+    // worded moves to different inputs (e.g. empty else-if slots) still get read.
+    const local = this.connectionCandidate?.local ?? null;
+    const neighbour = this.connectionCandidate?.neighbour ?? null;
+    if (
+      this.lastAnnouncedLocal !== undefined &&
+      local === this.lastAnnouncedLocal &&
+      neighbour === this.lastAnnouncedNeighbour
+    ) {
+      return;
+    }
+    this.lastAnnouncedLocal = local;
+    this.lastAnnouncedNeighbour = neighbour;
+
     // Collapse whitespace from unused template substitutions.
     aria.announceDynamicAriaState(announcement.replace(/\s+/g, ' '));
   }
@@ -319,6 +343,8 @@ export class BlockDragStrategy implements IDragStrategy {
     this.block.workspace.recordDragTargets();
 
     this.dragging = true;
+    this.lastAnnouncedLocal = undefined;
+    this.lastAnnouncedNeighbour = undefined;
     this.fireDragStartEvent();
 
     this.startLoc = this.block.getRelativeToSurfaceXY();

--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -121,6 +121,30 @@ suite('ARIA', function () {
       );
     });
 
+    test('repeated drags with unchanged state are not re-announced', function () {
+      const block = this.workspace.newBlock('basic_block');
+      block.initSvg();
+      block.render();
+
+      const startLoc = block.getRelativeToSurfaceXY();
+      block.startDrag();
+      this.clock.tick(11);
+      const initialAnnouncementText = this.liveRegion.textContent;
+      assert.equal(initialAnnouncementText, 'Moving default on workspace.');
+
+      block.drag(new Blockly.utils.Coordinate(startLoc.x + 20, startLoc.y));
+      block.drag(new Blockly.utils.Coordinate(startLoc.x + 40, startLoc.y));
+      block.drag(new Blockly.utils.Coordinate(startLoc.x + 60, startLoc.y));
+      this.clock.tick(11);
+
+      // Subsequent announcements during a move will drop the getStackBlocksCountLabel()
+      // and toggle a non-breaking space at the end. If the move candidate hasn't
+      // changed, the live region shouldn't be udpated.
+      assert.equal(this.liveRegion.textContent, initialAnnouncementText);
+
+      block.endDrag(undefined, Blockly.DragDisposition.COMMIT);
+    });
+
     test('Uses maximal assertiveness when coalescing', function () {
       Blockly.utils.aria.announceDynamicAriaState('First message', {
         assertiveness: Blockly.utils.aria.LiveRegionAssertiveness.OFF,

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -1599,6 +1599,52 @@ suite('Keyboard-driven movement', function () {
 
         cancelMove(this.workspace);
       });
+      test('re-announces when moving between identically labeled inputs', function () {
+        const json = {
+          'blocks': {
+            'languageVersion': 0,
+            'blocks': [
+              {
+                'type': 'controls_if',
+                'id': 'ifBlock',
+                'x': 0,
+                'y': 100,
+                'extraState': {
+                  'elseIfCount': 2,
+                },
+              },
+            ],
+          },
+        };
+        Blockly.serialization.workspaces.load(json, this.workspace);
+        const boolean = this.workspace.newBlock('logic_boolean');
+        boolean.initSvg();
+        boolean.render();
+        this.workspace.cleanUp();
+
+        Blockly.getFocusManager().focusNode(boolean);
+        startMove(this.workspace);
+        // Skip the first `if` value input.
+        moveRight(this.workspace);
+
+        this.moveAndAssert(
+          moveRight,
+          ['Moving', 'to', 'else if'],
+          [this.getBlockLabel(boolean)],
+        );
+        const afterFirstElseIf = this.liveRegion.textContent;
+
+        this.moveAndAssert(
+          moveRight,
+          ['Moving', 'to', 'else if'],
+          [this.getBlockLabel(boolean)],
+        );
+
+        const afterSecondElseIf = this.liveRegion.textContent;
+        assert.notEqual(afterSecondElseIf, afterFirstElseIf);
+
+        cancelMove(this.workspace);
+      });
       test('disambiguates between unlabeled value inputs', function () {
         const textJoin = this.workspace.newBlock('text_join');
         textJoin.itemCount_ = 3;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Adds an early return before announcing move mode updates if the target connection has not changed. 

### Reason for Changes

Prevents repeated/stuttering announcements like "M-M-M-M-Moving on workspace." 
This check is based on the actual connections themselves rather than a simple announcement string comparison. This is necessary so that moves to distinct connections with the same labels (e.g. empty `else if`s) are still announced.

### Test Coverage

One new test checks that the live region is _not_ updated between several on-workspace drags.
The other new ensures that identical move announcements can still happen when expected.

I manually tested these changes using VoiceOver with speech unmuted.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
