### PR TITLE
fix: Prevent registering a keyboard shortcut under the same key combo multiple times

### DIFF
--- a/packages/blockly/core/shortcut_registry.ts
+++ b/packages/blockly/core/shortcut_registry.ts
@@ -29,8 +29,8 @@ export class ShortcutRegistry {
   /** Registry of all keyboard shortcuts, keyed by name of shortcut. */
   private shortcuts = new Map<string, KeyboardShortcut>();
 
-  /** Map of key codes to an array of shortcut names. */
-  private keyMap = new Map<string, string[]>();
+  /** Map of key codes to a set of shortcut names. */
+  private keyMap = new Map<string, Set<string>>();
 
   /** Resets the existing ShortcutRegistry singleton. */
   private constructor() {
@@ -115,12 +115,14 @@ export class ShortcutRegistry {
     const shortcutNames = this.keyMap.get(keyCode);
     if (shortcutNames && !allowCollision) {
       throw new Error(
-        `Shortcut named "${shortcutName}" collides with shortcuts "${shortcutNames}"`,
+        `Shortcut named "${shortcutName}" collides with shortcuts "${[
+          ...shortcutNames,
+        ]}"`,
       );
     } else if (shortcutNames && allowCollision) {
-      shortcutNames.unshift(shortcutName);
+      this.keyMap.set(keyCode, new Set([shortcutName, ...shortcutNames]));
     } else {
-      this.keyMap.set(keyCode, [shortcutName]);
+      this.keyMap.set(keyCode, new Set([shortcutName]));
     }
   }
 
@@ -152,10 +154,8 @@ export class ShortcutRegistry {
       return false;
     }
 
-    const shortcutIdx = shortcutNames.indexOf(shortcutName);
-    if (shortcutIdx > -1) {
-      shortcutNames.splice(shortcutIdx, 1);
-      if (shortcutNames.length === 0) {
+    if (shortcutNames.delete(shortcutName)) {
+      if (shortcutNames.size === 0) {
         this.keyMap.delete(keyCode);
       }
       return true;
@@ -190,7 +190,7 @@ export class ShortcutRegistry {
   setKeyMap(newKeyMap: {[key: string]: string[]}) {
     this.keyMap.clear();
     for (const key in newKeyMap) {
-      this.keyMap.set(key, newKeyMap[key]);
+      this.keyMap.set(key, new Set(newKeyMap[key]));
     }
   }
 
@@ -202,7 +202,7 @@ export class ShortcutRegistry {
   getKeyMap(): {[key: string]: string[]} {
     const legacyKeyMap: {[key: string]: string[]} = Object.create(null);
     for (const [key, value] of this.keyMap) {
-      legacyKeyMap[key] = value;
+      legacyKeyMap[key] = [...value];
     }
     return legacyKeyMap;
   }
@@ -280,7 +280,8 @@ export class ShortcutRegistry {
   getShortcutNamesByKeyCode(keyCode: string): string[] | undefined {
     // Copy the list of shortcuts in case one of them unregisters itself
     // in its callback.
-    return this.keyMap.get(keyCode)?.slice() || [];
+    const shortcutNames = this.keyMap.get(keyCode);
+    return shortcutNames ? [...shortcutNames] : [];
   }
 
   /**
@@ -293,8 +294,7 @@ export class ShortcutRegistry {
   getKeyCodesByShortcutName(shortcutName: string): string[] {
     const keys = [];
     for (const [keyCode, shortcuts] of this.keyMap) {
-      const shortcutIdx = shortcuts.indexOf(shortcutName);
-      if (shortcutIdx > -1) {
+      if (shortcuts.has(shortcutName)) {
         keys.push(keyCode);
       }
     }

--- a/packages/blockly/tests/mocha/shortcut_registry_test.js
+++ b/packages/blockly/tests/mocha/shortcut_registry_test.js
@@ -94,6 +94,23 @@ suite('Keyboard Shortcut Registry Test', function () {
       };
       assert.doesNotThrow(shouldNotThrow);
     });
+    test('Registering a shortcut multiple times under the same keycode is idempotent', function () {
+      const testShortcut = {
+        'name': 'test_shortcut',
+        'keyCodes': ['65', '65', '65'],
+        allowCollision: true,
+      };
+
+      this.registry.register(testShortcut, true);
+      this.registry.register(testShortcut, true);
+      this.registry.register(testShortcut, true);
+
+      assert.lengthOf(this.registry.getKeyMap()['65'], 1);
+
+      this.registry.unregister('test_shortcut');
+
+      assert.isUndefined(this.registry.getKeyMap()['65']);
+    });
   });
 
   suite('Unregistering', function () {


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR converts the `ShortcutRegistry`'s internal store of keycodes to shortcut names to use a set of shortcut names rather than an array. This prevents a bug that allowed registering the same shortcut under the same key combo multiple times. This does not affect registering the same shortcut under multiple key combos, or multiple shortcuts under the same combo, both of which remain supported.

This surfaced IRL in the KeyboardMover's placeholder shortcut that ends a move which is registered under all existing keyboard shortcuts. There are two shortcuts mapped to Page Up, one for navigating stacks and the other for navigating toolbox/flyout sections. This caused the placeholder shortcut to be registered under Page Up twice, which is nonsensical and caused problems for test teardown.

### Test Coverage
I added a test to verify that registering a shortcut multiple times with the same key combo listed multiple times results in only 1 entry in the registry, and that that failed before this change.