### PR TITLE
chore: add advanced playground back to github pages

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Npm Clean Install
+        run: npm ci
+
       - name: Update GitHub Pages
         working-directory: ./packages/blockly
         run: npm run updateGithubPages:staging

--- a/package-lock.json
+++ b/package-lock.json
@@ -38411,9 +38411,11 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/block-test": "^13.1.0",
+        "@blockly/dev-tools": "^13.1.0",
+        "@blockly/theme-modern": "^13.1.0",
         "@hyperjump/browser": "^1.3.1",
         "@hyperjump/json-schema": "^1.17.6",
-        "@microsoft/api-documenter": "^7.30.13",
+        "@microsoft/api-documenter": "7.30.13",
         "@microsoft/api-extractor": "^7.58.9",
         "async-done": "^2.0.0",
         "chai": "^6.2.2",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -29,7 +29,9 @@
   },
   "nx": {
     "implicitDependencies": [
-      "!@blockly/block-test"
+      "!@blockly/block-test",
+      "!@blockly/dev-tools",
+      "!@blockly/theme-modern"
     ],
     "targets": {
       "build": {
@@ -55,6 +57,18 @@
           "package",
           "^build"
         ]
+      },
+      "start": {
+        "dependsOn": [
+          {
+            "projects": "@blockly/dev-tools",
+            "target": "build"
+          },
+          {
+            "projects": "@blockly/theme-modern",
+            "target": "build"
+          }
+        ]      
       }
     }
   },
@@ -75,7 +89,9 @@
     "minify": "gulp minify",
     "package": "gulp pack",
     "prepareDemos": "gulp prepareDemos",
-    "start": "npm run package && npx nx run @blockly/dev-tools:build && concurrently -n watch,devtools-server,core-server \"npx nx watch --projects=@blockly/dev-tools --includeDependencies -- npm run build\" \"npx nx run @blockly/dev-tools:start --no-open\" \"http-server ./ -p 8081 -s -o /tests/playground.html -c-1\"",
+    "start": "npm run package && nx run @blockly/dev-tools:build && node \"scripts/prepare_advanced_playground.mjs\" && concurrently -n devtools-watch,blockly-watch,server \"nx watch --projects=@blockly/dev-tools --includeDependencies -- nx run rebuildAdvancedPlayground\" \"nx watch --projects=blockly -- nx run rebuildBlockly\" \"http-server ./ -s -o /tests/playground.html -c-1\"",
+    "rebuildAdvancedPlayground": "npm run build --workspace=@blockly/dev-tools && node \"scripts/prepare_advanced_playground.mjs\"",
+    "rebuildBlockly": "npm run build && node \"scripts/prepare_advanced_playground.mjs\"",
     "tsc": "gulp tsc",
     "test": "gulp test",
     "test:browser": "npx mocha --config tests/browser/.mocharc.js",
@@ -138,6 +154,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@blockly/block-test": "^13.1.0",
+    "@blockly/dev-tools": "^13.1.0",
+    "@blockly/theme-modern": "^13.1.0",
     "@hyperjump/browser": "^1.3.1",
     "@hyperjump/json-schema": "^1.17.6",
     "@microsoft/api-documenter": "7.30.13",

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -99,8 +99,8 @@
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && node scripts/prepare_mocha_bundle.mjs && concurrently -n tsc,esbuild,python3 \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"esbuild build/tests/bundle-entry.js --bundle --sourcemap --alias:blockly/core=./build/src/core/blockly.js --alias:blockly/blocks=./build/src/blocks/blocks.js --alias:blockly=./build/src/core/blockly.js --outfile=build/tests/mocha-bundle.js --servedir=. --serve=127.0.0.1:8080 --watch=forever --log-level=warning\" \"python3 -m webbrowser 'http://localhost:8080/tests/mocha/index.html'\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "updateGithubPages": "npm ci && node scripts/update_github_pages.mjs --upstream",
-    "updateGithubPages:staging": "npm ci && node scripts/update_github_pages.mjs --use-local"
+    "updateGithubPages": "node scripts/update_github_pages.mjs --upstream",
+    "updateGithubPages:staging": "node scripts/update_github_pages.mjs --use-local"
   },
   "exports": {
     ".": {

--- a/packages/blockly/package.json
+++ b/packages/blockly/package.json
@@ -99,8 +99,8 @@
     "test:generators": "gulp testGenerators",
     "test:mocha:interactive": "npm run build && node scripts/prepare_mocha_bundle.mjs && concurrently -n tsc,esbuild,python3 \"tsc --watch --preserveWatchOutput --outDir \"build/src\" --declarationDir \"build/declarations\"\" \"esbuild build/tests/bundle-entry.js --bundle --sourcemap --alias:blockly/core=./build/src/core/blockly.js --alias:blockly/blocks=./build/src/blocks/blocks.js --alias:blockly=./build/src/core/blockly.js --outfile=build/tests/mocha-bundle.js --servedir=. --serve=127.0.0.1:8080 --watch=forever --log-level=warning\" \"python3 -m webbrowser 'http://localhost:8080/tests/mocha/index.html'\"",
     "test:compile:advanced": "gulp buildAdvancedCompilationTest --debug",
-    "updateGithubPages": "node scripts/update_github_pages.mjs --upstream",
-    "updateGithubPages:staging": "node scripts/update_github_pages.mjs --use-local"
+    "updateGithubPages": "npm ci && node scripts/update_github_pages.mjs --upstream",
+    "updateGithubPages:staging": "npm ci && node scripts/update_github_pages.mjs --use-local"
   },
   "exports": {
     ".": {

--- a/packages/blockly/scripts/prepare_advanced_playground.mjs
+++ b/packages/blockly/scripts/prepare_advanced_playground.mjs
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Raspberry Pi Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import {BUILD_DIR} from './gulpfiles/config.mjs';
+
+/**
+ * This task bundles the modules used by the advanced playground and generates a
+ * file in build/playgrounds. This file is then bundled with the github pages
+ * and loaded into the advanced playground.
+ */
+function prepareAdvancedPlayground() {
+  const OUTPUT_DIR = path.join(BUILD_DIR, 'playgrounds');
+  // Create output directory.
+  fs.mkdirSync(OUTPUT_DIR, {recursive: true});
+  fs.mkdirSync(path.join('node_modules', '@blockly', 'dev-tools'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join('node_modules', '@blockly', 'theme-modern'), {
+    recursive: true,
+  });
+
+  const input = path.join('tests', 'playgrounds', 'advanced_playground.cjs');
+  const bundlePlaygroundCmd = `cp -R ../plugins/dev-tools/dist node_modules/@blockly/dev-tools && 
+  cp -R ../plugins/theme-modern/dist node_modules/@blockly/theme-modern && 
+  esbuild ${input} \
+  --bundle \
+  --sourcemap \
+  --outfile=${path.join(OUTPUT_DIR, 'advanced_playground.js')} \
+  --define:process.env.NODE_ENV='\"development\"'`;
+  execSync(bundlePlaygroundCmd, {stdio: 'inherit'});
+}
+
+await prepareAdvancedPlayground();

--- a/packages/blockly/scripts/update_github_pages.mjs
+++ b/packages/blockly/scripts/update_github_pages.mjs
@@ -135,6 +135,8 @@ function updateGithubPages({remote, upstream, useLocal}) {
 
   run('npm run clean');
   run('npm run build');
+  run('npx nx run @blockly/dev-tools:build');
+  run('npx nx run @blockly/theme-modern:build');
   // Build the advanced playground with its dependencies. This is not part of
   // the regular build process as it's only used for ghpages and development.
   run('node \"scripts/prepare_advanced_playground.mjs\"');

--- a/packages/blockly/scripts/update_github_pages.mjs
+++ b/packages/blockly/scripts/update_github_pages.mjs
@@ -28,7 +28,13 @@ const UPSTREAM_URL = 'git@github.com:RaspberryPiFoundation/blockly.git';
  * Extra paths to include in the gh-pages branch (beyond the normal
  * contents of main).  Passed to shell unquoted, so can include globs.
  */
-const EXTRAS = ['build/msg', 'dist/*_compressed.js*', 'build/*.loader.mjs'];
+const EXTRAS = [
+  'build/msg',
+  'build/playgrounds',
+  'dist/*_compressed.js*',
+  'node_modules/@blockly',
+  'build/*.loader.mjs',
+];
 
 const USAGE = `Usage: node scripts/update_github_pages.mjs [options]
 
@@ -129,6 +135,9 @@ function updateGithubPages({remote, upstream, useLocal}) {
 
   run('npm run clean');
   run('npm run build');
+  // Build the advanced playground with its dependencies. This is not part of
+  // the regular build process as it's only used for ghpages and development.
+  run('node \"scripts/prepare_advanced_playground.mjs\"');
 
   // Extra paths (e.g. build/, dist/ etc.) are normally gitignored,
   // so we have to force add.

--- a/packages/blockly/tests/playground.html
+++ b/packages/blockly/tests/playground.html
@@ -549,7 +549,7 @@
       <input id="show" type="button" value="Show" /> -
       <input id="hide" type="button" value="Hide" /> -
       <span class="advancedPlayground"
-        ><a href="http://localhost:8080/">Advanced</a> -</span
+        ><a href="playgrounds/advanced_playground.html">Advanced</a> -</span
       >
       <a href="playgrounds/web_component.html">Web Component</a> -
       <a href="multi_playground.html">Multi Playground</a>

--- a/packages/blockly/tests/playgrounds/advanced_playground.cjs
+++ b/packages/blockly/tests/playgrounds/advanced_playground.cjs
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Raspberry Pi Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Dependency loader for the advanced playground
+ *
+ * This loads the blockly plugins used in the advanced playground. It is bundled
+ * into build/tests/advanced_playground.js, which is loaded into the advanced
+ * playground.
+ */
+
+const blocklyDevTools = require('@blockly/dev-tools');
+const modernTheme = require('@blockly/theme-modern');
+
+globalThis.createPlayground = blocklyDevTools.createPlayground;
+globalThis.toolboxCategories = blocklyDevTools.toolboxCategories;
+globalThis.toolboxSimple = blocklyDevTools.toolboxSimple;
+globalThis.toolboxTestBlocks = blocklyDevTools.toolboxTestBlocks;
+globalThis.modernTheme = modernTheme;

--- a/packages/blockly/tests/playgrounds/advanced_playground.html
+++ b/packages/blockly/tests/playgrounds/advanced_playground.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Advanced Blockly Playground</title>
+
+    <script type="module">
+      import {loadScript} from '../scripts/load.mjs';
+
+      import * as Blockly from '../../build/blockly.loader.mjs';
+      import '../../build/blocks.loader.mjs';
+      // Generators not needed (but see also bug #6597).
+
+      await loadScript('../../build/msg/en.js');
+      await loadScript('screenshot.js');
+      await loadScript('../themes/test_themes.js');
+      await loadScript('../../node_modules/@blockly/dev-tools/dist/index.js');
+      await loadScript(
+        '../../node_modules/@blockly/theme-modern/dist/index.js',
+      );
+
+      let kbNavigation;
+
+      function start() {
+        setBackgroundColour();
+        initPlayground();
+      }
+
+      function createWorkspace(blocklyDiv, options) {
+        var workspace = Blockly.inject(blocklyDiv, options);
+        return workspace;
+      }
+
+      function configurePlayground(playground) {
+        // Rendering options.
+        var gui = playground.getGUI();
+        var renderingFolder = gui.addFolder('Rendering');
+        var renderingOptions = {
+          'font Size': 10,
+        };
+        renderingFolder
+          .add(renderingOptions, 'font Size', 0, 50)
+          .onChange(function (value) {
+            var ws = playground.getWorkspace();
+            var fontStyle = {
+              'size': value,
+            };
+            ws.getTheme().setFontStyle(fontStyle);
+            // Refresh theme.
+            ws.setTheme(ws.getTheme());
+          });
+      }
+
+      function initPlayground() {
+        if (typeof window.createPlayground === 'undefined') {
+          alert(
+            "You need to run 'npm install' in order to use this playground.",
+          );
+          return;
+        }
+        var defaultOptions = {
+          comments: true,
+          collapse: true,
+          disable: true,
+          grid: {
+            spacing: 25,
+            length: 3,
+            colour: '#ccc',
+            snap: true,
+          },
+          horizontalLayout: false,
+          maxBlocks: Infinity,
+          maxInstances: {'test_basic_limit_instances': 3},
+          maxTrashcanContents: 256,
+          media: '../../media/',
+          oneBasedIndex: true,
+          readOnly: false,
+          rtl: false,
+          move: {
+            scrollbars: true,
+            drag: true,
+            wheel: false,
+          },
+          toolbox: toolboxCategories,
+          toolboxPosition: 'start',
+          zoom: {
+            controls: true,
+            wheel: true,
+            startScale: 1.0,
+            maxScale: 4,
+            minScale: 0.25,
+            scaleSpeed: 1.1,
+          },
+        };
+
+        const playgroundConfig = {
+          toolboxes: {
+            'categories': toolboxCategories,
+            'simple': toolboxSimple,
+            'test blocks': toolboxTestBlocks,
+          },
+        };
+
+        Blockly.ContextMenuItems.registerCommentOptions();
+
+        createPlayground(
+          document.getElementById('root'),
+          createWorkspace,
+          defaultOptions,
+          playgroundConfig,
+          'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.19.2/min/vs',
+        ).then(function (playground) {
+          configurePlayground(playground);
+        });
+      }
+
+      function setBackgroundColour() {
+        // Set background colour to differentiate file: vs. localhost
+        // vs. server copy.
+        if (location.protocol == 'file:') {
+          document.body.style.backgroundColor = '#89A203'; // Unpleasant green.
+        } else if (
+          location.hostname === 'localhost' ||
+          location.hostname === '127.0.0.1' ||
+          location.hostname === '[::1]'
+        ) {
+          document.body.style.backgroundColor = '#d6d6ff'; // Familliar lilac.
+        }
+      }
+      start();
+    </script>
+
+    <style>
+      html,
+      body {
+        margin: 0;
+      }
+
+      .ioLabel > .blocklyFlyoutLabelText {
+        font-style: italic;
+      }
+
+      .playgroundToggleOptions {
+        list-style: none;
+        padding: 0;
+      }
+      .playgroundToggleOptions li {
+        margin-top: 1em;
+      }
+
+      .zelos-renderer .blocklyFlyoutButton .blocklyText {
+        font-size: 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="shortcuts"></div>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes #7769 

### Proposed Changes

Adds the advanced playground html page back into the blockly project along with the scripting needed to run it at `npm run start` as well as to build it and its dependencies for the github pages.

### Reason for Changes

The advanced playground has been broken on the github pages since we removed it temporarily while updating tooling.

