### PR TITLE
docs: fix documentation on changing max dropdown height

### DIFF
--- a/packages/docs/docs/guides/create-custom-blocks/fields/built-in-fields/dropdown.mdx
+++ b/packages/docs/docs/guides/create-custom-blocks/fields/built-in-fields/dropdown.mdx
@@ -439,13 +439,27 @@ This is a global property, so it will modify all dropdown fields when set.
 
 ### Menu height
 
-The `Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH` property can be used to change
-the maximum height of the menu. It is defined as a percentage of the viewport
-height, the viewport being the window.
+To change the maximum height of the dropdown menu, you can override Blockly's 
+CSS. 
 
-The `MAX_MENU_HEIGHT_VH` property defaults to 0.45.
+```CSS
+.blocklyDropDownContent {
+  max-height: 50; /* Set your desired height. Blockly uses 300px by default. */
+}
+```
 
-This is a global property, so it will modify all dropdown fields when set.
+Changing the `max-height` of `blocklyDropDownContent` will modify all dropdown 
+fields. This would include plugin fields like [`FieldColour`](https://github.com/RaspberryPiFoundation/blockly/tree/main/packages/plugins/field-colour). 
+
+If you would like to only override the `max-height` for `FieldDropdown` objects, 
+then you can use the `:has()` CSS selector to match the menu element that 
+`FieldDropdown` renders:
+
+```CSS
+.blocklyDropDownContent:has(.blocklyDropdownMenu) {
+  max-height: 50;
+}
+```
 
 ## Prefix/suffix matching
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #8147

### Proposed Changes

Adds documentation on how to set max height of dropdown field.

### Reason for Changes

The docs previously described using a property (`Blockly.FieldDropdown.MAX_MENU_HEIGHT_VH`) that has since been completely refactored out.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
n/a

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
n/a

### Additional Information

It might be a slightly specific scenario that someone a) would want to adjust the max height of field dropdowns, b) use a plugin that extends the `FieldDropdown` class, and c) care that they are both affected by changing `max-height`. 

I was going back and forth on whether to provide the workaround using `:has()` of if the section should just end by stating that overriding `max-height` might affect plugins. I erred on the side of caution and kept it in, but can remove if it doesn't seem applicable enough. 

<!-- Anything else we should know? -->
