### PR TITLE
chore: add redirects for plugins docs

### DIFF
--- a/packages/docs/docs/guides/contribute/core/plugins/debugging.mdx
+++ b/packages/docs/docs/guides/contribute/core/plugins/debugging.mdx
@@ -16,7 +16,7 @@ Blockly core.](#making-changes-to-a-plugin-and-to-blockly-core)
 ## Making changes to a plugin
 
 1. Run `npm install` from the root of the [blockly repo](https://github.com/RaspberryPiFoundation/blockly).
-1. Navigate to your plugin's directory (e.g. `cd /packages/plugins/my-favorite-plugin).
+1. Navigate to your plugin's directory (e.g. `cd /packages/plugins/my-favorite-plugin`).
 1. Run `npm start` in the plugin's directory.
 
 ## Making changes to a plugin and to blockly core
@@ -28,7 +28,7 @@ first build blockly.
 
 1. Run `npm ci` from the root of the [blockly repo](https://github.com/RaspberryPiFoundation/blockly).
 1. Run `npm run build` from the root of the [blockly repo](https://github.com/RaspberryPiFoundation/blockly).
-1. Navigate to your plugin's directory (e.g. `cd /packages/plugins/my-favorite-plugin).
+1. Navigate to your plugin's directory (e.g. `cd /packages/plugins/my-favorite-plugin`).
 1. Run `npm start` in the plugin's directory.
 
 :::tip

--- a/packages/docs/docs/guides/contribute/get-started/write_a_good_issue.mdx
+++ b/packages/docs/docs/guides/contribute/get-started/write_a_good_issue.mdx
@@ -83,7 +83,7 @@ We would love to allow every idea to enter this repository! But sadly
 we're only human, so we have some guidelines in place about what kinds of
 requests we will pursue. Here are the guidelines for some of the different categories of projects:
 
-- [Plugins](/guides/contribute/samples/add_a_plugin#first-party-criteria)
+- [Plugins](/guides/contribute/core/plugins/add_a_plugin#first-party-criteria)
 - Examples: Show how to use only one or two Blockly features.
 - Codelabs: Show how to complete a single task or implement a single behaviour.
 

--- a/packages/docs/docs/guides/contribute/index.mdx
+++ b/packages/docs/docs/guides/contribute/index.mdx
@@ -15,7 +15,7 @@ contributions.
 - [Fix issues](/guides/contribute/get-started/write_a_good_pr)
 - [Add tests](/guides/contribute/core/unit_testing)
 - [Write codelabs](/guides/contribute/core/write_a_codelab)
-- [Write plugins](/guides/contribute/samples/add_a_plugin)
+- [Write plugins](/guides/contribute/core/plugins/add_a_plugin)
 - [Answer questions](https://groups.google.com/g/blockly)
 
 ## Where to start

--- a/packages/docs/docs/guides/programming/plugin_overview.mdx
+++ b/packages/docs/docs/guides/programming/plugin_overview.mdx
@@ -27,7 +27,7 @@ For a quick introduction to plugins, see our [Plugins Overview talk
 (2021)](https://www.youtube.com/watch?v=rg-V0w7UZFc&list=PLSIUOFhnxEiCjoIwJ0jAdwpTZET73CK7d&index=3).
 
 If you want to create your own plugin, see [Add a
-plugin](/guides/contribute/samples/add_a_plugin).
+plugin](/guides/contribute/core/plugins/add_a_plugin).
 
 ## First- and third-party plugins
 

--- a/packages/docs/static/_redirects
+++ b/packages/docs/static/_redirects
@@ -45,8 +45,7 @@
 /guides/modify/web/playground   /guides/contribute/core/testing/playground/   301
 
 # Contributing to Samples section
-# Targets updated for the 2026 monorepo move (Cloudflare does not chain redirects,
-# so these must point at the final destination, not at the old samples/ URLs).
+# Monorepo move plugins into core 
 /guides/modify/contribute/add_a_plugin   /guides/contribute/core/plugins/add_a_plugin/   301
 /guides/plugins/debugging   /guides/contribute/core/plugins/debugging/   301
 /guides/plugins/naming   /guides/contribute/core/plugins/naming/   301
@@ -136,9 +135,7 @@
 
 # End - Site refactoring - 2025
 
-# Monorepo move - 2026
-# Plugin contribution docs moved from Contribute > Samples to Contribute > Core > Plugins.
-# repository_structure was folded into the samples overview page.
+# Monorepo move plugins into core
 /guides/contribute/samples/add_a_plugin   /guides/contribute/core/plugins/add_a_plugin/   301
 /guides/contribute/samples/block_factory   /guides/contribute/core/plugins/block_factory/   301
 /guides/contribute/samples/block_libraries   /guides/contribute/core/plugins/block_libraries/   301

--- a/packages/docs/static/_redirects
+++ b/packages/docs/static/_redirects
@@ -45,11 +45,13 @@
 /guides/modify/web/playground   /guides/contribute/core/testing/playground/   301
 
 # Contributing to Samples section
-/guides/modify/contribute/add_a_plugin   /guides/contribute/samples/add_a_plugin/   301
-/guides/plugins/debugging   /guides/contribute/samples/debugging/   301
-/guides/plugins/naming   /guides/contribute/samples/naming/   301
+# Targets updated for the 2026 monorepo move (Cloudflare does not chain redirects,
+# so these must point at the final destination, not at the old samples/ URLs).
+/guides/modify/contribute/add_a_plugin   /guides/contribute/core/plugins/add_a_plugin/   301
+/guides/plugins/debugging   /guides/contribute/core/plugins/debugging/   301
+/guides/plugins/naming   /guides/contribute/core/plugins/naming/   301
 /guides/plugins/overview   /guides/programming/plugin_overview/   301
-/guides/modify/contribute/samples_repository_structure   /guides/contribute/samples/repository_structure/   301
+/guides/modify/contribute/samples_repository_structure   /guides/contribute/samples/   301
 /guides/modify/contribute/write_a_codelab   /guides/contribute/core/write_a_codelab/   301
 
 # Contributing to Core section
@@ -133,6 +135,16 @@
 /guides/contribute/samples/plugin_overview   /guides/programming/plugin_overview/   301
 
 # End - Site refactoring - 2025
+
+# Monorepo move - 2026
+# Plugin contribution docs moved from Contribute > Samples to Contribute > Core > Plugins.
+# repository_structure was folded into the samples overview page.
+/guides/contribute/samples/add_a_plugin   /guides/contribute/core/plugins/add_a_plugin/   301
+/guides/contribute/samples/block_factory   /guides/contribute/core/plugins/block_factory/   301
+/guides/contribute/samples/block_libraries   /guides/contribute/core/plugins/block_libraries/   301
+/guides/contribute/samples/debugging   /guides/contribute/core/plugins/debugging/   301
+/guides/contribute/samples/naming   /guides/contribute/core/plugins/naming/   301
+/guides/contribute/samples/repository_structure   /guides/contribute/samples/   301
 
 # Legacy developers.google.com/blockly marketing pages
 /summits/summits   https://www.blockly.com/summit/home   301


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes broken links

### Proposed Changes

Adds redirects

### Reason for Changes

I forgot to include the redirects in my initial plugins PR, and also missed a couple of backticks in one doc.

I had to also adjust some existing redirects bc [Cloudflare won't chain them](https://developers.cloudflare.com/pages/configuration/redirects/#proxying)

### Test Coverage

Had claude fill in the correct redirects, but I verified link correctness 

### Documentation

n/a

### Additional Information

<!-- Anything else we should know? -->
