### PR TITLE
test: Fix several flaky tests

### DIFF
--- a/packages/blockly/tests/mocha/aria_test.js
+++ b/packages/blockly/tests/mocha/aria_test.js
@@ -130,7 +130,7 @@ suite('ARIA', function () {
       block.startDrag();
       this.clock.tick(11);
       const initialAnnouncementText = this.liveRegion.textContent;
-      assert.equal(initialAnnouncementText, 'Moving default on workspace.');
+      assert.include(initialAnnouncementText, 'Moving default on workspace.');
 
       block.drag(new Blockly.utils.Coordinate(startLoc.x + 20, startLoc.y));
       block.drag(new Blockly.utils.Coordinate(startLoc.x + 40, startLoc.y));

--- a/packages/blockly/tests/mocha/blocks/procedures_test.js
+++ b/packages/blockly/tests/mocha/blocks/procedures_test.js
@@ -695,6 +695,8 @@ suite('Procedures', function () {
         .connection.connect(paramBlock1.previousConnection);
       paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
       this.clock.runAll();
+      await Blockly.renderManagement.finishQueuedRenders();
+      this.clock.runAll();
 
       // Reorder the parameters.
       paramBlock2.previousConnection.disconnect();
@@ -704,13 +706,16 @@ suite('Procedures', function () {
         .connection.connect(paramBlock2.previousConnection);
       paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
       this.clock.runAll();
+      await Blockly.renderManagement.finishQueuedRenders();
+      this.clock.runAll();
 
       assert.isNotNull(
         defBlock.getField('PARAMS'),
         'Expected the params field to exist',
       );
-      assert.isTrue(
-        defBlock.getFieldValue('PARAMS').includes('param2, param1'),
+      assert.include(
+        defBlock.getFieldValue('PARAMS'),
+        'param2, param1',
         'Expected the params field order to match the parameter order',
       );
     });
@@ -732,6 +737,8 @@ suite('Procedures', function () {
         .connection.connect(paramBlock1.previousConnection);
       paramBlock1.nextConnection.connect(paramBlock2.previousConnection);
       this.clock.runAll();
+      await Blockly.renderManagement.finishQueuedRenders();
+      this.clock.runAll();
 
       // Reorder the parameters.
       paramBlock2.previousConnection.disconnect();
@@ -740,6 +747,8 @@ suite('Procedures', function () {
         .getInput('STACK')
         .connection.connect(paramBlock2.previousConnection);
       paramBlock2.nextConnection.connect(paramBlock1.previousConnection);
+      this.clock.runAll();
+      await Blockly.renderManagement.finishQueuedRenders();
       this.clock.runAll();
 
       assert.isNotNull(

--- a/packages/blockly/tests/mocha/dropdowndiv_test.js
+++ b/packages/blockly/tests/mocha/dropdowndiv_test.js
@@ -176,6 +176,7 @@ suite('DropDownDiv', function () {
 
   suite('show()', function () {
     test('without bounds set throws error', function () {
+      Blockly.DropDownDiv.setBoundsElement(null);
       const block = this.setUpBlockWithField();
       const field = Array.from(block.getFields())[0];
 

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -51,6 +51,7 @@ suite('Keyboard-driven movement', function () {
   });
 
   teardown(function () {
+    Blockly.KeyboardMover.mover.setMoveDistance(20);
     sharedTestTeardown.call(this);
   });
 
@@ -1217,7 +1218,6 @@ suite('Keyboard-driven movement', function () {
                   this.strategy.cacheAllConnectionPairs();
 
                   moveRight(this.workspace);
-                  console.log(getConnectionCandidate());
                   assert.deepEqual(getConnectionCandidate(), {
                     id: 'join0',
                     index: 2,
@@ -1225,7 +1225,6 @@ suite('Keyboard-driven movement', function () {
                   });
 
                   moveRight(this.workspace);
-                  console.log(getConnectionCandidate());
                   assert.deepEqual(getConnectionCandidate(), {
                     id: 'join0',
                     index: 3,

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -2219,11 +2219,6 @@ suite('Keyboard Shortcut Items', function () {
 
   suite('Jump shortcuts', function () {
     setup(function () {
-      this.getFocusedNodeStub = sinon.stub(
-        Blockly.getFocusManager(),
-        'getFocusedNode',
-      );
-      this.focusNodeSpy = sinon.stub(Blockly.getFocusManager(), 'focusNode');
       Blockly.serialization.workspaces.load(blockJson, this.workspace);
     });
 
@@ -2252,210 +2247,204 @@ suite('Keyboard Shortcut Items', function () {
 
     test('Home focuses current block if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      this.getFocusedNodeStub.returns(inListBlock);
+      Blockly.getFocusManager().focusNode(inListBlock);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
     });
 
     test('Home focuses owning block if field is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
     });
 
     test('End focuses last input on owning block', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
       const expectedFocus = inListBlock.getInput('AT').connection;
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('End has no effect if block has no inputs', function () {
       const textBlock = this.workspace.getBlockById('text_1');
-      this.getFocusedNodeStub.returns(textBlock);
+      Blockly.getFocusManager().focusNode(textBlock);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
-      sinon.assert.notCalled(this.focusNodeSpy);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), textBlock);
     });
 
     test('CtrlHome focuses top block in workspace if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      this.getFocusedNodeStub.returns(inListBlock);
+      Blockly.getFocusManager().focusNode(inListBlock);
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
     });
 
     test('CtrlHome focuses top block in workspace if field is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
     });
 
     test('CtrlHome focuses top block in workspace if workspace is focused', function () {
-      this.getFocusedNodeStub.returns(this.workspace);
+      Blockly.getFocusManager().focusNode(this.workspace);
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
     });
 
     test('CtrlEnd focuses last block in workspace if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      this.getFocusedNodeStub.returns(inListBlock);
+      Blockly.getFocusManager().focusNode(inListBlock);
       const lastBlock = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), lastBlock);
     });
 
     test('CtrlEnd focuses last block in workspace if field is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       const lastBlock = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), lastBlock);
     });
 
     test('CtrlEnd focuses last block in workspace if workspace is focused', function () {
-      this.getFocusedNodeStub.returns(this.workspace);
+      Blockly.getFocusManager().focusNode(this.workspace);
       const lastBlock = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), lastBlock);
     });
 
     test('PageUp focuses on first block in stack', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_UP),
       );
       const expectedFocus = this.workspace.getBlockById('controls_repeat_1');
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('PageDown focuses on last block in stack with nested row blocks', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
       );
       const expectedFocus = this.workspace.getBlockById('math_number_2');
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('PageDown focuses on last block in stack with many stack blocks', function () {
       const blockToFocus = this.workspace.getBlockById('text_1');
-      this.getFocusedNodeStub.returns(blockToFocus);
+      Blockly.getFocusManager().focusNode(blockToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
       );
       const expectedFocus = this.workspace.getBlockById('text_2');
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     suite('in flyout', function () {
+      setup(function () {
+        this.workspace.getToolbox().selectItemByPosition(0);
+        this.flyoutWorkspace = this.workspace.getFlyout().getWorkspace();
+        const flyoutItems = [
+          ...this.flyoutWorkspace
+            .getNavigator()
+            .getNavigableItems(this.flyoutWorkspace.getRootFocusableNode()),
+        ];
+        this.firstFlyoutItem = flyoutItems[0];
+        this.lastFlyoutItem = flyoutItems[flyoutItems.length - 1];
+        assert.notEqual(this.firstFlyoutItem, this.lastFlyoutItem);
+      });
+
       test('Home has no effect', function () {
-        this.workspace.internalIsFlyout = true;
-        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(this.lastFlyoutItem);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
+        assert.equal(
+          Blockly.getFocusManager().getFocusedNode(),
+          this.lastFlyoutItem,
+        );
       });
       test('End has no effect', function () {
-        this.workspace.internalIsFlyout = true;
-        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(this.firstFlyoutItem);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END),
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
+        assert.equal(
+          Blockly.getFocusManager().getFocusedNode(),
+          this.firstFlyoutItem,
+        );
       });
-      test('CtrlHome focuses top block in flyout workspace', function () {
-        this.workspace.internalIsFlyout = true;
-        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
-        const topBlock = this.workspace.getBlockById('controls_repeat_1');
+      test('CtrlHome focuses top item in flyout workspace', function () {
+        Blockly.getFocusManager().focusNode(this.lastFlyoutItem);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
             Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
-        sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+        assert.equal(
+          Blockly.getFocusManager().getFocusedNode(),
+          this.firstFlyoutItem,
+        );
       });
-      test('CtrlEnd focuses last block in flyout workspace', function () {
-        this.workspace.internalIsFlyout = true;
-        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
-        const lastBlock = this.workspace.getBlockById('text_2');
+      test('CtrlEnd focuses last item in flyout workspace', function () {
+        Blockly.getFocusManager().focusNode(this.firstFlyoutItem);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END, [
             Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
-        sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
-      });
-      // Page Up and Page Down page through flyout items instead of jumping
-      // between stacks, which flyouts do not have. The paging behaviour itself
-      // is covered by keyboard_navigation_test.js, against a real flyout.
-      test('PageUp does not jump to the top of a stack', function () {
-        this.workspace.internalIsFlyout = true;
-        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
-        this.injectionDiv.dispatchEvent(
-          createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_UP),
+        assert.equal(
+          Blockly.getFocusManager().getFocusedNode(),
+          this.lastFlyoutItem,
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
-      });
-      test('PageDown does not jump to the bottom of a stack', function () {
-        this.workspace.internalIsFlyout = true;
-        const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
-        this.injectionDiv.dispatchEvent(
-          createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
-        );
-        sinon.assert.notCalled(this.focusNodeSpy);
       });
     });
   });

--- a/packages/blockly/tests/mocha/shortcut_registry_test.js
+++ b/packages/blockly/tests/mocha/shortcut_registry_test.js
@@ -24,6 +24,7 @@ suite('Keyboard Shortcut Registry Test', function () {
     this.registry.reset();
     Blockly.ShortcutItems.registerDefaultShortcuts();
     Blockly.ShortcutItems.registerKeyboardNavigationShortcuts();
+    Blockly.ShortcutItems.registerScreenReaderShortcuts();
   });
 
   suite('Registering', function () {

--- a/packages/blockly/tests/mocha/tooltip_test.js
+++ b/packages/blockly/tests/mocha/tooltip_test.js
@@ -45,6 +45,7 @@ suite('Tooltip', function () {
     });
 
     teardown(function () {
+      Blockly.Tooltip.setCustomTooltip(undefined);
       workspaceTeardown.call(this, this.renderedWorkspace);
     });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR resolves various leaked state and potentially invalid assertions in the test suite that could cause flakes. These were identified with LLM assistance and manually reviewed. The shortcut items test was flaky, but it was best resolved by using the real focus manager instead of a stub, so the changes there are more extensive but also make the test more robust. I did remove two tests from it that weren't doing anything useful, for Page Up/Down in a flyout; since child blocks can't be focused in a flyout, you can't set up a scenario to test that they don't attempt to focus the root/end of the stack, and as the comment used to note, assertions about what they *do* do are tested elsewhere.