### PR TITLE
docs: fix spelling typos in .mdx docs

### DIFF
--- a/packages/docs/docs/codelabs/custom-toolbox/adding-a-custom-toolbox-item.mdx
+++ b/packages/docs/docs/codelabs/custom-toolbox/adding-a-custom-toolbox-item.mdx
@@ -81,7 +81,7 @@ In order to create a toolbox item we must implement one of the toolbox item inte
 
 For this example, we will be implementing the basic `IToolboxItem` interface.
 There are three different types of toolbox item interfaces:
-`IToolboxItem`, `ISelectableToobloxItem` and `ICollapsibleToolboxItem`.
+`IToolboxItem`, `ISelectableToolboxItem` and `ICollapsibleToolboxItem`.
 Since we do not need our label to be selectable or collapsible, we can implement
 the basic `IToolboxItem` interface.
 

--- a/packages/docs/docs/codelabs/getting-started/the-end.mdx
+++ b/packages/docs/docs/codelabs/getting-started/the-end.mdx
@@ -15,7 +15,7 @@ What you've built today is almost identical to Blocky's sample app.
 To make your own Blockly project, you can follow the instructions to install the sample app from the [sample app overview](/guides/get-started/sample-app-overview) or continue building off this codelab. 
 
 One key difference to note between this codelab and the sample app is the toolbox. 
-The sample app's toolbox is a category toolbox, which changes some of the default [configuration](/guides/configure/configuration_struct#the-options-dictionary) values discussed in the [create a Blockly workpace](/codelabs/getting-started/create-a-blockly-workspace) step. 
+The sample app's toolbox is a category toolbox, which changes some of the default [configuration](/guides/configure/configuration_struct#the-options-dictionary) values discussed in the [create a Blockly workspace](/codelabs/getting-started/create-a-blockly-workspace) step. 
 For instance, when using a category toolbox, the `scrollbars` option will default to `true`, making scrollbars appear on the workspace automatically. 
 
 The sample app also includes *all* of Blockly's built-in blocks. We strongly recommend against using every built-in block in your toolbox. Instead, you should carefully select the blocks that your users may need. 

--- a/packages/docs/docs/guides/app-integration/attribution.mdx
+++ b/packages/docs/docs/guides/app-integration/attribution.mdx
@@ -58,7 +58,7 @@ To give Blockly attribution in your app or website, please use one of the
 following logos, depending on background color:
 
 <table>
-  <theader>
+  <thead>
     <tr>
       <th style={{ backgroundColor: 'white' }}>
         <Image
@@ -75,7 +75,7 @@ following logos, depending on background color:
         />
       </th>
     </tr>
-  </theader>
+  </thead>
   <tbody>
     <tr>
       <td>

--- a/packages/docs/docs/guides/configure/dragging/draggable.mdx
+++ b/packages/docs/docs/guides/configure/dragging/draggable.mdx
@@ -201,7 +201,7 @@ other systems in Blockly.
 
 ### Deletable
 
-You can implement the [`IDeleteable`][IDeletable] interface to allow your
+You can implement the [`IDeletable`][IDeletable] interface to allow your
 draggable to be disposed by the trashcan or other delete targets.
 
 ```js

--- a/packages/docs/docs/guides/configure/keyboard-shortcuts.mdx
+++ b/packages/docs/docs/guides/configure/keyboard-shortcuts.mdx
@@ -159,7 +159,7 @@ This is not common.
 If your keyboard shortcut is activated by a combination of keys, such as holding
 `Control` and `C` simultaneously, create a serialized keycode by calling
 `Blockly.ShortcutRegistry.registry.createSerializedKey`. On Windows and Linux 
-many shortcuts are activated with the `Control` key. On Apple plaforms these
+many shortcuts are activated with the `Control` key. On Apple platforms these
 keyboard shortcuts use the `Command` key instead. Register your shortcuts with 
 the `CTRL_CMD` keycode whenever you want your shortcut to use the system's 
 primary modifier key. Blockly will map the key combination appropriately.

--- a/packages/docs/docs/guides/configure/metrics_manager.mdx
+++ b/packages/docs/docs/guides/configure/metrics_manager.mdx
@@ -91,7 +91,7 @@ workspace the top and left position of the viewport are updated.
 `workspace.getMetricsManager().getAbsoluteMetrics();`
 
 The absolute metrics are composed of the `top` and `left` offset of the viewport
-from the pareng SVG. Depending on where the toolbox is positioned on the
+from the parent SVG. Depending on where the toolbox is positioned on the
 workspace, this is usually the width or height of the toolbox.
 
 <Image

--- a/packages/docs/docs/guides/contribute/core/building_and_compilation/building.mdx
+++ b/packages/docs/docs/guides/contribute/core/building_and_compilation/building.mdx
@@ -166,7 +166,7 @@ follows:
   `build/src/generators/javascript.js`) become `dist/javascript_compressed.js`.
 - And likewise for `dart`, `lua`, `php`, and `python`.
 
-The generated chuks use a wrapper to ensure compatibility with the [Universal
+The generated chunks use a wrapper to ensure compatibility with the [Universal
 Module Definition](https://github.com/umdjs/umd) so no extra processing is
 needed before they are included in the package.
 

--- a/packages/docs/docs/guides/contribute/core/testing/unit_testing.mdx
+++ b/packages/docs/docs/guides/contribute/core/testing/unit_testing.mdx
@@ -96,7 +96,7 @@ immediately (will stub by default).
     (i.e. you did not define it in the outermost suite), you must manually
     dispose of it by calling `workspaceTeardown.call(this, this.workspace)`
     in the teardown of that suite.
-  - If you define `this.workpace` in the outermost suite, but then redefine
+  - If you define `this.workspace` in the outermost suite, but then redefine
     it in an inner test suite, you must first call
     `workspaceTeardown.call(this, this.workspace)` **before redefining it**
     to tear down the original workspace defined in the top level suite. You

--- a/packages/docs/docs/guides/contribute/samples.mdx
+++ b/packages/docs/docs/guides/contribute/samples.mdx
@@ -7,7 +7,7 @@ image: images/blockly_banner.png
 # Blockly samples
 
 The [blockly-samples](https://github.com/RaspberryPiFoundation/blockly-samples) 
-respository contains extra content related to Blockly that isn't part of the 
+repository contains extra content related to Blockly that isn't part of the 
 core repository. There are two main pieces of blockly-samples: 
 
 1. [Examples](#examples)

--- a/packages/docs/docs/guides/create-custom-blocks/define/block-anatomy.mdx
+++ b/packages/docs/docs/guides/create-custom-blocks/define/block-anatomy.mdx
@@ -154,7 +154,7 @@ number):
 or three dummy inputs, each with a single field:
 
 <Image
-  alt="An addition block built from three dummy inputs, each wieht a single field."
+  alt="An addition block built from three dummy inputs, each with a single field."
   src="/images/block-anatomy/dummy-input-3-1.png"
   srcDark="/images/block-anatomy/dummy-input-3-1-dark.png"
 />

--- a/packages/docs/docs/guides/create-custom-blocks/icons/creating-custom-icons/save-and-load.mdx
+++ b/packages/docs/docs/guides/create-custom-blocks/icons/creating-custom-icons/save-and-load.mdx
@@ -49,7 +49,7 @@ interface. This method can return arbitrary json, which gets passed to your
 
 ```js
 saveState() {
-  return this.state;  // Some arbirtary JSON-compatible data.
+  return this.state;  // Some arbitrary JSON-compatible data.
 }
 ```
 

--- a/packages/docs/docs/guides/create-custom-blocks/mutators.mdx
+++ b/packages/docs/docs/guides/create-custom-blocks/mutators.mdx
@@ -222,7 +222,7 @@ compose: function(topBlock) {
     }
   }
 
-  // Then we update the shape of our block (removing or adding iputs as necessary).
+  // Then we update the shape of our block (removing or adding inputs as necessary).
   // `this` refers to the main block.
   this.itemCount_ = connections.length;
   this.updateShape_();

--- a/packages/docs/docs/guides/programming/plugin_overview.mdx
+++ b/packages/docs/docs/guides/programming/plugin_overview.mdx
@@ -165,7 +165,7 @@ you can simply check your Blockly version and use the same plugin version.
 <details>
 <summary>What if I'm using a major version of Blockly that's older than v13? </summary>
 
-Keeping Blockly up-to-date is strongly reccomended, so that you get the newest 
+Keeping Blockly up-to-date is strongly recommended, so that you get the newest 
 features and fixes. However, if you can't upgrade Blockly, you can use the 
 following npm command to list all of the pre-v13 versions of a plugin alongside 
 the minimum Blockly version that they support:


### PR DESCRIPTION
## The basics

- [x] I validated my changes

## The details

### Proposed Changes

Fixes 13 spelling typos across `.mdx` files in `packages/docs`, found by running `cspell` over all 225 of them.

Two are more than cosmetic:

- `attribution.mdx` used `<theader>`, which JSX renders as an unknown element rather than a table header. Changed to `<thead>`.
- `draggable.mdx` referred to `IDeleteable`; the interface is `IDeletable` (the link reference on the same page already used the correct spelling).

The rest are plain misspellings in prose and code comments: `workpace`, `respository`, `chuks`, `iputs`, `arbirtary`, `wieht`, `plaforms`, `pareng`, `reccomended`, `ISelectableToobloxItem`.

### Reason for Changes

Docs typos, some of which produce broken output.

### Test Coverage

Docs only, no runtime code touched.

### Additional Information

`cspell` also flags **`behaviour`** in 20 places across 17 files. Per `AGENTS.md`, only `colour`, `neighbour`, and `centre` are spelled the British way; everything else, `behavior` included, is American. Left alone here so this PR stays a pure typo fix. Happy to do it as a follow-up if you want it, or to leave it.
