### PR TITLE
chore: pin all the nx packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
       docusaurus:
         patterns:
           - '@docusaurus/*'
+      # nx requires every @nx/* package to be on exactly the same version as
+      # nx itself, so they are pinned exactly and must be updated together.
+      nx:
+        patterns:
+          - 'nx'
+          - '@nx/*'
   - package-ecosystem: 'github-actions' # See documentation for possible values
     directory: '/'
     target-branch: 'main'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.0.2",
         "@eslint/js": "^10.0.1",
-        "@nx/js": "^23.1.0",
+        "@nx/js": "23.1.1",
         "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint": "10.5.0",
         "eslint-config-google": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/js": "^10.0.1",
-    "@nx/js": "^23.1.0",
+    "@nx/js": "23.1.1",
     "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "10.5.0",
     "eslint-config-google": "^0.14.0",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes issue with nx installing

### Proposed Changes

- Pins the exact version of `@nx/js` to match what `nx` itself does
- Adds a dependabot group so they get updated together

### Reason for Changes

nx was pinned but not `@nx/js` so when I deleted a package-lock and regenerated it for unrelated reasons, the version of `@nx/js` increased in the package-lock but not the version of nx.

The nx installer pins the version of nx itself and any other nx packages you install at the same time, so pinning it is correct. `@nx/js` was hand-added with the caret; if it had been added by the installer it would have been pinned as well.

### Test Coverage

no more nx build failures

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
