### PR TITLE
chore: upgrade node to 24.x on deploy-docusaurus

### DIFF
--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: "npm"
           cache-dependency-path: "package-lock.json" # root level, since we're using npm workspaces
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://docs.blockly.com/guides/contribute/core/#make-and-verify-a-change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

claude.md symlink in `packages/plugins` seems to be breaking the deploy docs task bc `npm ci` won't run. Upgrading to node 24.x resolves the issue (at least locally)

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
