### PR TITLE
fix: align Home/End/Page Down shortcuts with arrow-key navigation

### DIFF
--- a/packages/blockly/core/keyboard_nav/navigators/navigator.ts
+++ b/packages/blockly/core/keyboard_nav/navigators/navigator.ts
@@ -167,10 +167,10 @@ export class Navigator {
     if (!previous || (previous as any) === node.getFocusableTree()) {
       const stackRoot = this.navigateStacks(node, -1);
       if (!stackRoot) return null;
-      previous = this.getLastNodeInStack(stackRoot, node);
+      previous = this.walkToLastNodeInStack(stackRoot, node);
     }
 
-    return this.getLeftmostSibling(previous);
+    return this.getFirstNodeInRow(previous);
   }
 
   /**
@@ -385,12 +385,14 @@ export class Navigator {
   }
 
   /**
-   * Returns the leftmost node in the same row as the given node.
+   * Returns the first node in the same row as the given node, i.e. the node
+   * reached by repeatedly navigating out (left in LTR).
    *
-   * @param node The node to find the leftmost sibling of.
-   * @returns The leftmost sibling of the given node in the same row.
+   * @param node The node to find the first in-row peer of.
+   * @returns The first node in the same row as the given node, or null if none
+   *     was provided.
    */
-  private getLeftmostSibling(node: IFocusableNode | null) {
+  getFirstNodeInRow(node: IFocusableNode | null): IFocusableNode | null {
     if (!node) return null;
 
     let left = node;
@@ -405,6 +407,145 @@ export class Navigator {
   }
 
   /**
+   * Returns the last node in the same row as the given node, i.e. the node
+   * reached by repeatedly navigating in (right in LTR).
+   *
+   * @param node The node to find the last in-row peer of.
+   * @returns The last node in the same row as the given node, or null if none
+   *     was provided.
+   */
+  getLastNodeInRow(node: IFocusableNode | null): IFocusableNode | null {
+    if (!node) return null;
+
+    const visited = new Set<IFocusableNode>();
+    let right = node;
+    let temp;
+    while ((temp = this.getInNode(right)) && !visited.has(temp)) {
+      visited.add(right);
+      right = temp;
+    }
+
+    return right;
+  }
+
+  /**
+   * Returns the first focusable node in the current block reachable by
+   * repeatedly navigating out, without leaving that block.
+   *
+   * Typically this is the owning block itself. Full-block field blocks are
+   * treated as fields of their parent.
+   *
+   * @param node The node to navigate relative to.
+   * @returns The first in-block node, or the given node if none exists.
+   */
+  getFirstNodeInBlock(node: IFocusableNode): IFocusableNode {
+    const owner = this.getOwningBlock(node);
+    if (!owner) return this.getFirstNodeInRow(node) ?? node;
+
+    let current = node;
+    let next;
+    while (
+      (next = this.getOutNode(current)) &&
+      this.isUnderOwningBlock(next, owner)
+    ) {
+      current = next;
+    }
+    return current;
+  }
+
+  /**
+   * Returns the last focusable node in the current block reachable by
+   * repeatedly navigating in, without leaving that block or its current row.
+   *
+   * Full-block field blocks are treated as fields of their parent.
+   *
+   * @param node The node to navigate relative to.
+   * @returns The last in-block node, or the given node if none exists.
+   */
+  getLastNodeInBlock(node: IFocusableNode): IFocusableNode {
+    const owner = this.getOwningBlock(node);
+    if (!owner) return this.getLastNodeInRow(node) ?? node;
+
+    const visited = new Set<IFocusableNode>();
+    let current = node;
+    let next;
+    while (
+      (next = this.getInNode(current)) &&
+      !visited.has(next) &&
+      this.isUnderOwningBlock(next, owner)
+    ) {
+      visited.add(current);
+      current = next;
+    }
+    return current;
+  }
+
+  /**
+   * Returns the block that Home/End should be scoped to for the given node.
+   *
+   * Full-block field blocks look like fields, so the parent block is used.
+   *
+   * @param node The focused node.
+   * @returns The owning block, or null if the node is not part of a block.
+   */
+  private getOwningBlock(node: IFocusableNode): BlockSvg | null {
+    const block = this.getSourceBlockFromNode(node);
+    if (block?.getFullBlockField() && block.getParent()) {
+      return block.getParent() as BlockSvg;
+    }
+    return block;
+  }
+
+  /**
+   * Returns whether the given node belongs to `owner` or one of its
+   * descendants (including nested value blocks).
+   *
+   * @param node The node to check.
+   * @param owner The block that defines the Home/End scope.
+   * @returns True if `node` is `owner` or is nested under it.
+   */
+  private isUnderOwningBlock(node: IFocusableNode, owner: BlockSvg): boolean {
+    if (node === owner) return true;
+    let block = this.getSourceBlockFromNode(node);
+    while (block) {
+      if (block === owner) return true;
+      block = block.getParent() as BlockSvg | null;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the last node in the stack containing the given node that is
+   * reachable by repeatedly navigating down, without leaving the stack.
+   *
+   * @param node A node in the stack to find the last down-reachable node of.
+   * @returns The last down-reachable node in the same stack as the given node.
+   */
+  getLastNodeInStack(node: IFocusableNode): IFocusableNode {
+    const root = this.getSourceBlockFromNode(node)?.getRootBlock() ?? node;
+    return this.walkToLastNodeInStack(root);
+  }
+
+  /**
+   * Returns the last focusable node on the given node's focusable tree, i.e.
+   * the node reached by navigating to the last top-level stack, then down to
+   * the end of that stack, then in to the end of that row.
+   *
+   * @param from A node whose tree should be searched; defaults to the currently
+   *     focused tree's root.
+   * @returns The last focusable node on the tree, or null if none exist.
+   */
+  getLastFocusableNode(from?: IFocusableNode | null): IFocusableNode | null {
+    const root =
+      from ?? getFocusManager().getFocusedTree()?.getRootFocusableNode();
+    if (!root) return null;
+
+    const lastTop = this.getTopLevelItems(root).slice(-1)[0];
+    if (!lastTop) return null;
+    return this.getLastNodeInRow(this.getLastNodeInStack(lastTop));
+  }
+
+  /**
    * Returns the last node in a stack of blocks or other top-level workspace
    * entity.
    *
@@ -413,9 +554,9 @@ export class Navigator {
    *     encountered; typically the root node of the next stack.
    * @returns The last node in the given stack.
    */
-  private getLastNodeInStack(
+  private walkToLastNodeInStack(
     stackRoot: IFocusableNode,
-    stopIfFound: IFocusableNode,
+    stopIfFound?: IFocusableNode,
   ) {
     let target = stackRoot;
     let temp;

--- a/packages/blockly/core/keyboard_nav/navigators/navigator.ts
+++ b/packages/blockly/core/keyboard_nav/navigators/navigator.ts
@@ -385,94 +385,27 @@ export class Navigator {
   }
 
   /**
-   * Returns the first node in the same row as the given node, i.e. the node
-   * reached by repeatedly navigating out (left in LTR).
+   * Walks from `start` by repeatedly applying `step` until `stay` rejects the
+   * next candidate, a cycle is detected, or there is no next node.
    *
-   * @param node The node to find the first in-row peer of.
-   * @returns The first node in the same row as the given node, or null if none
-   *     was provided.
+   * @param start The node to begin walking from.
+   * @param step Returns the next candidate from the current node.
+   * @param stay If provided, walking stops before a candidate that fails this
+   *     check.
+   * @returns The last accepted node in the walk.
    */
-  getFirstNodeInRow(node: IFocusableNode | null): IFocusableNode | null {
-    if (!node) return null;
-
-    let left = node;
-    let temp;
-    while (
-      (temp = this.getPreviousNodeImpl(left, left, NavigationDirection.OUT))
-    ) {
-      left = temp;
-    }
-
-    return left;
-  }
-
-  /**
-   * Returns the last node in the same row as the given node, i.e. the node
-   * reached by repeatedly navigating in (right in LTR).
-   *
-   * @param node The node to find the last in-row peer of.
-   * @returns The last node in the same row as the given node, or null if none
-   *     was provided.
-   */
-  getLastNodeInRow(node: IFocusableNode | null): IFocusableNode | null {
-    if (!node) return null;
-
+  private walkAlong(
+    start: IFocusableNode,
+    step: (node: IFocusableNode) => IFocusableNode | null,
+    stay?: (candidate: IFocusableNode) => boolean,
+  ): IFocusableNode {
     const visited = new Set<IFocusableNode>();
-    let right = node;
-    let temp;
-    while ((temp = this.getInNode(right)) && !visited.has(temp)) {
-      visited.add(right);
-      right = temp;
-    }
-
-    return right;
-  }
-
-  /**
-   * Returns the first focusable node in the current block reachable by
-   * repeatedly navigating out, without leaving that block.
-   *
-   * Typically this is the owning block itself. Full-block field blocks are
-   * treated as fields of their parent.
-   *
-   * @param node The node to navigate relative to.
-   * @returns The first in-block node, or the given node if none exists.
-   */
-  getFirstNodeInBlock(node: IFocusableNode): IFocusableNode {
-    const owner = this.getOwningBlock(node);
-    if (!owner) return this.getFirstNodeInRow(node) ?? node;
-
-    let current = node;
-    let next;
+    let current = start;
+    let next: IFocusableNode | null;
     while (
-      (next = this.getOutNode(current)) &&
-      this.isUnderOwningBlock(next, owner)
-    ) {
-      current = next;
-    }
-    return current;
-  }
-
-  /**
-   * Returns the last focusable node in the current block reachable by
-   * repeatedly navigating in, without leaving that block or its current row.
-   *
-   * Full-block field blocks are treated as fields of their parent.
-   *
-   * @param node The node to navigate relative to.
-   * @returns The last in-block node, or the given node if none exists.
-   */
-  getLastNodeInBlock(node: IFocusableNode): IFocusableNode {
-    const owner = this.getOwningBlock(node);
-    if (!owner) return this.getLastNodeInRow(node) ?? node;
-
-    const visited = new Set<IFocusableNode>();
-    let current = node;
-    let next;
-    while (
-      (next = this.getInNode(current)) &&
+      (next = step(current)) &&
       !visited.has(next) &&
-      this.isUnderOwningBlock(next, owner)
+      (stay?.(next) ?? true)
     ) {
       visited.add(current);
       current = next;
@@ -481,68 +414,20 @@ export class Navigator {
   }
 
   /**
-   * Returns the block that Home/End should be scoped to for the given node.
+   * Returns the first node in the same row as the given node, i.e. the node
+   * reached by repeatedly navigating out (left in LTR).
    *
-   * Full-block field blocks look like fields, so the parent block is used.
-   *
-   * @param node The focused node.
-   * @returns The owning block, or null if the node is not part of a block.
+   * @param node The node to find the first in-row peer of.
+   * @returns The first node in the same row as the given node, or null if none
+   *     was provided.
    */
-  private getOwningBlock(node: IFocusableNode): BlockSvg | null {
-    const block = this.getSourceBlockFromNode(node);
-    if (block?.getFullBlockField() && block.getParent()) {
-      return block.getParent() as BlockSvg;
-    }
-    return block;
-  }
-
-  /**
-   * Returns whether the given node belongs to `owner` or one of its
-   * descendants (including nested value blocks).
-   *
-   * @param node The node to check.
-   * @param owner The block that defines the Home/End scope.
-   * @returns True if `node` is `owner` or is nested under it.
-   */
-  private isUnderOwningBlock(node: IFocusableNode, owner: BlockSvg): boolean {
-    if (node === owner) return true;
-    let block = this.getSourceBlockFromNode(node);
-    while (block) {
-      if (block === owner) return true;
-      block = block.getParent() as BlockSvg | null;
-    }
-    return false;
-  }
-
-  /**
-   * Returns the last node in the stack containing the given node that is
-   * reachable by repeatedly navigating down, without leaving the stack.
-   *
-   * @param node A node in the stack to find the last down-reachable node of.
-   * @returns The last down-reachable node in the same stack as the given node.
-   */
-  getLastNodeInStack(node: IFocusableNode): IFocusableNode {
-    const root = this.getSourceBlockFromNode(node)?.getRootBlock() ?? node;
-    return this.walkToLastNodeInStack(root);
-  }
-
-  /**
-   * Returns the last focusable node on the given node's focusable tree, i.e.
-   * the node reached by navigating to the last top-level stack, then down to
-   * the end of that stack, then in to the end of that row.
-   *
-   * @param from A node whose tree should be searched; defaults to the currently
-   *     focused tree's root.
-   * @returns The last focusable node on the tree, or null if none exist.
-   */
-  getLastFocusableNode(from?: IFocusableNode | null): IFocusableNode | null {
-    const root =
-      from ?? getFocusManager().getFocusedTree()?.getRootFocusableNode();
-    if (!root) return null;
-
-    const lastTop = this.getTopLevelItems(root).slice(-1)[0];
-    if (!lastTop) return null;
-    return this.getLastNodeInRow(this.getLastNodeInStack(lastTop));
+  private getFirstNodeInRow(
+    node: IFocusableNode | null,
+  ): IFocusableNode | null {
+    if (!node) return null;
+    return this.walkAlong(node, (current) =>
+      this.getPreviousNodeImpl(current, current, NavigationDirection.OUT),
+    );
   }
 
   /**
@@ -558,16 +443,12 @@ export class Navigator {
     stackRoot: IFocusableNode,
     stopIfFound?: IFocusableNode,
   ) {
-    let target = stackRoot;
-    let temp;
-    while (
-      (temp = this.getNextNodeImpl(target, target, NavigationDirection.NEXT)) &&
-      temp !== stopIfFound
-    ) {
-      target = temp;
-    }
-
-    return target;
+    return this.walkAlong(
+      stackRoot,
+      (current) =>
+        this.getNextNodeImpl(current, current, NavigationDirection.NEXT),
+      (candidate) => candidate !== stopIfFound,
+    );
   }
 
   private getRowId(node: IFocusableNode) {

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -32,7 +32,6 @@ import {isSelectable} from './interfaces/i_selectable.js';
 import {Direction, KeyboardMover} from './keyboard_nav/keyboard_mover.js';
 import {keyboardNavigationController} from './keyboard_navigation_controller.js';
 import {Msg} from './msg.js';
-import {RenderedConnection} from './rendered_connection.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
 import * as Tooltip from './tooltip.js';
 import {aria} from './utils.js';
@@ -1354,8 +1353,28 @@ const shouldDoBlockNavigation = (workspace: WorkspaceSvg, scope: Scope) => {
 };
 
 /**
- * Registers a keyboard shortcut that sets the focus to the block
- * that owns the current focused node.
+ * Moves focus to `dest` if it differs from the currently focused node.
+ * Always prevents the browser default (e.g. scrolling on Home/End).
+ *
+ * @param e The keyboard event that triggered the shortcut.
+ * @param current The currently focused node, if any.
+ * @param dest The node to focus, if any.
+ * @returns True if focus moved, otherwise false.
+ */
+function jumpFocus(
+  e: Event,
+  current: IFocusableNode | undefined,
+  dest: IFocusableNode | null | undefined,
+): boolean {
+  e.preventDefault();
+  if (!dest || dest === current) return false;
+  getFocusManager().focusNode(dest);
+  return true;
+}
+
+/**
+ * Registers a keyboard shortcut that sets the focus to the first
+ * focusable node in the current block, typically the owning block.
  */
 export function registerJumpBlockStart() {
   const jumpBlockStartShortcut: KeyboardShortcut = {
@@ -1363,18 +1382,11 @@ export function registerJumpBlockStart() {
     preconditionFn: shouldDoBlockNavigation,
     callback(workspace, e, shortcut, scope) {
       if (!scope.focusedNode) return false;
-      let selectedBlock = workspace
-        .getNavigator()
-        .getSourceBlockFromNode(scope.focusedNode);
-      if (selectedBlock?.getFullBlockField() && !!selectedBlock.getParent()) {
-        // Act on the parent block if the current block is a full-block field block.
-        // Because full-block field blocks look like fields, so treat them that way.
-        selectedBlock = selectedBlock.getParent();
-      }
-      if (!selectedBlock) return false;
-
-      getFocusManager().focusNode(selectedBlock);
-      return true;
+      return jumpFocus(
+        e,
+        scope.focusedNode,
+        workspace.getNavigator().getFirstNodeInBlock(scope.focusedNode),
+      );
     },
     keyCodes: [KeyCodes.HOME],
     displayText: () => Msg['SHORTCUTS_JUMP_BLOCK_START'],
@@ -1383,8 +1395,8 @@ export function registerJumpBlockStart() {
 }
 
 /**
- * Registers a keyboard shortcut that sets the focus to the
- * last input of the block that owns the current focused node.
+ * Registers a keyboard shortcut that sets the focus to the last
+ * focusable node on the current block's row.
  */
 export function registerJumpBlockEnd() {
   const jumpBlockEndShortcut: KeyboardShortcut = {
@@ -1392,22 +1404,11 @@ export function registerJumpBlockEnd() {
     preconditionFn: shouldDoBlockNavigation,
     callback(workspace, e, shortcut, scope) {
       if (!scope.focusedNode) return false;
-      let selectedBlock = workspace
-        .getNavigator()
-        .getSourceBlockFromNode(scope.focusedNode);
-      if (selectedBlock?.getFullBlockField() && !!selectedBlock.getParent()) {
-        // Act on the parent block if the current block is a full-block field block.
-        // Because full-block field blocks look like fields, so treat them that way.
-        selectedBlock = selectedBlock.getParent();
-      }
-      if (!selectedBlock) return false;
-      const inputs = selectedBlock.inputList;
-      if (!inputs.length) return false;
-      const connection = inputs[inputs.length - 1].connection;
-      if (!connection || !(connection instanceof RenderedConnection))
-        return false;
-      getFocusManager().focusNode(connection);
-      return true;
+      return jumpFocus(
+        e,
+        scope.focusedNode,
+        workspace.getNavigator().getLastNodeInBlock(scope.focusedNode),
+      );
     },
     keyCodes: [KeyCodes.END],
     displayText: () => Msg['SHORTCUTS_JUMP_BLOCK_END'],
@@ -1429,9 +1430,7 @@ export function registerJumpTopStack() {
         .getNavigator()
         .getSourceBlockFromNode(scope.focusedNode);
       if (!selectedBlock) return false;
-      const topOfStack = selectedBlock.getRootBlock();
-      getFocusManager().focusNode(topOfStack);
-      return true;
+      return jumpFocus(e, scope.focusedNode, selectedBlock.getRootBlock());
     },
     keyCodes: [KeyCodes.PAGE_UP],
     displayText: () => Msg['SHORTCUTS_JUMP_TOP_STACK'],
@@ -1440,8 +1439,8 @@ export function registerJumpTopStack() {
 }
 
 /**
- * Registers a keyboard shortcut that sets the focus to the bottom block
- * in the current stack.
+ * Registers a keyboard shortcut that sets the focus to the last node
+ * in the current stack reachable by repeatedly pressing Down.
  */
 export function registerJumpBottomStack() {
   const jumpBottomStackShortcut: KeyboardShortcut = {
@@ -1449,22 +1448,11 @@ export function registerJumpBottomStack() {
     preconditionFn: shouldDoBlockNavigation,
     callback(workspace, e, shortcut, scope) {
       if (!scope.focusedNode) return false;
-      const selectedBlock = workspace
-        .getNavigator()
-        .getSourceBlockFromNode(scope.focusedNode);
-      if (!selectedBlock) return false;
-      // To get the bottom block in a stack, first go to the top of the stack
-      // Then get the last next connection
-      // Then get the last descendant of that block
-      const lastBlock = selectedBlock
-        .getRootBlock()
-        .lastConnectionInStack(false)
-        ?.getSourceBlock();
-      if (!lastBlock) return false;
-      const descendants = lastBlock.getDescendants(true);
-      const bottomOfStack = descendants[descendants.length - 1];
-      getFocusManager().focusNode(bottomOfStack);
-      return true;
+      return jumpFocus(
+        e,
+        scope.focusedNode,
+        workspace.getNavigator().getLastNodeInStack(scope.focusedNode),
+      );
     },
     keyCodes: [KeyCodes.PAGE_DOWN],
     displayText: () => Msg['SHORTCUTS_JUMP_BOTTOM_STACK'],
@@ -1488,11 +1476,10 @@ export function registerJumpFirstBlock() {
         !workspace.isDragging() && !getFocusManager().ephemeralFocusTaken()
       );
     },
-    callback(workspace) {
+    callback(workspace, e, shortcut, scope) {
       const topBlocks = workspace.getTopBlocks(true);
       if (!topBlocks.length) return false;
-      getFocusManager().focusNode(topBlocks[0]);
-      return true;
+      return jumpFocus(e, scope.focusedNode, topBlocks[0]);
     },
     keyCodes: [ctrlCmdHome],
     displayText: () => Msg['SHORTCUTS_JUMP_FIRST_BLOCK'],
@@ -1502,7 +1489,7 @@ export function registerJumpFirstBlock() {
 
 /**
  * Registers a keyboard shortcut that sets the focus to the last
- * block in the workspace.
+ * focusable node on the workspace.
  */
 export function registerJumpLastBlock() {
   const ctrlCmdEnd = ShortcutRegistry.registry.createSerializedKey(
@@ -1516,11 +1503,12 @@ export function registerJumpLastBlock() {
         !workspace.isDragging() && !getFocusManager().ephemeralFocusTaken()
       );
     },
-    callback(workspace) {
-      const allBlocks = workspace.getAllBlocks(true);
-      if (!allBlocks.length) return false;
-      getFocusManager().focusNode(allBlocks[allBlocks.length - 1]);
-      return true;
+    callback(workspace, e, shortcut, scope) {
+      return jumpFocus(
+        e,
+        scope.focusedNode,
+        workspace.getNavigator().getLastFocusableNode(workspace),
+      );
     },
     keyCodes: [ctrlCmdEnd],
     displayText: () => Msg['SHORTCUTS_JUMP_LAST_BLOCK'],

--- a/packages/blockly/core/shortcut_items.ts
+++ b/packages/blockly/core/shortcut_items.ts
@@ -30,6 +30,7 @@ import {type IFlyout} from './interfaces/i_flyout.js';
 import {type IFocusableNode} from './interfaces/i_focusable_node.js';
 import {isSelectable} from './interfaces/i_selectable.js';
 import {Direction, KeyboardMover} from './keyboard_nav/keyboard_mover.js';
+import type {Navigator} from './keyboard_nav/navigators/navigator.js';
 import {keyboardNavigationController} from './keyboard_navigation_controller.js';
 import {Msg} from './msg.js';
 import {KeyboardShortcut, ShortcutRegistry} from './shortcut_registry.js';
@@ -1373,6 +1374,132 @@ function jumpFocus(
 }
 
 /**
+ * Walks from `start` by repeatedly applying `step` until `stay` rejects the
+ * next candidate, a cycle is detected, or there is no next node.
+ */
+function walkFocusableNodes(
+  start: IFocusableNode,
+  step: (node: IFocusableNode) => IFocusableNode | null,
+  stay: (candidate: IFocusableNode) => boolean = () => true,
+): IFocusableNode {
+  const visited = new Set<IFocusableNode>();
+  let current = start;
+  let next: IFocusableNode | null;
+  while ((next = step(current)) && !visited.has(next) && stay(next)) {
+    visited.add(current);
+    current = next;
+  }
+  return current;
+}
+
+/**
+ * Returns the block that Home/End should be scoped to for the given node.
+ *
+ * Full-block field blocks look like fields, so the parent block is used.
+ */
+function getOwningBlock(
+  navigator: Navigator,
+  node: IFocusableNode,
+): BlockSvg | null {
+  const block = navigator.getSourceBlockFromNode(node);
+  if (block?.getFullBlockField() && block.getParent()) {
+    return block.getParent() as BlockSvg;
+  }
+  return block;
+}
+
+/**
+ * Returns whether the given node belongs to `owner` or one of its
+ * descendants (including nested value blocks).
+ */
+function isUnderOwningBlock(
+  navigator: Navigator,
+  node: IFocusableNode,
+  owner: BlockSvg,
+): boolean {
+  if (node === owner) return true;
+  let block = navigator.getSourceBlockFromNode(node);
+  while (block) {
+    if (block === owner) return true;
+    block = block.getParent() as BlockSvg | null;
+  }
+  return false;
+}
+
+/**
+ * Returns whether `node` is in the same top-level stack as `stackRoot`.
+ */
+function isInSameStack(
+  navigator: Navigator,
+  node: IFocusableNode,
+  stackRoot: IFocusableNode,
+): boolean {
+  if (node === stackRoot) return true;
+  return navigator.getSourceBlockFromNode(node)?.getRootBlock() === stackRoot;
+}
+
+/**
+ * First focusable node in the current block reachable by repeatedly
+ * navigating out, without leaving that block.
+ */
+function getFirstNodeInBlock(
+  navigator: Navigator,
+  node: IFocusableNode,
+): IFocusableNode {
+  const owner = getOwningBlock(navigator, node);
+  if (!owner) return node;
+  return walkFocusableNodes(
+    node,
+    (current) => navigator.getOutNode(current),
+    (candidate) => isUnderOwningBlock(navigator, candidate, owner),
+  );
+}
+
+/**
+ * Last focusable node on the current block's row reachable by repeatedly
+ * navigating in, without leaving that block.
+ */
+function getLastNodeInBlock(
+  navigator: Navigator,
+  node: IFocusableNode,
+): IFocusableNode {
+  const owner = getOwningBlock(navigator, node);
+  if (!owner) return node;
+  return walkFocusableNodes(
+    node,
+    (current) => navigator.getInNode(current),
+    (candidate) => isUnderOwningBlock(navigator, candidate, owner),
+  );
+}
+
+/**
+ * Last node in the current stack reachable by repeatedly navigating down.
+ */
+function getLastNodeInStack(
+  navigator: Navigator,
+  node: IFocusableNode,
+): IFocusableNode {
+  const root = navigator.getSourceBlockFromNode(node)?.getRootBlock() ?? node;
+  return walkFocusableNodes(
+    root,
+    (current) => navigator.getNextNode(current),
+    (candidate) => isInSameStack(navigator, candidate, root),
+  );
+}
+
+/**
+ * Last focusable node on the workspace: last top-level stack, then down to
+ * the end of that stack, then in to the end of that row.
+ */
+function getLastFocusableNode(navigator: Navigator): IFocusableNode | null {
+  const lastTop = navigator.getLastNode();
+  if (!lastTop) return null;
+  return walkFocusableNodes(getLastNodeInStack(navigator, lastTop), (current) =>
+    navigator.getInNode(current),
+  );
+}
+
+/**
  * Registers a keyboard shortcut that sets the focus to the first
  * focusable node in the current block, typically the owning block.
  */
@@ -1385,7 +1512,7 @@ export function registerJumpBlockStart() {
       return jumpFocus(
         e,
         scope.focusedNode,
-        workspace.getNavigator().getFirstNodeInBlock(scope.focusedNode),
+        getFirstNodeInBlock(workspace.getNavigator(), scope.focusedNode),
       );
     },
     keyCodes: [KeyCodes.HOME],
@@ -1407,7 +1534,7 @@ export function registerJumpBlockEnd() {
       return jumpFocus(
         e,
         scope.focusedNode,
-        workspace.getNavigator().getLastNodeInBlock(scope.focusedNode),
+        getLastNodeInBlock(workspace.getNavigator(), scope.focusedNode),
       );
     },
     keyCodes: [KeyCodes.END],
@@ -1451,7 +1578,7 @@ export function registerJumpBottomStack() {
       return jumpFocus(
         e,
         scope.focusedNode,
-        workspace.getNavigator().getLastNodeInStack(scope.focusedNode),
+        getLastNodeInStack(workspace.getNavigator(), scope.focusedNode),
       );
     },
     keyCodes: [KeyCodes.PAGE_DOWN],
@@ -1507,7 +1634,7 @@ export function registerJumpLastBlock() {
       return jumpFocus(
         e,
         scope.focusedNode,
-        workspace.getNavigator().getLastFocusableNode(workspace),
+        getLastFocusableNode(workspace.getNavigator()),
       );
     },
     keyCodes: [ctrlCmdEnd],

--- a/packages/blockly/tests/mocha/navigation_test.js
+++ b/packages/blockly/tests/mocha/navigation_test.js
@@ -898,5 +898,49 @@ suite('Navigation', function () {
         assert.equal(outNode, this.blocks.dummyInput);
       });
     });
+
+    suite('Row and stack jump helpers', function () {
+      test('getFirstNodeInBlock from a field returns the owning block', function () {
+        const field = this.blocks.statementInput1.getField('NAME1');
+        const dest = this.navigator.getFirstNodeInBlock(field);
+        assert.equal(dest, this.blocks.statementInput1);
+      });
+
+      test('getFirstNodeInBlock from the owning block returns the block', function () {
+        const dest = this.navigator.getFirstNodeInBlock(
+          this.blocks.statementInput1,
+        );
+        assert.equal(dest, this.blocks.statementInput1);
+      });
+
+      test('getLastNodeInBlock from a field stays on the header row', function () {
+        const field = this.blocks.statementInput1.getField('NAME1');
+        const dest = this.navigator.getLastNodeInBlock(field);
+        const statementConnection =
+          this.blocks.statementInput1.getInput('NAME4').connection;
+        assert.notEqual(dest, field);
+        assert.notEqual(dest, statementConnection);
+        assert.equal(
+          dest,
+          this.navigator.getLastNodeInBlock(this.blocks.statementInput1),
+        );
+      });
+
+      test('getLastNodeInBlock on a container does not focus the statement input', function () {
+        const dest = this.navigator.getLastNodeInBlock(
+          this.blocks.statementInput2,
+        );
+        const statementConnection =
+          this.blocks.statementInput2.getInput('NAME4').connection;
+        assert.notEqual(dest, statementConnection);
+      });
+
+      test('getLastNodeInStack does not enter inline value inputs', function () {
+        const dest = this.navigator.getLastNodeInStack(
+          this.blocks.statementInput1,
+        );
+        assert.notEqual(dest, this.blocks.fieldWithOutput);
+      });
+    });
   });
 });

--- a/packages/blockly/tests/mocha/navigation_test.js
+++ b/packages/blockly/tests/mocha/navigation_test.js
@@ -898,49 +898,5 @@ suite('Navigation', function () {
         assert.equal(outNode, this.blocks.dummyInput);
       });
     });
-
-    suite('Row and stack jump helpers', function () {
-      test('getFirstNodeInBlock from a field returns the owning block', function () {
-        const field = this.blocks.statementInput1.getField('NAME1');
-        const dest = this.navigator.getFirstNodeInBlock(field);
-        assert.equal(dest, this.blocks.statementInput1);
-      });
-
-      test('getFirstNodeInBlock from the owning block returns the block', function () {
-        const dest = this.navigator.getFirstNodeInBlock(
-          this.blocks.statementInput1,
-        );
-        assert.equal(dest, this.blocks.statementInput1);
-      });
-
-      test('getLastNodeInBlock from a field stays on the header row', function () {
-        const field = this.blocks.statementInput1.getField('NAME1');
-        const dest = this.navigator.getLastNodeInBlock(field);
-        const statementConnection =
-          this.blocks.statementInput1.getInput('NAME4').connection;
-        assert.notEqual(dest, field);
-        assert.notEqual(dest, statementConnection);
-        assert.equal(
-          dest,
-          this.navigator.getLastNodeInBlock(this.blocks.statementInput1),
-        );
-      });
-
-      test('getLastNodeInBlock on a container does not focus the statement input', function () {
-        const dest = this.navigator.getLastNodeInBlock(
-          this.blocks.statementInput2,
-        );
-        const statementConnection =
-          this.blocks.statementInput2.getInput('NAME4').connection;
-        assert.notEqual(dest, statementConnection);
-      });
-
-      test('getLastNodeInStack does not enter inline value inputs', function () {
-        const dest = this.navigator.getLastNodeInStack(
-          this.blocks.statementInput1,
-        );
-        assert.notEqual(dest, this.blocks.fieldWithOutput);
-      });
-    });
   });
 });

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -2208,18 +2208,18 @@ suite('Keyboard Shortcut Items', function () {
       }
     });
 
-    test('Home focuses current block if block is focused', function () {
+    test('Home has no effect if the owning block is already focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       this.getFocusedNodeStub.returns(inListBlock);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
+      sinon.assert.notCalled(this.focusNodeSpy);
     });
 
-    test('Home focuses owning block if field is focused', function () {
+    test('Home from a middle field focuses the owning block', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      const fieldToFocus = inListBlock.getField('MODE');
+      const fieldToFocus = inListBlock.getField('WHERE');
       this.getFocusedNodeStub.returns(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
@@ -2227,20 +2227,55 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
     });
 
-    test('End focuses last input on owning block', function () {
+    test('End focuses last same-row node on owning block', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
       this.getFocusedNodeStub.returns(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
-      const expectedFocus = inListBlock.getInput('AT').connection;
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastNodeInBlock(fieldToFocus);
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.notEqual(
+        expectedFocus,
+        inListBlock.getInput('VALUE')?.connection,
+        'End should not focus a connected value input connection',
+      );
+    });
+
+    test('End on a container block does not focus the statement input', function () {
+      const repeatBlock = this.workspace.getBlockById('controls_repeat_1');
+      this.getFocusedNodeStub.returns(repeatBlock);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END),
+      );
+      const statementConnection = repeatBlock.getInput('DO').connection;
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastNodeInBlock(repeatBlock);
+      assert.notEqual(expectedFocus, statementConnection);
+      assert.notEqual(expectedFocus, repeatBlock);
       sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
     });
 
-    test('End has no effect if block has no inputs', function () {
-      const textBlock = this.workspace.getBlockById('text_1');
-      this.getFocusedNodeStub.returns(textBlock);
+    test('End has no effect on a container end statement position', function () {
+      const forEachBlock = this.workspace.getBlockById('controls_forEach_1');
+      const endStatement = forEachBlock.nextConnection;
+      this.getFocusedNodeStub.returns(endStatement);
+      this.injectionDiv.dispatchEvent(
+        createKeyDownEvent(Blockly.utils.KeyCodes.END),
+      );
+      sinon.assert.notCalled(this.focusNodeSpy);
+    });
+
+    test('End has no effect if already at the last in-block node', function () {
+      const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
+      const last = this.workspace
+        .getNavigator()
+        .getLastNodeInBlock(inListBlock);
+      this.getFocusedNodeStub.returns(last);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
@@ -2283,40 +2318,46 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.calledWith(this.focusNodeSpy, topBlock);
     });
 
-    test('CtrlEnd focuses last block in workspace if block is focused', function () {
+    test('CtrlEnd focuses last focusable node in workspace if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       this.getFocusedNodeStub.returns(inListBlock);
-      const lastBlock = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastFocusableNode(this.workspace);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
     });
 
-    test('CtrlEnd focuses last block in workspace if field is focused', function () {
+    test('CtrlEnd focuses last focusable node in workspace if field is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
       this.getFocusedNodeStub.returns(fieldToFocus);
-      const lastBlock = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastFocusableNode(this.workspace);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
     });
 
-    test('CtrlEnd focuses last block in workspace if workspace is focused', function () {
+    test('CtrlEnd focuses last focusable node in workspace if workspace is focused', function () {
       this.getFocusedNodeStub.returns(this.workspace);
-      const lastBlock = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastFocusableNode(this.workspace);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
     });
 
     test('PageUp focuses on first block in stack', function () {
@@ -2330,25 +2371,39 @@ suite('Keyboard Shortcut Items', function () {
       sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
     });
 
-    test('PageDown focuses on last block in stack with nested row blocks', function () {
+    test('PageDown focuses on last down-reachable node in stack with nested row blocks', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
       this.getFocusedNodeStub.returns(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
       );
-      const expectedFocus = this.workspace.getBlockById('math_number_2');
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastNodeInStack(inListBlock);
       sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.notEqual(
+        expectedFocus,
+        this.workspace.getBlockById('math_number_2'),
+        'Page Down should not walk right into inline value inputs',
+      );
     });
 
-    test('PageDown focuses on last block in stack with many stack blocks', function () {
+    test('PageDown focuses on last down-reachable node in stack with many stack blocks', function () {
       const blockToFocus = this.workspace.getBlockById('text_1');
       this.getFocusedNodeStub.returns(blockToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
       );
-      const expectedFocus = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getNavigator()
+        .getLastNodeInStack(blockToFocus);
       sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.notEqual(
+        expectedFocus,
+        this.workspace.getBlockById('text_2'),
+        'Page Down should not walk right into inline value inputs',
+      );
     });
 
     suite('in flyout', function () {
@@ -2382,17 +2437,19 @@ suite('Keyboard Shortcut Items', function () {
         );
         sinon.assert.calledWith(this.focusNodeSpy, topBlock);
       });
-      test('CtrlEnd focuses last block in flyout workspace', function () {
+      test('CtrlEnd focuses last focusable node in flyout workspace', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
         this.getFocusedNodeStub.returns(inListBlock);
-        const lastBlock = this.workspace.getBlockById('text_2');
+        const expectedFocus = this.workspace
+          .getNavigator()
+          .getLastFocusableNode(this.workspace);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END, [
             Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
-        sinon.assert.calledWith(this.focusNodeSpy, lastBlock);
+        sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
       });
       test('PageUp has no effect', function () {
         this.workspace.internalIsFlyout = true;

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -2309,7 +2309,9 @@ suite('Keyboard Shortcut Items', function () {
     test('CtrlEnd focuses last focusable node in workspace if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       Blockly.getFocusManager().focusNode(inListBlock);
-      const expectedFocus = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getBlockById('text_2')
+        .getField('TEXT');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
@@ -2322,7 +2324,9 @@ suite('Keyboard Shortcut Items', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
       Blockly.getFocusManager().focusNode(fieldToFocus);
-      const expectedFocus = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getBlockById('text_2')
+        .getField('TEXT');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
@@ -2333,7 +2337,9 @@ suite('Keyboard Shortcut Items', function () {
 
     test('CtrlEnd focuses last focusable node in workspace if workspace is focused', function () {
       Blockly.getFocusManager().focusNode(this.workspace);
-      const expectedFocus = this.workspace.getBlockById('text_2');
+      const expectedFocus = this.workspace
+        .getBlockById('text_2')
+        .getField('TEXT');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
@@ -2420,7 +2426,9 @@ suite('Keyboard Shortcut Items', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
         Blockly.getFocusManager().focusNode(inListBlock);
-        const expectedFocus = this.workspace.getBlockById('text_2');
+        const expectedFocus = this.workspace
+          .getBlockById('text_2')
+          .getField('TEXT');
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END, [
             Blockly.utils.KeyCodes.CTRL_CMD,

--- a/packages/blockly/tests/mocha/shortcut_items_test.js
+++ b/packages/blockly/tests/mocha/shortcut_items_test.js
@@ -2183,11 +2183,6 @@ suite('Keyboard Shortcut Items', function () {
 
   suite('Jump shortcuts', function () {
     setup(function () {
-      this.getFocusedNodeStub = sinon.stub(
-        Blockly.getFocusManager(),
-        'getFocusedNode',
-      );
-      this.focusNodeSpy = sinon.stub(Blockly.getFocusManager(), 'focusNode');
       Blockly.serialization.workspaces.load(blockJson, this.workspace);
     });
 
@@ -2210,34 +2205,32 @@ suite('Keyboard Shortcut Items', function () {
 
     test('Home has no effect if the owning block is already focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      this.getFocusedNodeStub.returns(inListBlock);
+      Blockly.getFocusManager().focusNode(inListBlock);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
       );
-      sinon.assert.notCalled(this.focusNodeSpy);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
     });
 
     test('Home from a middle field focuses the owning block', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('WHERE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, inListBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
     });
 
     test('End focuses last same-row node on owning block', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastNodeInBlock(fieldToFocus);
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      const expectedFocus = inListBlock.getInput('AT').connection;
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
       assert.notEqual(
         expectedFocus,
         inListBlock.getInput('VALUE')?.connection,
@@ -2247,141 +2240,129 @@ suite('Keyboard Shortcut Items', function () {
 
     test('End on a container block does not focus the statement input', function () {
       const repeatBlock = this.workspace.getBlockById('controls_repeat_1');
-      this.getFocusedNodeStub.returns(repeatBlock);
+      Blockly.getFocusManager().focusNode(repeatBlock);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
-      const statementConnection = repeatBlock.getInput('DO').connection;
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastNodeInBlock(repeatBlock);
-      assert.notEqual(expectedFocus, statementConnection);
+      const expectedFocus = this.workspace.getBlockById('math_number_1');
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
+      assert.notEqual(expectedFocus, repeatBlock.getInput('DO').connection);
       assert.notEqual(expectedFocus, repeatBlock);
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
     });
 
     test('End has no effect on a container end statement position', function () {
       const forEachBlock = this.workspace.getBlockById('controls_forEach_1');
       const endStatement = forEachBlock.nextConnection;
-      this.getFocusedNodeStub.returns(endStatement);
+      Blockly.getFocusManager().focusNode(endStatement);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
-      sinon.assert.notCalled(this.focusNodeSpy);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), endStatement);
     });
 
     test('End has no effect if already at the last in-block node', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      const last = this.workspace
-        .getNavigator()
-        .getLastNodeInBlock(inListBlock);
-      this.getFocusedNodeStub.returns(last);
+      const last = inListBlock.getInput('AT').connection;
+      Blockly.getFocusManager().focusNode(last);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END),
       );
-      sinon.assert.notCalled(this.focusNodeSpy);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), last);
     });
 
     test('CtrlHome focuses top block in workspace if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      this.getFocusedNodeStub.returns(inListBlock);
+      Blockly.getFocusManager().focusNode(inListBlock);
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
     });
 
     test('CtrlHome focuses top block in workspace if field is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
     });
 
     test('CtrlHome focuses top block in workspace if workspace is focused', function () {
-      this.getFocusedNodeStub.returns(this.workspace);
+      Blockly.getFocusManager().focusNode(this.workspace);
       const topBlock = this.workspace.getBlockById('controls_repeat_1');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
     });
 
     test('CtrlEnd focuses last focusable node in workspace if block is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-      this.getFocusedNodeStub.returns(inListBlock);
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastFocusableNode(this.workspace);
+      Blockly.getFocusManager().focusNode(inListBlock);
+      const expectedFocus = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('CtrlEnd focuses last focusable node in workspace if field is focused', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastFocusableNode(this.workspace);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
+      const expectedFocus = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('CtrlEnd focuses last focusable node in workspace if workspace is focused', function () {
-      this.getFocusedNodeStub.returns(this.workspace);
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastFocusableNode(this.workspace);
+      Blockly.getFocusManager().focusNode(this.workspace);
+      const expectedFocus = this.workspace.getBlockById('text_2');
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.END, [
           Blockly.utils.KeyCodes.CTRL_CMD,
         ]),
       );
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('PageUp focuses on first block in stack', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_UP),
       );
       const expectedFocus = this.workspace.getBlockById('controls_repeat_1');
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
     });
 
     test('PageDown focuses on last down-reachable node in stack with nested row blocks', function () {
       const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
       const fieldToFocus = inListBlock.getField('MODE');
-      this.getFocusedNodeStub.returns(fieldToFocus);
+      Blockly.getFocusManager().focusNode(fieldToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
       );
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastNodeInStack(inListBlock);
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      const expectedFocus =
+        this.workspace.getBlockById('controls_forEach_1').nextConnection;
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
       assert.notEqual(
         expectedFocus,
         this.workspace.getBlockById('math_number_2'),
@@ -2391,14 +2372,12 @@ suite('Keyboard Shortcut Items', function () {
 
     test('PageDown focuses on last down-reachable node in stack with many stack blocks', function () {
       const blockToFocus = this.workspace.getBlockById('text_1');
-      this.getFocusedNodeStub.returns(blockToFocus);
+      Blockly.getFocusManager().focusNode(blockToFocus);
       this.injectionDiv.dispatchEvent(
         createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
       );
-      const expectedFocus = this.workspace
-        .getNavigator()
-        .getLastNodeInStack(blockToFocus);
-      sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+      const expectedFocus = this.workspace.getBlockById('text_print_2');
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
       assert.notEqual(
         expectedFocus,
         this.workspace.getBlockById('text_2'),
@@ -2410,64 +2389,62 @@ suite('Keyboard Shortcut Items', function () {
       test('Home has no effect', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(inListBlock);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.HOME),
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
+        assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
       });
       test('End has no effect', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(inListBlock);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END),
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
+        assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
       });
       test('CtrlHome focuses top block in flyout workspace', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(inListBlock);
         const topBlock = this.workspace.getBlockById('controls_repeat_1');
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.HOME, [
             Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
-        sinon.assert.calledWith(this.focusNodeSpy, topBlock);
+        assert.equal(Blockly.getFocusManager().getFocusedNode(), topBlock);
       });
       test('CtrlEnd focuses last focusable node in flyout workspace', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
-        const expectedFocus = this.workspace
-          .getNavigator()
-          .getLastFocusableNode(this.workspace);
+        Blockly.getFocusManager().focusNode(inListBlock);
+        const expectedFocus = this.workspace.getBlockById('text_2');
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.END, [
             Blockly.utils.KeyCodes.CTRL_CMD,
           ]),
         );
-        sinon.assert.calledWith(this.focusNodeSpy, expectedFocus);
+        assert.equal(Blockly.getFocusManager().getFocusedNode(), expectedFocus);
       });
       test('PageUp has no effect', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(inListBlock);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_UP),
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
+        assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
       });
       test('PageDown has no effect', function () {
         this.workspace.internalIsFlyout = true;
         const inListBlock = this.workspace.getBlockById('lists_getIndex_1');
-        this.getFocusedNodeStub.returns(inListBlock);
+        Blockly.getFocusManager().focusNode(inListBlock);
         this.injectionDiv.dispatchEvent(
           createKeyDownEvent(Blockly.utils.KeyCodes.PAGE_DOWN),
         );
-        sinon.assert.notCalled(this.focusNodeSpy);
+        assert.equal(Blockly.getFocusManager().getFocusedNode(), inListBlock);
       });
     });
   });

--- a/packages/docs/docs/guides/configure/keyboard-nav.mdx
+++ b/packages/docs/docs/guides/configure/keyboard-nav.mdx
@@ -88,12 +88,12 @@ We also provide optional navigation shortcuts to make navigating the workspace e
 
 | Key | Action |
 | --- | --- |
-| Home | Jump to block start |
-| End | Jump to block end |
-| Page Up | Jump to top of stack |
-| Page Down | Jump to bottom of stack |
-| Ctrl/Cmd + Home | Jump to first block |
-| Ctrl/Cmd + End | Jump to last block |
+| Home | Jump to the start of the current block (the block itself) |
+| End | Jump to the last focusable position on the current block's row |
+| Page Up | Jump to the top of the current stack |
+| Page Down | Jump to the last block reachable by Down in the current stack |
+| Ctrl/Cmd + Home | Jump to the first block on the workspace |
+| Ctrl/Cmd + End | Jump to the last focusable position on the workspace |
 
 We recommend that you enable these for your application by calling:
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/RaspberryPiFoundation/blockly/issues/10186

### Proposed Changes

Rewrite the opt-in Home / End / Page Down / Ctrl+Home / Ctrl+End shortcuts so they land on the same nodes as holding the matching arrow keys.

- Home: first in-block node (usually the owning block). Full-block field blocks are treated as fields of their parent.
- End: last same-row in-block node via In. Does not enter statement inputs. No-op if already there, or if focus is on a container `nextConnection`.
- Page Down: last down-reachable node in the current stack via Down. Does not walk into inline value inputs.
- Ctrl/Cmd+End: last top-level stack, then Down, then In to the end of that row.

Home/End/Page Down scoping lives in `shortcut_items.ts`. Navigator only exposes private walk helpers.

### Reason for Changes

End was focusing unreachable container statement connections, and Page Down was walking into inline value inputs. Those destinations did not match arrow-key navigation.

### Test Coverage

Jump shortcut mocha tests now use real `focusNode()` and assert the concrete destination node, not helper return values. Chrome mocha `Jump shortcuts`: 21 passing, 0 failing.

### Documentation

Updated the keyboard navigation shortcut table in `packages/docs/docs/guides/configure/keyboard-nav.mdx`.

### Additional Information

Based on `fix/navigation-shortcuts`.