### PR TITLE
fix: scroll field into view after window resize instead of bumping block

### DIFF
--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -14,7 +14,6 @@
 import {computeAriaLabel, getBeginStackLabel} from './block_aria_composer.js';
 import {BlockSvg} from './block_svg.js';
 import * as browserEvents from './browser_events.js';
-import * as bumpObjects from './bump_objects.js';
 import * as css from './css.js';
 import * as dialog from './dialog.js';
 import * as dropDownDiv from './dropdowndiv.js';
@@ -33,8 +32,10 @@ import * as renderManagement from './render_management.js';
 import * as aria from './utils/aria.js';
 import {Verbosity} from './utils/aria.js';
 import * as dom from './utils/dom.js';
+import {Rect} from './utils/rect.js';
 import {Size} from './utils/size.js';
 import {Svg} from './utils/svg.js';
+import * as svgMath from './utils/svg_math.js';
 import * as userAgent from './utils/useragent.js';
 import * as WidgetDiv from './widgetdiv.js';
 import type {WorkspaceSvg} from './workspace_svg.js';
@@ -842,26 +843,34 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
 
   /**
    * Handles repositioning the WidgetDiv used for input fields when the
-   * workspace is resized. Will bump the block into the viewport and update the
-   * position of the text input if necessary.
+   * workspace is resized. Scrolls this field into view, then updates the
+   * position of the text input.
    *
    * @returns True for rendered workspaces, as we never want to hide the widget
    *     div.
    */
   override repositionForWindowResize(): boolean {
-    const block = this.getSourceBlock()?.getRootBlock();
+    const block = this.getSourceBlock();
+    const workspace = this.workspace_;
     // This shouldn't be possible. We should never have a WidgetDiv if not using
     // rendered blocks.
     if (!(block instanceof BlockSvg)) return false;
 
-    const bumped = bumpObjects.bumpIntoBounds(
-      this.workspace_!,
-      this.workspace_!.getMetricsManager().getViewMetrics(true),
-      block,
+    this.resizeEditor_();
+
+    const element = this.getClickTarget_();
+    if (!element || !workspace) return true;
+
+    const bbox = Rect.from(element.getBoundingClientRect());
+    const origin = svgMath.screenToWsCoordinates(workspace, bbox.getOrigin());
+    const scale = workspace.scale;
+    workspace.scrollBoundsIntoView(
+      Rect.createFromPoint(
+        origin,
+        bbox.getWidth() / scale,
+        bbox.getHeight() / scale,
+      ),
     );
-
-    if (!bumped) this.resizeEditor_();
-
     return true;
   }
 

--- a/packages/blockly/core/inject.ts
+++ b/packages/blockly/core/inject.ts
@@ -235,9 +235,9 @@ function init(mainWorkspace: WorkspaceSvg) {
       // possible.
       Tooltip.hide();
       mainWorkspace.hideComponents(true);
+      common.svgResize(mainWorkspace);
       dropDownDiv.repositionForWindowResize();
       WidgetDiv.repositionForWindowResize();
-      common.svgResize(mainWorkspace);
       bumpObjects.bumpTopObjectsIntoBounds(mainWorkspace);
     },
   );

--- a/packages/blockly/core/workspace_svg.ts
+++ b/packages/blockly/core/workspace_svg.ts
@@ -2236,9 +2236,12 @@ export class WorkspaceSvg
    *
    * @param x Target X to scroll to.
    * @param y Target Y to scroll to.
+   * @param shouldHidePopups Whether to hide popups. Defaults to true.
    */
-  scroll(x: number, y: number) {
-    this.hideChaff(/* opt_onlyClosePopups= */ true);
+  scroll(x: number, y: number, shouldHidePopups = true) {
+    if (shouldHidePopups) {
+      this.hideChaff(/* opt_onlyClosePopups= */ true);
+    }
 
     // Keep scrolling within the bounds of the content.
     const metrics = this.getMetrics();
@@ -2770,7 +2773,7 @@ export class WorkspaceSvg
 
     deltaX *= scale;
     deltaY *= scale;
-    this.scroll(this.scrollX + deltaX, this.scrollY + deltaY);
+    this.scroll(this.scrollX + deltaX, this.scrollY + deltaY, false);
   }
 
   /** See IFocusableNode.getFocusableElement. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)



## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10277

### Proposed Changes
`FieldInput.repositionForWindowResize` no longer bumps the block into the viewport. Instead, it calls `scrollBoundsIntoView` so the **field** pans into view and the block’s workspace position is unchanged.
This required adding an optional `shouldHidePopups` param to `workspace.scroll()` so to prevent `hideChaff` from being called.
The window `resize` handler in `inject.ts` calls `svgResize` **before** dropdown/widget repositioning so there's no chance of using stale cached metrics.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Bumping a block wider than the view when an input field is being edited and the window resizes (for example the mobile Android keyboard) left-aligns it to the flyout, so the focused field goes off-screen.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Testing

I validated the changes to the best of my ability using desktop Chrome. I do not have an Android device available for further testing.
I tested the need for the resize handler manually by using a `setTimeout` function in the console to significantly shrink the injection div then fire `resize`. With the original sequence, the focused field/block still end up hidden below the viewable workspace bounds:

https://github.com/user-attachments/assets/8f335c98-6911-4336-958e-c1460b1c9a64

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
