### PR TITLE
test: Remove logspam when running test suite

### DIFF
--- a/packages/blockly/core/clipboard/block_paster.ts
+++ b/packages/blockly/core/clipboard/block_paster.ts
@@ -61,9 +61,10 @@ export class BlockPaster implements IPaster<BlockCopyData, BlockSvg> {
     // Sometimes there's a delay before the block is fully created and ready for
     // focusing, so wait slightly before focusing the newly pasted block.
     const nodeToFocus: IFocusableNode = block;
-    renderManagement
-      .finishQueuedRenders()
-      .then(() => getFocusManager().focusNode(nodeToFocus));
+    renderManagement.finishQueuedRenders().then(() => {
+      if (block.isDeadOrDying()) return;
+      getFocusManager().focusNode(nodeToFocus);
+    });
     return block;
   }
 }

--- a/packages/blockly/core/field_input.ts
+++ b/packages/blockly/core/field_input.ts
@@ -819,9 +819,10 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
       const block = this.getSourceBlock();
       if (!block) throw new UnattachedFieldError();
       const div = WidgetDiv.getDiv();
+      if (!div) return;
       const bBox = this.getScaledBBox();
-      div!.style.width = bBox.right - bBox.left + 'px';
-      div!.style.height = bBox.bottom - bBox.top + 'px';
+      div.style.width = bBox.right - bBox.left + 'px';
+      div.style.height = bBox.bottom - bBox.top + 'px';
 
       // In RTL mode block fields and LTR input fields the left edge moves,
       // whereas the right edge is fixed.  Reposition the editor.
@@ -835,8 +836,8 @@ export abstract class FieldInput<T extends InputTypes> extends Field<
         y -= bounds.top + window.scrollY;
       }
 
-      div!.style.left = `${x}px`;
-      div!.style.top = `${y}px`;
+      div.style.left = `${x}px`;
+      div.style.top = `${y}px`;
     });
   }
 

--- a/packages/blockly/core/workspace_audio.ts
+++ b/packages/blockly/core/workspace_audio.ts
@@ -90,6 +90,7 @@ export class WorkspaceAudio {
     const sound = this.sounds.get(name);
     if (sound) {
       await this.prepareToPlay();
+      if (this.context.state !== 'running') return;
 
       const source = this.context.createBufferSource();
       const gainNode = this.context.createGain();
@@ -122,6 +123,7 @@ export class WorkspaceAudio {
   async beep(tone: number, duration = 0.2) {
     if (!this.isPlayingAllowed()) return;
     await this.prepareToPlay();
+    if (this.context.state !== 'running') return;
 
     const oscillator = this.context.createOscillator();
     oscillator.type = 'sine';
@@ -209,7 +211,10 @@ export class WorkspaceAudio {
   ) {
     this.lastSound = new Date();
 
-    if (this.context.state === 'suspended') {
+    if (
+      this.context.state === 'suspended' &&
+      navigator.userActivation.hasBeenActive
+    ) {
       await this.context.resume();
     }
   }

--- a/packages/blockly/tests/mocha/block_test.js
+++ b/packages/blockly/tests/mocha/block_test.js
@@ -1500,9 +1500,16 @@ suite('Blocks', function () {
       teardown(function () {
         workspaceTeardown.call(this, this.workspace);
 
-        Blockly.icons.registry.unregister(
-          Blockly.icons.IconType.COMMENT.toString(),
-        );
+        if (
+          Blockly.registry.hasItem(
+            Blockly.registry.Type.ICON,
+            Blockly.icons.IconType.COMMENT.toString(),
+          )
+        ) {
+          Blockly.icons.registry.unregister(
+            Blockly.icons.IconType.COMMENT.toString(),
+          );
+        }
         Blockly.icons.registry.register(
           Blockly.icons.IconType.COMMENT,
           Blockly.icons.CommentIcon,

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -46,7 +46,9 @@ suite('Keyboard-driven movement', function () {
       ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
     });
-    Blockly.common.defineBlocks(p5blocks);
+    if (!('p5_setup' in Blockly.Blocks)) {
+      Blockly.common.defineBlocks(p5blocks);
+    }
     Blockly.KeyboardMover.mover.setMoveDistance(20);
   });
 

--- a/packages/blockly/tests/mocha/keyboard_movement_test.js
+++ b/packages/blockly/tests/mocha/keyboard_movement_test.js
@@ -46,14 +46,15 @@ suite('Keyboard-driven movement', function () {
       ...DEFAULT_INJECT_OPTIONS,
       toolbox: toolbox,
     });
-    if (!('p5_setup' in Blockly.Blocks)) {
-      Blockly.common.defineBlocks(p5blocks);
-    }
+    Blockly.common.defineBlocks(p5blocks);
     Blockly.KeyboardMover.mover.setMoveDistance(20);
   });
 
   teardown(function () {
     Blockly.KeyboardMover.mover.setMoveDistance(20);
+    for (const block of Object.keys(p5blocks)) {
+      delete Blockly.Blocks[block];
+    }
     sharedTestTeardown.call(this);
   });
 

--- a/packages/blockly/tests/mocha/keyboard_navigation_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_test.js
@@ -139,7 +139,9 @@ suite('Keyboard navigation on Blocks', function () {
       toolbox: toolbox,
       renderer: 'zelos',
     });
-    Blockly.common.defineBlocks(p5blocks);
+    if (!('p5_setup' in Blockly.Blocks)) {
+      Blockly.common.defineBlocks(p5blocks);
+    }
     Blockly.serialization.workspaces.load(navigationTestBlocks, this.workspace);
     for (const block of this.workspace.getAllBlocks()) {
       block.initSvg();
@@ -415,7 +417,9 @@ suite('Keyboard navigation on Fields', function () {
       toolbox: toolbox,
       renderer: 'zelos',
     });
-    Blockly.common.defineBlocks(p5blocks);
+    if (!('p5_setup' in Blockly.Blocks)) {
+      Blockly.common.defineBlocks(p5blocks);
+    }
     Blockly.serialization.workspaces.load(navigationTestBlocks, this.workspace);
   });
 
@@ -482,7 +486,9 @@ suite('Workspace comment navigation', function () {
       toolbox: toolbox,
       renderer: 'zelos',
     });
-    Blockly.common.defineBlocks(p5blocks);
+    if (!('p5_setup' in Blockly.Blocks)) {
+      Blockly.common.defineBlocks(p5blocks);
+    }
     Blockly.serialization.workspaces.load(navigationTestBlocks, this.workspace);
     this.workspace.getTopBlocks(false).forEach((b) => b.queueRender());
     Blockly.renderManagement.triggerQueuedRenders(this.workspace);

--- a/packages/blockly/tests/mocha/keyboard_navigation_test.js
+++ b/packages/blockly/tests/mocha/keyboard_navigation_test.js
@@ -139,9 +139,7 @@ suite('Keyboard navigation on Blocks', function () {
       toolbox: toolbox,
       renderer: 'zelos',
     });
-    if (!('p5_setup' in Blockly.Blocks)) {
-      Blockly.common.defineBlocks(p5blocks);
-    }
+    Blockly.common.defineBlocks(p5blocks);
     Blockly.serialization.workspaces.load(navigationTestBlocks, this.workspace);
     for (const block of this.workspace.getAllBlocks()) {
       block.initSvg();
@@ -150,6 +148,9 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   teardown(function () {
+    for (const block of Object.keys(p5blocks)) {
+      delete Blockly.Blocks[block];
+    }
     sharedTestTeardown.call(this);
   });
 
@@ -417,13 +418,14 @@ suite('Keyboard navigation on Fields', function () {
       toolbox: toolbox,
       renderer: 'zelos',
     });
-    if (!('p5_setup' in Blockly.Blocks)) {
-      Blockly.common.defineBlocks(p5blocks);
-    }
+    Blockly.common.defineBlocks(p5blocks);
     Blockly.serialization.workspaces.load(navigationTestBlocks, this.workspace);
   });
 
   teardown(function () {
+    for (const block of Object.keys(p5blocks)) {
+      delete Blockly.Blocks[block];
+    }
     sharedTestTeardown.call(this);
   });
 
@@ -486,9 +488,7 @@ suite('Workspace comment navigation', function () {
       toolbox: toolbox,
       renderer: 'zelos',
     });
-    if (!('p5_setup' in Blockly.Blocks)) {
-      Blockly.common.defineBlocks(p5blocks);
-    }
+    Blockly.common.defineBlocks(p5blocks);
     Blockly.serialization.workspaces.load(navigationTestBlocks, this.workspace);
     this.workspace.getTopBlocks(false).forEach((b) => b.queueRender());
     Blockly.renderManagement.triggerQueuedRenders(this.workspace);
@@ -506,6 +506,9 @@ suite('Workspace comment navigation', function () {
   });
 
   teardown(function () {
+    for (const block of Object.keys(p5blocks)) {
+      delete Blockly.Blocks[block];
+    }
     sharedTestTeardown.call(this);
   });
 

--- a/packages/blockly/tests/mocha/render_management_test.js
+++ b/packages/blockly/tests/mocha/render_management_test.js
@@ -6,6 +6,7 @@
 
 import {assert} from 'chai';
 import {
+  DEFAULT_INJECT_OPTIONS,
   sharedTestSetup,
   sharedTestTeardown,
   workspaceTeardown,
@@ -130,7 +131,7 @@ suite('Render Management', function () {
 
   suite('Post-render bumpNeighbours', function () {
     setup(function () {
-      this.workspace = Blockly.inject('blocklyDiv', {});
+      this.workspace = Blockly.inject('blocklyDiv', DEFAULT_INJECT_OPTIONS);
 
       this.block = this.workspace.newBlock('controls_if');
       this.block.initSvg();

--- a/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
+++ b/packages/blockly/tests/mocha/test_helpers/setup_teardown.js
@@ -23,6 +23,7 @@ const TEST_MEDIA_PATH = '../../media/';
  */
 export const DEFAULT_INJECT_OPTIONS = Object.freeze({
   media: TEST_MEDIA_PATH,
+  scrollbars: true,
 });
 
 /**
@@ -186,6 +187,16 @@ export function sharedTestTeardown(workspace = this.workspace) {
     console.error('"' + testRef.fullTitle() + '" did not call sharedTestSetup');
   }
 
+  // Remove the globally registered listener from FocusManager to avoid state
+  // being shared across test boundaries.
+  for (const registeredListener of this.globalDocumentEventListeners) {
+    document.removeEventListener(
+      registeredListener.type,
+      registeredListener.listener,
+    );
+  }
+  this.globalDocumentEventListeners = [];
+
   try {
     if (workspace) {
       workspaceTeardown.call(this, workspace);
@@ -230,14 +241,6 @@ export function sharedTestTeardown(workspace = this.workspace) {
 
     Blockly.WidgetDiv.testOnly_setDiv(null);
 
-    // Remove the globally registered listener from FocusManager to avoid state
-    // being shared across test boundaries.
-    for (const registeredListener of this.globalDocumentEventListeners) {
-      const eventType = registeredListener.type;
-      const eventListener = registeredListener.listener;
-      document.removeEventListener(eventType, eventListener);
-    }
-    this.globalDocumentEventListeners = [];
     FocusManager.getFocusManager = this.oldGetFocusManager;
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR avoids several thousand lines of errors and warnings in the devtools console when running the Mocha test suite. There are now less than a dozen warnings from when tests actually try to do naughty things.

These changes fall into several buckets:
* Only register the p5 blocks once
* Make the test workspace scrollable to avoid lots of whining from the bumpIntoBounds handler about events not having groups during teardown
* Check if unregistering is actually needed during test teardown
* Move up the shared event listener teardown to before workspace teardown

There are also a few core changes. While these mostly show up in a test context, they all could happen during actual use, so I think the changes are justified:

* The block paster focuses the pasted block after a delay, and now checks to make sure that it hasn't been disposed of in between pasting and that callback firing
* `FieldInput.resizeEditor_` is more defensive instead of force unwrapping the `WidgetDiv`
* The `WorkspaceAudio` manager is more defensive and only attempts to play audio when not suspended by the browser


### Reason for Changes
Less logspam makes debugging new tests easier and increases the likelihood that important log messages from the test suite are noticed and acted upon.
