### PR TITLE
docs: fall back to @returns label on api docs

### DIFF
--- a/packages/blockly/core/block_svg.ts
+++ b/packages/blockly/core/block_svg.ts
@@ -1455,7 +1455,6 @@ export class BlockSvg
     this.queueRender();
   }
 
-  /** @override */
   override appendInput(input: Input): Input {
     super.appendInput(input);
     this.queueRender();

--- a/packages/docs/docs/guides/contribute/core/style_guide.mdx
+++ b/packages/docs/docs/guides/contribute/core/style_guide.mdx
@@ -114,7 +114,7 @@ Annotations for functions should include
   will return a value, with a description of the returned value.
 
 Descriptions may omitted for functions, parameters, or return values if they are
-self-explanatory.
+self-explanatory. 
 
 For example:
 
@@ -129,3 +129,6 @@ export function getWorkspaceById(id: string): Workspace | null {
   return WorkspaceDB_[id] || null;
 }
 ```
+
+If you are overriding a function and would like it to inherit the parent's 
+TSDoc in the documentation, you should not include a TSDoc at all. 

--- a/packages/docs/typedoc-member-index.mjs
+++ b/packages/docs/typedoc-member-index.mjs
@@ -11,6 +11,16 @@ import { ReflectionKind } from 'typedoc';
 const INDEXED_SECTIONS = ['Properties', 'Methods'];
 
 /**
+ * Lowercases the first letter, leaving text that opens with an acronym (JSON,
+ * SVG, DOM) alone.
+ */
+function decapitalize(text) {
+  return /^[A-Z](?![A-Z])/.test(text)
+    ? text[0].toLowerCase() + text.slice(1)
+    : text;
+}
+
+/**
  * Adds Properties and Methods index tables to each generated reference page.
  *
  * This needs a custom theme because the plugin will only insert an index if we
@@ -21,6 +31,26 @@ class MemberIndexContext extends MarkdownThemeContext {
   constructor(theme, page, options) {
     super(theme, page, options);
     const base = { ...this.partials };
+    const baseHelpers = { ...this.helpers };
+
+    this.helpers = {
+      ...baseHelpers,
+      // Fall back to @returns text for index tables, if there is no description
+      getDescriptionForComment: (comment) => {
+        const description = baseHelpers.getDescriptionForComment(comment);
+        if (description) return description;
+
+        const returns = comment?.getTag('@returns');
+        if (!returns) return null;
+
+        const text = baseHelpers
+          .getCommentParts(returns.content)
+          .replace(/\r?\n/g, ' ')
+          .trim();
+
+        return text ? `Returns ${decapitalize(text)}` : null;
+      },
+    };
 
     this.partials = {
       ...base,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #7244

### Proposed Changes

Falls back to `@returns` tag for method descriptions when there isn't a description provided, but only for the methods index. 

### Reason for Changes

#7244 highlights gaps in API docs in two scenarios: 
"1. We are overriding a function - the description should be inheritted but is not.
2. We only have an @return tag with no description - the @return tag should be used as the description."

1. TypeDoc resolves the first automatically. Methods which override a parent and do not have any doc comment of their own inherit the parent's doc. The issue is when there is an existing doc tag that doesn't give information, like `@overrides` with no other information. The only case this happens in the codebase is in `block_svg.ts` which is why I removed that comment.  
2. I would argue that it doesn't make sense to use the `@returns` tag as the description when the `@returns` tag is already displayed. As-is, the documentation looks something like this when there isn't a description: 
<img width="570" height="407" alt="Screenshot 2026-09-04 at 2 18 02 PM" src="https://github.com/user-attachments/assets/012e68af-4cf5-4111-8f71-d0a362dd6541" />

IMO this looks fine and has all the necessary information. 

That said, the methods index only displays the name and description, leaving it incomplete. The changes in this PR only affect that index, so that the full description will be shown.

Before:
<img width="405" height="157" alt="Screenshot 2026-09-04 at 2 30 58 PM" src="https://github.com/user-attachments/assets/3e70035c-2663-46b5-ba11-37938dc3173f" />

After:
<img width="404" height="143" alt="Screenshot 2026-09-04 at 2 35 21 PM" src="https://github.com/user-attachments/assets/11d1cccb-d54e-4309-b271-31bbecdb6ea3" />

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

Added a line to the style guide nothing that TSDoc comments should be left out entirely if you want an overriding method to inherit the doc of the parent. 

### Additional Information

<!-- Anything else we should know? -->
