### PR TITLE
chore: revive advanced playground on gh pages

### DIFF
--- a/packages/blockly/tests/playground.html
+++ b/packages/blockly/tests/playground.html
@@ -95,15 +95,6 @@
         addEventHandlers();
 
         document.querySelector('#version').innerText = Blockly.VERSION;
-
-        // If we're running locally, display the Advanced Playground link
-        if (
-          window.location.href.includes('127.0.0.1') ||
-          window.location.href.includes('localhost')
-        ) {
-          document.querySelector('.advancedPlayground').style.display =
-            'inline';
-        }
       }
 
       /**
@@ -515,10 +506,6 @@
         font-family: monospace;
       }
 
-      .advancedPlayground {
-        display: none;
-      }
-
       .ioLabel > .blocklyFlyoutLabelText {
         font-style: italic;
       }
@@ -548,9 +535,7 @@
     <p>
       <input id="show" type="button" value="Show" /> -
       <input id="hide" type="button" value="Hide" /> -
-      <span class="advancedPlayground"
-        ><a href="playgrounds/advanced_playground.html">Advanced</a> -</span
-      >
+      <a href="playgrounds/advanced_playground.html">Advanced</a> -
       <a href="playgrounds/web_component.html">Web Component</a> -
       <a href="multi_playground.html">Multi Playground</a>
     </p>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://docs.blockly.com/guides/contribute/core/#make-and-verify-a-change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes the advanced playground link on github pages.

