### PR TITLE
fix: Fix bug that could cause unneeded scrollbars to appear when deserializing workspace comments

### DIFF
--- a/packages/blockly/core/serialization/workspace_comments.ts
+++ b/packages/blockly/core/serialization/workspace_comments.ts
@@ -70,7 +70,6 @@ export function append(
 
   const comment = workspace.newComment(state.id);
 
-  if (state.text !== undefined) comment.setText(state.text);
   if (state.x !== undefined || state.y !== undefined) {
     const defaultLoc = comment.getRelativeToSurfaceXY();
     let x = state.x ?? defaultLoc.x;
@@ -87,6 +86,7 @@ export function append(
       ),
     );
   }
+  if (state.text !== undefined) comment.setText(state.text);
   if (state.collapsed !== undefined) comment.setCollapsed(state.collapsed);
   if (state.editable !== undefined) comment.setEditable(state.editable);
   if (state.movable !== undefined) comment.setMovable(state.movable);


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://docs.blockly.com/guides/contribute/core/#make-and-verify-a-change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #10416

### Proposed Changes
This PR fixes a bug that caused workspace comments that were serialized without a scrollbar to display one when deserialized. Previously, deserialization set the comment's text before its bounds. Therefore, if the comment's text was (a) too large to fit in a default-sized workspace comment and (b) wider than the comment's serialized bounds minus the size of the scroll gutters, deserialization would:

1. Load the text on a default-sized comment, displaying scrollbars, because the text was too wide to fit in the default comment bounds
2. Resize the comment to the serialized bounds; since the text was wider than the comment's saved width minus the width of the scroll gutter, and the scrollbar was already showing because of step 1, the scrollbar would not disappear.

Inverting the order to set the bounds first and then the text when deserializing fixes this, because the text is narrow enough to fit without scrollbars as long as the scrollbar isn't already showing.

### Reason for Changes
Serializing and deserializing a workspace should give identical results.
