### PR TITLE
docs: Update links to current playground

### DIFF
--- a/packages/docs/docs/codelabs/custom-renderer/observe-the-built-in-renderers.mdx
+++ b/packages/docs/docs/codelabs/custom-renderer/observe-the-built-in-renderers.mdx
@@ -6,6 +6,6 @@ description: Introduction to the built-in renderers.
 
 ## 3. Observe the built-in renderers
 
-First, visit [the advanced playground](https://blockly-demo.appspot.com/static/tests/playgrounds/advanced_playground.html) to observe what the built-in renderers look like.
+First, visit [the advanced playground](https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/playgrounds/advanced_playground.html) to observe what the built-in renderers look like.
 
 Click on the "Loops" entry and drag out a repeat block. Now, change the selection in the "renderer" drop down to observe the look of each built-in renderer. By default, the renderer named "Thrasos" is used.

--- a/packages/docs/docs/guides/contribute/core/testing/playground.mdx
+++ b/packages/docs/docs/guides/contribute/core/testing/playground.mdx
@@ -10,7 +10,7 @@ When hacking in Blockly's core or developing a plugin, the playground is a
 tremendously useful tool. It has a preconfigured instance of Blockly that you
 can use for testing, debugging, or prototyping. At the Raspberry Pi Foundation, virtually all of
 Blockly's development occurs using the playground. As a preview, here is the
-[simple playground on the demo server](https://blockly-demo.appspot.com/static/tests/playground.html).
+[simple playground on the demo server](https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/playground.html).
 
 There are 3 types of playgrounds for core Blockly: simple, advanced, and multi.
 In blockly-samples, typically only the advanced playground is used.

--- a/packages/docs/docs/guides/create-custom-blocks/legacy-blockly-developer-tools.md
+++ b/packages/docs/docs/guides/create-custom-blocks/legacy-blockly-developer-tools.md
@@ -146,7 +146,7 @@ category.](/images/category_menu.png)
 
 :::note
 The standard categories and toolbox include all the blocks in the
-[Playground](https://blockly-demo.appspot.com/static/tests/playground.html).
+[Playground](https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/playground.html).
 This set of blocks is not appropriate for most apps and should be pruned as
 needed. Also, some blocks are not supported on mobile yet.
 :::

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -502,7 +502,7 @@ const sidebars = {
             {
               type: 'link',
               label: 'Blockly Playground',
-              href: 'https://blockly-demo.appspot.com/static/tests/playground.html',
+              href: 'https://raspberrypifoundation.github.io/blockly/packages/blockly/tests/playground.html',
             },
             {
               type: 'link',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://docs.blockly.com/guides/contribute/core/#make-and-verify-a-change)

## The details
### Proposed Changes
This PR updates several links in the docs to point to the current, maintained playground instead of the old App Engine version.