### PR TITLE
fix: Fix exception when disposing blocks with focused connections

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -896,8 +896,14 @@ export class BlockSvg
     }
 
     const focusManager = getFocusManager();
-    const focusedElement =
-      focusManager.getFocusedNode()?.getFocusableElement() ?? null;
+    let focusedElement: Element | null;
+    try {
+      // This can throw for a focused connection.
+      focusedElement =
+        focusManager.getFocusedNode()?.getFocusableElement() ?? null;
+    } catch {
+      focusedElement = null;
+    }
 
     super.dispose(!!healStack);
     dom.removeNode(this.svgGroup);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes an exception when disposing of a block stack with a focused connection in it. `RenderedConnection.getFocusableElement()` throws if the connection's highlight element doesn't exist, and if a block stack is disposed, subsequent blocks in the stack will attempt to access the focused connection's focusable element after the block that owns the connection has been disposed and removed the child connection's element from the DOM.