### PR TITLE
fix: Improve block placement when inserting from flyout via keyboard

### DIFF
--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -149,8 +149,12 @@ export class BlockDragStrategy implements IDragStrategy {
 
     if (this.moveMode !== MoveMode.CONSTRAINED) return;
     const workspace = newBlock.workspace;
-    const initialY = this.WORKSPACE_MARGIN;
-    const initialX = this.WORKSPACE_MARGIN;
+    const metrics = workspace.getMetricsManager().getViewMetrics(true);
+    const initialY = metrics.top + this.WORKSPACE_MARGIN;
+    const initialX = workspace.RTL
+      ? metrics.left + metrics.width - this.WORKSPACE_MARGIN
+      : metrics.left + this.WORKSPACE_MARGIN;
+
     // How far apart the new block should be placed horizontally from an
     // existing one.
     const xSpacing = 80;
@@ -172,10 +176,8 @@ export class BlockDragStrategy implements IDragStrategy {
       );
     });
 
-    const toolboxWidth = workspace.getToolbox()?.getWidth();
-    const workspaceWidth =
-      workspace.getParentSvg().clientWidth - (toolboxWidth ?? 0);
-    const workspaceHeight = workspace.getParentSvg().clientHeight;
+    const workspaceWidth = metrics.width;
+    const workspaceHeight = metrics.height;
     const {height: newBlockHeight, width: newBlockWidth} =
       newBlock.getHeightWidth();
 
@@ -198,31 +200,39 @@ export class BlockDragStrategy implements IDragStrategy {
     // Make the initial movement of shifting the block to its best possible
     // position.
     let boundingRect = newBlock.getBoundingRectangle();
-    newBlock.moveBy(cursorX - boundingRect.left, cursorY - boundingRect.top, [
-      'cleanup',
-    ]);
+    newBlock.moveBy(
+      workspace.RTL
+        ? cursorX - boundingRect.right
+        : cursorX - boundingRect.left,
+      cursorY - boundingRect.top,
+      ['cleanup'],
+    );
 
     boundingRect = newBlock.getBoundingRectangle();
     let conflictingRect = getNextIntersectingBlock(boundingRect);
     while (conflictingRect != null) {
-      const newCursorX =
-        conflictingRect.left + conflictingRect.getWidth() + xSpacing;
+      const newCursorX = workspace.RTL
+        ? conflictingRect.left - xSpacing
+        : conflictingRect.right + xSpacing;
       const newCursorY =
         conflictingRect.top + conflictingRect.getHeight() + minBlockHeight;
-      if (newCursorX + newBlockWidth <= workspaceWidth) {
+      if (
+        workspace.RTL
+          ? newCursorX - newBlockWidth >= metrics.left
+          : newCursorX + newBlockWidth <= metrics.left + metrics.width
+      ) {
         cursorX = newCursorX;
-      } else if (newCursorY + newBlockHeight <= workspaceHeight) {
-        cursorY = newCursorY;
-        cursorX = initialX;
       } else {
-        // Off screen, but new blocks will be selected which will scroll them
-        // into view.
         cursorY = newCursorY;
         cursorX = initialX;
       }
-      newBlock.moveBy(cursorX - boundingRect.left, cursorY - boundingRect.top, [
-        'cleanup',
-      ]);
+      newBlock.moveBy(
+        workspace.RTL
+          ? cursorX - boundingRect.right
+          : cursorX - boundingRect.left,
+        cursorY - boundingRect.top,
+        ['cleanup'],
+      );
       boundingRect = newBlock.getBoundingRectangle();
       conflictingRect = getNextIntersectingBlock(boundingRect);
     }

--- a/packages/blockly/core/dragging/block_drag_strategy.ts
+++ b/packages/blockly/core/dragging/block_drag_strategy.ts
@@ -176,10 +176,7 @@ export class BlockDragStrategy implements IDragStrategy {
       );
     });
 
-    const workspaceWidth = metrics.width;
-    const workspaceHeight = metrics.height;
-    const {height: newBlockHeight, width: newBlockWidth} =
-      newBlock.getHeightWidth();
+    const newBlockWidth = newBlock.getHeightWidth().width;
 
     const getNextIntersectingBlock = function (
       newBlockRect: Rect,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10072

### Proposed Changes
This PR improves the placement of blocks inserted from the flyout via the keyboard. Previously, blocks would be tiled left to right, top to bottom from (0, 0). Now, tiling starts from the top left (in LTR) or top right (in RTL) of the workspace's visible viewport, and proceeds right-to-left in RTL mode. This provides the spatially-expected behavior, and tiles blocks in the entire visible viewport without jumping the scroll position around.