### PR TITLE
docs: update plugins page with dependabot info

### DIFF
--- a/packages/docs/docs/guides/programming/plugin_overview.mdx
+++ b/packages/docs/docs/guides/programming/plugin_overview.mdx
@@ -192,3 +192,39 @@ This will let npm install any minor version at or above the listed version, so
 version `13.3.1` or `13.2.6` works, but a new major version such as `14.0.1` would
 not. When you update to a major version of Blockly, you should update your plugins
 as well.
+
+### Keeping plugins up to date with Dependabot
+
+[Dependabot](https://github.com/dependabot) is a popular GitHub tool for 
+automatically managing dependencies. If your project is hosted on GitHub, you 
+can use Dependabot to ensure that Blockly and its plugis are updated together.
+
+To start with, your project's `dependabot.yml` file might look something like 
+this:
+
+```
+updates:
+  - package-ecosystem: 'npm' 
+    directory: '/' 
+    target-branch: 'main'
+    schedule:
+      interval: 'weekly'
+```
+
+In `dependabot.yml`, you can group Blockly and its plugins together using 
+Dependabot's [groups option](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--). 
+For example:
+
+```
+updates:
+  - package-ecosystem: 'npm' 
+    directory: '/' 
+    target-branch: 'main'
+    schedule:
+      interval: 'weekly'
+    groups:
+      blockly: # You can give this group a different name if you'd like
+        patterns:
+          - 'blockly'
+          - '@blockly/*' # You can use the wildcard (*) notation to specify any plugin
+```

--- a/packages/docs/docs/guides/programming/plugin_overview.mdx
+++ b/packages/docs/docs/guides/programming/plugin_overview.mdx
@@ -196,8 +196,8 @@ as well.
 ### Keeping plugins up to date with Dependabot
 
 [Dependabot](https://github.com/dependabot) is a popular GitHub tool for 
-automatically managing dependencies. If your project is hosted on GitHub, you 
-can use Dependabot to ensure that Blockly and its plugis are updated together.
+automated dependency updates. If your project is hosted on GitHub, you can use 
+Dependabot to ensure that Blockly and its plugins are updated together.
 
 To start with, your project's `dependabot.yml` file might look something like 
 this:


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Closes #7772
After #10240 and #10317 this finishes the documentation tasks described in #7772

### Proposed Changes

Adds info about configuring Dependabot for plugins and Blockly

### Reason for Changes

Adding dependabot info makes it easier for those who use GitHub to keep plugins and Blockly up to date

### Test Coverage

n/a

### Documentation

n/a

### Additional Information

<!-- Anything else we should know? -->
