### PR TITLE
feat: Allow unsetting a custom tooltip

### DIFF
--- a/packages/blockly/core/tooltip.ts
+++ b/packages/blockly/core/tooltip.ts
@@ -40,9 +40,10 @@ let customTooltip: CustomTooltip | undefined = undefined;
  * Sets a custom function that will be called if present instead of the default
  * tooltip UI.
  *
- * @param customFn A custom tooltip used to render an alternate tooltip UI.
+ * @param customFn A custom tooltip used to render an alternate tooltip UI, or
+ *     undefined to use the default implementation.
  */
-export function setCustomTooltip(customFn: CustomTooltip) {
+export function setCustomTooltip(customFn: CustomTooltip | undefined) {
   customTooltip = customFn;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR updates the types on `Tooltip.setCustomTooltip()` to allow for `undefined`, which reverts to the default implementation. This was always possible, but during the TS conversion it was inadvertently prohibited.

### Reason for Changes
We allow setting custom tooltips, and we should allow undoing that as well. This is also needed for test teardown.