### PR TITLE
chore: Stop Extensions from importing FieldDropdown

### DIFF
--- a/packages/blockly/core/extensions.ts
+++ b/packages/blockly/core/extensions.ts
@@ -8,7 +8,6 @@
 
 import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
-import {FieldDropdown} from './field_dropdown.js';
 import {MutatorIcon} from './icons/mutator_icon.js';
 import * as parsing from './utils/parsing.js';
 
@@ -395,6 +394,7 @@ export function runAfterPageLoad(fn: () => void) {
  *     lookup table.
  * @param lookupTable The table of field values to tooltip text.
  * @returns The extension function.
+ * @throws {Error} if the dropdown options checker has not been installed.
  */
 export function buildTooltipForDropdown(
   dropdownName: string,
@@ -405,6 +405,12 @@ export function buildTooltipForDropdown(
 
   return function (this: Block) {
     if (!blockTypesChecked.includes(this.type)) {
+      // FieldDropdown registers the checker at module load. Blockly's own
+      // blocks already import field_dropdown.js, so this only throws if that
+      // import was skipped and a custom checker wasn't installed.
+      if (!checkDropdownOptionsInTable) {
+        throw Error('Dropdown options checker has not been installed.');
+      }
       checkDropdownOptionsInTable(this, dropdownName, lookupTable);
       blockTypesChecked.push(this.type);
     }
@@ -419,35 +425,31 @@ export function buildTooltipForDropdown(
 }
 
 /**
- * Checks all options keys are present in the provided string lookup table.
- * Emits console warnings when they are not.
+ * Checker that validates dropdown tooltip lookup tables.
  *
  * @param block The block containing the dropdown
  * @param dropdownName The name of the dropdown
  * @param lookupTable The string lookup table
  */
-function checkDropdownOptionsInTable(
-  block: Block,
-  dropdownName: string,
-  lookupTable: {[key: string]: string},
+let checkDropdownOptionsInTable:
+  | ((
+      block: Block,
+      dropdownName: string,
+      lookupTable: {[key: string]: string},
+    ) => void)
+  | undefined;
+
+/**
+ * Sets the checker used to validate dropdown tooltip lookup tables.
+ *
+ * @see {@link buildTooltipForDropdown}
+ * @param fn The checker to install.
+ * @internal
+ */
+export function setDropdownOptionsChecker(
+  fn: NonNullable<typeof checkDropdownOptionsInTable>,
 ) {
-  const dropdown = block.getField(dropdownName);
-  if (!(dropdown instanceof FieldDropdown) || dropdown.isOptionListDynamic()) {
-    return;
-  }
-
-  const options = dropdown.getOptions();
-  for (const option of options) {
-    if (option === FieldDropdown.SEPARATOR) continue;
-
-    const [, key] = option;
-    if (lookupTable[key] === undefined) {
-      console.warn(
-        `No tooltip mapping for value ${key} of field ` +
-          `${dropdownName} of block type ${block.type}.`,
-      );
-    }
-  }
+  checkDropdownOptionsInTable = fn;
 }
 
 /**

--- a/packages/blockly/core/field_dropdown.ts
+++ b/packages/blockly/core/field_dropdown.ts
@@ -13,8 +13,10 @@
  */
 // Former goog.module ID: Blockly.FieldDropdown
 
+import type {Block} from './block.js';
 import type {BlockSvg} from './block_svg.js';
 import * as dropDownDiv from './dropdowndiv.js';
+import * as Extensions from './extensions.js';
 import {
   Field,
   FieldConfig,
@@ -1073,4 +1075,37 @@ export interface FieldDropdownFromJsonConfig extends FieldDropdownConfig {
  */
 export type FieldDropdownValidator = FieldValidator<string>;
 
+/**
+ * Checks all options keys are present in the provided string lookup table.
+ * Emits console warnings when they are not.
+ *
+ * @param block The block containing the dropdown
+ * @param dropdownName The name of the dropdown
+ * @param lookupTable The string lookup table
+ */
+function checkOptionsInTable(
+  block: Block,
+  dropdownName: string,
+  lookupTable: {[key: string]: string},
+) {
+  const dropdown = block.getField(dropdownName);
+  if (!(dropdown instanceof FieldDropdown) || dropdown.isOptionListDynamic()) {
+    return;
+  }
+
+  const options = dropdown.getOptions();
+  for (const option of options) {
+    if (option === FieldDropdown.SEPARATOR) continue;
+
+    const [, key] = option;
+    if (lookupTable[key] === undefined) {
+      console.warn(
+        `No tooltip mapping for value ${key} of field ` +
+          `${dropdownName} of block type ${block.type}.`,
+      );
+    }
+  }
+}
+
 fieldRegistry.register('field_dropdown', FieldDropdown);
+Extensions.setDropdownOptionsChecker(checkOptionsInTable);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details


### Proposed Changes

This moves `checkDropdownOptionsInTable` out of `Extensions` and into `FieldDropdown`. `Extensions` now includes a setter for this checker so that the field can provide its own. `field_dropdown.ts` now registers the checker once at module initialization time .Subclasses like `FieldVariable`, `FieldGridDropdown`, and `FieldDependentDropdown` should not need updating. 
An error is thrown just in case an application somehow uses the extension without ever importing `field_dropdown.ts` or installing a custom checker.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

The current dependency chain is problematic. As part of https://github.com/RaspberryPiFoundation/blockly/issues/1276, I expect to need to be able to value `import {BlockSvg}`. The parent `Block` imports `Extensions`, which means there's a potential for circular dependency. Given that this checker is strictly used for dropdown fields, moving it out feels like a reasonable way around this issue.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Manually confirmed that tooltips are still shown and nothing is thrown. All tests continue to pass.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
